### PR TITLE
docs(ci): annotate Windows Nightly badge with threshold note

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mono-repo skeleton for a shared Core (C++), a Qt desktop editor, and a Unity ada
 - Core Strict - Exports, Validation, Comparison:
   - ![Core Strict - Exports, Validation, Comparison](https://github.com/zensgit/CADGameFusion/actions/workflows/strict-exports.yml/badge.svg)
 - Windows Nightly - Strict Build Monitor (non-blocking):
-  - ![Windows Nightly - Strict Build Monitor](https://github.com/zensgit/CADGameFusion/actions/workflows/windows-nightly.yml/badge.svg)
+  - ![Windows Nightly - Strict Build Monitor](https://github.com/zensgit/CADGameFusion/actions/workflows/windows-nightly.yml/badge.svg) — Non‑blocking; threshold: 3× green
   - Policy: keep non-blocking until ≥3 consecutive green runs, then consider enabling blocking on strict CI.
   - Watchdog: failures auto-open Issues (labels: ci, windows, triage).
 


### PR DESCRIPTION
- README: add 'Non‑blocking; threshold: 3× green' to Windows Nightly badge line\n- Aligns with Troubleshooting and policy PRs