### PR TITLE
fix(ci): Test Simple build without TinyGLTF

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,8 +8,9 @@ find_path(TINYGLTF_INCLUDE_DIR NAMES tiny_gltf.h)
 if(TINYGLTF_INCLUDE_DIR)
     message(STATUS "TinyGLTF found for tools: ${TINYGLTF_INCLUDE_DIR}")
     target_include_directories(export_cli PRIVATE ${TINYGLTF_INCLUDE_DIR})
+    target_compile_definitions(export_cli PRIVATE CADGF_HAS_TINYGLTF)
 else()
-    message(WARNING "TinyGLTF not found for tools")
+    message(WARNING "TinyGLTF not found for tools - export_cli will be built without glTF export")
 endif()
 
 # Link with core library

--- a/tools/export_cli.cpp
+++ b/tools/export_cli.cpp
@@ -10,10 +10,13 @@
 #include <cmath>
 #include <limits>
 #include "core/core_c_api.h"
+
+#if defined(CADGF_HAS_TINYGLTF)
 #define TINYGLTF_IMPLEMENTATION
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <tiny_gltf.h>
+#endif
 
 namespace fs = std::filesystem;
 
@@ -354,6 +357,19 @@ void writeJSON(const std::string& filepath, const SceneData& scene, double unitS
 // EXP_FEATURES: signature extended with ExportOptions for experimental flags (normals/uvs/materials)
 void writeGLTF(const std::string& gltfPath, const std::string& binPath, 
                const SceneData& scene, bool outerOnlyFan, const ExportOptions& opts) {
+#if !defined(CADGF_HAS_TINYGLTF)
+    (void)gltfPath;
+    (void)binPath;
+    (void)scene;
+    (void)outerOnlyFan;
+    (void)opts;
+    static bool warnedOnce = false;
+    if (!warnedOnce) {
+        std::cerr << "[WARN] TinyGLTF not available; skipping glTF export. (Build with vcpkg tinygltf to enable)\n";
+        warnedOnce = true;
+    }
+    return;
+#else
     tinygltf::Model gltfModel;
     tinygltf::Scene gltfScene;
     tinygltf::Mesh gltfMesh;
@@ -609,6 +625,7 @@ void writeGLTF(const std::string& gltfPath, const std::string& binPath,
     if (!ret) {
         std::cerr << "Failed to write glTF file: " << gltfPath << "\n";
     }
+#endif
 }
 
 void exportScene(const std::string& outputDir, const std::string& sceneName,


### PR DESCRIPTION
Problem: main branch `Test Simple` workflow fails on Ubuntu because `export_cli` includes `<tiny_gltf.h>` but TinyGLTF is not installed in that workflow.

Fix:
- `tools/CMakeLists.txt`: define `CADGF_HAS_TINYGLTF` when `tiny_gltf.h` is found.
- `tools/export_cli.cpp`: compile-time guard TinyGLTF include + glTF writer; when missing, build succeeds and glTF export is skipped with a warning.

Result:
- Minimal builds (no vcpkg) no longer break the whole build.
- vcpkg builds still produce glTF exports as before.
