### PR TITLE
ci(windows): improve observability and docs link

### DIFF
--- a/.github/workflows/core-strict-build-tests.yml
+++ b/.github/workflows/core-strict-build-tests.yml
@@ -80,6 +80,13 @@ jobs:
           echo "VCPKG_ROOT=$VCPKG_DIR" >> $GITHUB_ENV
           echo "$VCPKG_DIR" >> $GITHUB_PATH
 
+      - name: Print vcpkg state (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "== vcpkg version =="; vcpkg version || true
+          echo "== vcpkg.json (head) =="; head -n 40 vcpkg.json || echo "(vcpkg.json not found)"
+
       - name: Enable long paths (Windows)
         if: runner.os == 'Windows'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ CADGameFusion.UnityAdapter.CoreBindings.core_document_destroy(docPtr);
 ### Quick Links
 - Project Schema — Constraints (v1): `docs/cad/architecture.md`
 - Contributing — Explicit STL Include Principle: `CONTRIBUTING.md`
+- Windows CI Strategy (minimal vcpkg + rollback): see README CI Status + `core-strict-build-tests.yml`
 
 ## Sample Exports and Validation
 - Sample scenes are provided under `sample_exports/`:


### PR DESCRIPTION
- Print vcpkg version and head of vcpkg.json on Windows\n- Keep CMake logs and built tools artifacts\n- Add quick link in README to Windows CI strategy and rollback notes