### PR TITLE
feat(abi): P1/PR1 - Add version/capability query APIs and stable boundary docs

### DIFF
--- a/core/include/core/core_c_api.h
+++ b/core/include/core/core_c_api.h
@@ -16,6 +16,36 @@
 
 #include <stdint.h>
 
+/*
+ * ============================================================================
+ * CADGameFusion Core C API - Stable Boundary
+ * ============================================================================
+ * This header defines the stable C ABI for CADGameFusion core library.
+ * All symbols prefixed with cadgf_* or core_* are part of the stable boundary.
+ *
+ * Stability guarantees (within major version):
+ *   - Existing struct fields will not be removed or reordered
+ *   - Existing function signatures will not change
+ *   - New fields may be appended to structs (check size field)
+ *   - New functions may be added
+ *
+ * See docs/STABLE_BOUNDARY.md for full documentation.
+ * ============================================================================
+ */
+
+/* C API version (increment when adding new functions/structs) */
+#define CADGF_CORE_API_VERSION_MAJOR 1
+#define CADGF_CORE_API_VERSION_MINOR 0
+#define CADGF_CORE_API_VERSION_PATCH 0
+#define CADGF_CORE_API_VERSION \
+    ((CADGF_CORE_API_VERSION_MAJOR << 16) | (CADGF_CORE_API_VERSION_MINOR << 8) | CADGF_CORE_API_VERSION_PATCH)
+
+/* Aliases for legacy compatibility */
+#define CORE_API_VERSION_MAJOR CADGF_CORE_API_VERSION_MAJOR
+#define CORE_API_VERSION_MINOR CADGF_CORE_API_VERSION_MINOR
+#define CORE_API_VERSION_PATCH CADGF_CORE_API_VERSION_PATCH
+#define CORE_API_VERSION CADGF_CORE_API_VERSION
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -66,10 +96,16 @@ CORE_API const char* core_get_version();
 // bit 0: USE_EARCUT, bit 1: USE_CLIPPER2
 CORE_API unsigned int core_get_feature_flags();
 // Feature flag helpers
-#define CORE_FEATURE_EARCUT   (1u << 0)
-#define CORE_FEATURE_CLIPPER2 (1u << 1)
-#define CADGF_FEATURE_EARCUT CORE_FEATURE_EARCUT
+#define CORE_FEATURE_EARCUT    (1u << 0)
+#define CORE_FEATURE_CLIPPER2  (1u << 1)
+#define CORE_FEATURE_TINYGLTF  (1u << 2)
+#define CADGF_FEATURE_EARCUT   CORE_FEATURE_EARCUT
 #define CADGF_FEATURE_CLIPPER2 CORE_FEATURE_CLIPPER2
+#define CADGF_FEATURE_TINYGLTF CORE_FEATURE_TINYGLTF
+
+// Runtime API version query (returns CADGF_CORE_API_VERSION packed value)
+CORE_API unsigned int core_get_api_version(void);
+CADGF_API unsigned int cadgf_get_api_version(void);
 
 // CADGameFusion preferred API names (ABI-level aliases, exported as symbols)
 CADGF_API const char* cadgf_get_version();

--- a/core/include/core/plugin_abi_c_v1.h
+++ b/core/include/core/plugin_abi_c_v1.h
@@ -4,11 +4,30 @@
 
 #include <stdint.h>
 
+/*
+ * ============================================================================
+ * CADGameFusion Plugin ABI (C Function Table) - Stable Boundary
+ * ============================================================================
+ * This header defines the stable C plugin ABI for CADGameFusion.
+ * Plugins implementing this ABI are binary-compatible across:
+ *   - Different compilers (MSVC, GCC, Clang)
+ *   - Different C++ standard library versions
+ *   - Different build configurations (Release/Debug)
+ *
+ * ABI v1 guarantees:
+ *   - cadgf_plugin_api_v1 is append-only (new fields at end only)
+ *   - Host checks api->size >= sizeof(cadgf_plugin_api_v1_min)
+ *   - Existing struct layouts are frozen within v1
+ *
+ * See docs/STABLE_BOUNDARY.md for full documentation.
+ * ============================================================================
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Plugin entry point export macro
+/* Plugin entry point export macro */
 #if defined(_WIN32)
 #  define CADGF_PLUGIN_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__) || defined(__clang__)
@@ -17,7 +36,18 @@ extern "C" {
 #  define CADGF_PLUGIN_EXPORT
 #endif
 
+/* Plugin ABI version (increment major for breaking changes, minor for additions) */
+#define CADGF_PLUGIN_ABI_VERSION_MAJOR 1
+#define CADGF_PLUGIN_ABI_VERSION_MINOR 0
 #define CADGF_PLUGIN_ABI_V1 1
+
+/* Packed version for runtime comparison */
+#define CADGF_PLUGIN_ABI_VERSION \
+    ((CADGF_PLUGIN_ABI_VERSION_MAJOR << 8) | CADGF_PLUGIN_ABI_VERSION_MINOR)
+
+/* Compile-time check: ensure plugin targets compatible ABI */
+#define CADGF_PLUGIN_CHECK_ABI(host_major, host_minor) \
+    ((host_major) == CADGF_PLUGIN_ABI_VERSION_MAJOR && (host_minor) >= CADGF_PLUGIN_ABI_VERSION_MINOR)
 
 typedef struct cadgf_string_view {
     const char* data; // UTF-8

--- a/core/src/core_c_api.cpp
+++ b/core/src/core_c_api.cpp
@@ -20,12 +20,19 @@ CORE_API const char* core_get_version() {
 CORE_API unsigned int core_get_feature_flags() {
     unsigned int flags = 0u;
 #if defined(USE_EARCUT)
-    flags |= 1u << 0;
+    flags |= CORE_FEATURE_EARCUT;
 #endif
 #if defined(USE_CLIPPER2)
-    flags |= 1u << 1;
+    flags |= CORE_FEATURE_CLIPPER2;
+#endif
+#if defined(CADGF_HAS_TINYGLTF)
+    flags |= CORE_FEATURE_TINYGLTF;
 #endif
     return flags;
+}
+
+CORE_API unsigned int core_get_api_version(void) {
+    return CADGF_CORE_API_VERSION;
 }
 
 CORE_API core_document* core_document_create() {
@@ -349,6 +356,7 @@ extern "C" {
 
 CADGF_API const char* cadgf_get_version() { return core_get_version(); }
 CADGF_API unsigned int cadgf_get_feature_flags() { return core_get_feature_flags(); }
+CADGF_API unsigned int cadgf_get_api_version(void) { return core_get_api_version(); }
 
 CADGF_API cadgf_document* cadgf_document_create() { return core_document_create(); }
 CADGF_API void cadgf_document_destroy(cadgf_document* doc) { core_document_destroy(doc); }

--- a/docs/STABLE_BOUNDARY.md
+++ b/docs/STABLE_BOUNDARY.md
@@ -1,0 +1,162 @@
+# CADGameFusion Stable Boundary
+
+This document defines the **stable API/ABI boundary** for CADGameFusion.
+Code within this boundary has strict compatibility guarantees.
+
+## Overview
+
+CADGameFusion exposes two stable C interfaces:
+
+| Header | Purpose | Stability |
+|--------|---------|-----------|
+| `core/core_c_api.h` | Core library C API | **Stable** |
+| `core/plugin_abi_c_v1.h` | Plugin ABI v1 | **Stable** |
+
+All symbols prefixed with `cadgf_*` or `core_*` are part of the stable boundary.
+
+## Stability Guarantees
+
+Within a **major version** (e.g., 1.x.x), we guarantee:
+
+### What Will NOT Change
+- Existing struct field order and types
+- Existing function signatures
+- Existing macro values
+- Existing enum values
+
+### What MAY Change
+- New fields appended to structs (check `size` field)
+- New functions added
+- New macros added
+- New feature flags added
+
+### What Requires Major Version Bump
+- Removing any symbol
+- Changing any function signature
+- Reordering struct fields
+- Changing struct field types
+
+## Version Macros
+
+### Core C API Version
+
+```c
+#include "core/core_c_api.h"
+
+// Compile-time version check
+#if CADGF_CORE_API_VERSION >= 0x010000  // 1.0.0
+    // Use new API features
+#endif
+
+// Runtime version check
+unsigned int api_ver = cadgf_get_api_version();
+int major = (api_ver >> 16) & 0xFF;
+int minor = (api_ver >> 8) & 0xFF;
+int patch = api_ver & 0xFF;
+```
+
+### Plugin ABI Version
+
+```c
+#include "core/plugin_abi_c_v1.h"
+
+// Plugin ABI version
+#define CADGF_PLUGIN_ABI_VERSION_MAJOR 1
+#define CADGF_PLUGIN_ABI_VERSION_MINOR 0
+#define CADGF_PLUGIN_ABI_V1 1
+
+// Compile-time compatibility check
+#if !CADGF_PLUGIN_CHECK_ABI(1, 0)
+    #error "Plugin ABI version mismatch"
+#endif
+```
+
+## Feature Flags
+
+Query available features at runtime:
+
+```c
+unsigned int flags = cadgf_get_feature_flags();
+
+if (flags & CADGF_FEATURE_EARCUT) {
+    // Earcut triangulation available
+}
+if (flags & CADGF_FEATURE_CLIPPER2) {
+    // Clipper2 boolean ops available
+}
+if (flags & CADGF_FEATURE_TINYGLTF) {
+    // TinyGLTF export available
+}
+```
+
+| Flag | Bit | Description |
+|------|-----|-------------|
+| `CADGF_FEATURE_EARCUT` | 0 | Earcut triangulation |
+| `CADGF_FEATURE_CLIPPER2` | 1 | Clipper2 boolean/offset |
+| `CADGF_FEATURE_TINYGLTF` | 2 | TinyGLTF export |
+
+## Struct Size Validation
+
+All extensible structs include a `size` field for forward compatibility:
+
+```c
+// Host-side plugin loading
+const cadgf_plugin_api_v1* api = cadgf_plugin_get_api_v1();
+if (api->size < sizeof(cadgf_plugin_api_v1_min)) {
+    // Plugin too old, missing required fields
+    return CADGF_FAILURE;
+}
+```
+
+## Best Practices
+
+### For Plugin Authors
+1. Always set `size` field to `sizeof(your_struct)`
+2. Check host API version before using new features
+3. Use `CADGF_PLUGIN_CHECK_ABI` for compile-time checks
+
+### For Host Applications
+1. Check `api->size` before accessing optional fields
+2. Use feature flags before calling optional functions
+3. Never assume a feature exists without checking
+
+## Headers Reference
+
+### core_c_api.h (Stable)
+
+Core document and geometry operations:
+- `cadgf_document_*` - Document CRUD
+- `cadgf_triangulate_*` - Triangulation
+- `cadgf_boolean_*` - Boolean operations
+- `cadgf_offset_*` - Offset operations
+- `cadgf_get_version()` - Library version string
+- `cadgf_get_api_version()` - API version (packed)
+- `cadgf_get_feature_flags()` - Feature bitflags
+
+### plugin_abi_c_v1.h (Stable)
+
+Plugin interface structures:
+- `cadgf_plugin_api_v1` - Main plugin entry point
+- `cadgf_exporter_api_v1` - Exporter plugin interface
+- `cadgf_importer_api_v1` - Importer plugin interface
+- `cadgf_plugin_desc_v1` - Plugin description
+- `cadgf_export_options_v1` - Export options
+- `cadgf_error_v1` - Error reporting
+
+## Unstable Components
+
+The following are **NOT** part of the stable boundary:
+
+- C++ headers (any `.hpp` file)
+- Internal implementation details
+- Editor-specific APIs
+- Test utilities
+- Build system internals
+
+## Changelog
+
+### API v1.0.0
+- Initial stable release
+- Core document operations
+- Plugin ABI v1
+- Triangulation, boolean, offset APIs


### PR DESCRIPTION
## Summary

P1/PR1: Stable Boundary Hardening - Version/Capability Query APIs

This PR adds compile-time and runtime version/capability query mechanisms to the C ABI, plus documentation defining the stable boundary.

### Changes

**core_c_api.h:**
- Add `CADGF_CORE_API_VERSION_MAJOR/MINOR/PATCH` macros
- Add `CADGF_CORE_API_VERSION` packed version macro
- Add `core_get_api_version()` / `cadgf_get_api_version()` runtime functions
- Add `CADGF_FEATURE_TINYGLTF` feature flag (bit 2)

**plugin_abi_c_v1.h:**
- Add `CADGF_PLUGIN_ABI_VERSION_MAJOR/MINOR` macros
- Add `CADGF_PLUGIN_ABI_VERSION` packed version macro
- Add `CADGF_PLUGIN_CHECK_ABI()` compile-time compatibility macro

**docs/STABLE_BOUNDARY.md:**
- Document what constitutes the stable API surface
- Explain version macros and usage
- List stability guarantees

### Why

- Plugins need to check host compatibility at compile-time and runtime
- Feature flags allow graceful degradation when optional features unavailable
- Clear documentation prevents accidental ABI breaks

## How to verify

```bash
# Build
cmake -S . -B build -DBUILD_EDITOR_QT=OFF
cmake --build build --target core_c

# Verify symbols exported
nm build/core/libcore_c.* | grep api_version
# Should show:
#   _cadgf_get_api_version
#   _core_get_api_version
```

## Checklist

- [x] No existing struct fields changed
- [x] No existing function signatures changed
- [x] New functions only (append-only)
- [x] Documentation added

🤖 Generated with [Claude Code](https://claude.com/claude-code)