### PR TITLE
ci(qt): weekly trial schedule + auto-labeler for Qt PRs

### DIFF
--- a/.github/workflows/auto-label-qt-tests.yml
+++ b/.github/workflows/auto-label-qt-tests.yml
@@ -1,0 +1,21 @@
+name: Auto Label Qt Tests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add qt-tests label when Qt paths changed
+        uses: actions-ecosystem/action-add-labels@v1
+        if: |
+          contains(join(github.event.pull_request.changed_files, '\n'), 'editor/qt/') ||
+          contains(join(github.event.pull_request.changed_files, '\n'), 'tests/qt/')
+        with:
+          labels: |
+            qt-tests

--- a/.github/workflows/qt-tests-trial.yml
+++ b/.github/workflows/qt-tests-trial.yml
@@ -15,6 +15,8 @@ on:
       - 'editor/qt/**'
       - 'tests/qt/**'
       - '.github/workflows/qt-tests-trial.yml'
+  schedule:
+    - cron: '0 3 * * 1' # Every Monday 03:00 UTC
 
 jobs:
   qt-tests-ubuntu:


### PR DESCRIPTION
- Add weekly schedule to Qt Tests (Trial) (Mon 03:00 UTC)\n- Add auto-labeler to tag PRs touching editor/qt/** or tests/qt/** with 'qt-tests'\n- Keeps trial non-blocking; works with label gating