### PR TITLE
fix: add schedule trigger condition to Qt workflow

### DIFF
--- a/.github/workflows/qt-tests-trial.yml
+++ b/.github/workflows/qt-tests-trial.yml
@@ -23,9 +23,10 @@ jobs:
     name: Qt Exporter Meta Tests (Ubuntu)
     runs-on: ubuntu-latest
     continue-on-error: true
-    # Run only when manually dispatched, or when PR has label `qt-tests`.
+    # Run when manually dispatched, scheduled, or when PR has label `qt-tests`.
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'qt-tests'))
 
     steps:


### PR DESCRIPTION
The schedule trigger was added to qt-tests-trial.yml but the if condition wasn't updated to include it, preventing scheduled runs from executing.

This adds `github.event_name == 'schedule'` to the trigger conditions.