### PR TITLE
ci(windows-nightly): non-blocking + concurrency + stronger retry

### DIFF
--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -7,6 +7,11 @@ on:
 
 jobs:
   build-windows:
+    continue-on-error: true
+    timeout-minutes: 45
+    concurrency:
+      group: windows-nightly-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +29,7 @@ jobs:
           set -e
           echo "VCPKG_BINARY_SOURCES=clear;default" >> $GITHUB_ENV
           VCPKG_DIR="C:/vcpkg"
-          retry() { local n=0; local max=3; local delay=5; until "$@"; do n=$((n+1)); if [ $n -ge $max ]; then echo "[retry] failed: $*" >&2; return 1; fi; echo "[retry] attempt $n failed; sleep ${delay}s"; sleep $delay; delay=$((delay*2)); done; }
+          retry() { local n=0; local max=5; local delay=5; until "$@"; do n=$((n+1)); if [ $n -ge $max ]; then echo "[retry] failed after $n attempts: $*" >&2; return 1; fi; echo "[retry] attempt $n failed; sleeping ${delay}s"; sleep $delay; delay=$((delay*2)); done; }
           if [ -d "$VCPKG_DIR/.git" ]; then (cd "$VCPKG_DIR" && retry git pull --ff-only); else rm -rf "$VCPKG_DIR" && retry git clone https://github.com/Microsoft/vcpkg.git "$VCPKG_DIR"; fi
           (cd "$VCPKG_DIR" && retry git checkout c9fa965c2a1b1334469b4539063f3ce95383653c)
           (cd "$VCPKG_DIR" && retry ./bootstrap-vcpkg.bat -disableMetrics)


### PR DESCRIPTION
- Mark nightly as non-blocking (continue-on-error) and add timeout\n- Add concurrency group to avoid overlapping runs\n- Increase vcpkg retry attempts to 5 with exponential backoff