### PR TITLE
fix: remove invalid qtbase module from Qt workflow

### DIFF
--- a/.github/workflows/qt-tests-trial.yml
+++ b/.github/workflows/qt-tests-trial.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           version: '6.6.2'
           cache: true
-          modules: 'qtbase'
 
       - name: Configure (BUILD_EDITOR_QT=ON)
         shell: bash


### PR DESCRIPTION
## Summary
- Remove invalid `qtbase` module specification from Qt 6.6.2 installation in qt-tests-trial.yml
- This fixes the workflow failure: "The packages ['qtbase'] were not found while parsing XML of package information!"

## Changes
- Removed `modules: 'qtbase'` from `.github/workflows/qt-tests-trial.yml`
- Qt 6.6.2 default installation already includes all necessary components

## Test plan
- [ ] Qt workflow should now run successfully without module parsing errors
- [ ] test_qt_export_meta should build and execute properly

🤖 Generated with [Claude Code](https://claude.ai/code)