### PR TITLE
fix: add missing STL headers following explicit include principle

### DIFF
--- a/tests/core/test_solver_poc.cpp
+++ b/tests/core/test_solver_poc.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <iostream>
+#include <vector>
 #include "../../core/include/core/solver.hpp"
 
 int main() {


### PR DESCRIPTION
## Summary

Apply explicit include principle to test files - directly include all STL headers for used types.

## Changes

- Added missing vector header to test_solver_poc.cpp which uses std::vector

## Rationale

Following the explicit include principle from PR #57 feedback:
- Always explicitly include STL headers for directly used types
- Do not rely on transitive includes from other headers
- Improves code portability across different compilers/platforms

## Testing

- Local build verified
- CI will validate across all platforms

## Risk Assessment

- Low risk: Only adds header includes
- No functional changes: Just makes dependencies explicit
- Improves portability: Reduces dependency on transitive includes