### PR TITLE
feat(editor): P2/PR3 - Make TinyGLTF optional for Qt editor

### DIFF
--- a/editor/qt/CMakeLists.txt
+++ b/editor/qt/CMakeLists.txt
@@ -8,12 +8,14 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 COMPONENTS Widgets REQUIRED QUIET)
 
-# Find TinyGLTF
+# Find TinyGLTF (optional - glTF export will be disabled if not found)
 find_path(TINYGLTF_INCLUDE_DIR NAMES tiny_gltf.h)
 if(TINYGLTF_INCLUDE_DIR)
     message(STATUS "TinyGLTF found for editor: ${TINYGLTF_INCLUDE_DIR}")
+    set(CADGF_EDITOR_HAS_TINYGLTF TRUE)
 else()
-    message(WARNING "TinyGLTF not found for editor")
+    message(STATUS "TinyGLTF not found for editor - glTF export disabled (JSON/DXF still available)")
+    set(CADGF_EDITOR_HAS_TINYGLTF FALSE)
 endif()
 
 add_executable(editor_qt
@@ -45,8 +47,13 @@ target_include_directories(editor_qt PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../..
     ${CMAKE_SOURCE_DIR}/tools
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${TINYGLTF_INCLUDE_DIR}
 )
+
+# Add TinyGLTF include and define if available
+if(CADGF_EDITOR_HAS_TINYGLTF)
+    target_include_directories(editor_qt PRIVATE ${TINYGLTF_INCLUDE_DIR})
+    target_compile_definitions(editor_qt PRIVATE CADGF_HAS_TINYGLTF)
+endif()
 
 target_link_libraries(editor_qt PRIVATE Qt6::Widgets core core_c ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
## Summary

P2/PR3: TinyGLTF Optional - Unified Dependency Strategy

Makes TinyGLTF an optional dependency for `editor/qt`. The editor can now build and function without TinyGLTF - only glTF export is disabled.

### Changes

**editor/qt/CMakeLists.txt:**
- Set `CADGF_EDITOR_HAS_TINYGLTF` variable based on find result
- Define `CADGF_HAS_TINYGLTF` compile definition when available
- Change warning to status message for cleaner output

**editor/qt/src/exporter.cpp:**
- Wrap TinyGLTF include with `#ifdef CADGF_HAS_TINYGLTF`
- Wrap glTF export code with `#ifdef` guards
- Add graceful degradation: error message when glTF requested but unavailable

### Behavior Matrix

| Feature | TinyGLTF Available | TinyGLTF Missing |
|---------|-------------------|------------------|
| JSON export | ✅ | ✅ |
| DXF export | ✅ | ✅ |
| glTF export | ✅ | ❌ (clear error) |
| Editor compiles | ✅ | ✅ |

### Why

- Unified dependency strategy across all targets
- Matches export_cli behavior (already has optional TinyGLTF)
- Allows faster builds when glTF not needed
- Reduces friction for new contributors

## How to verify

```bash
# Build with Qt (TinyGLTF optional):
cmake -S . -B build -DBUILD_EDITOR_QT=ON
cmake --build build --target editor_qt

# Check CMake output shows TinyGLTF status:
# -- TinyGLTF found for editor: /path/to/include
# OR
# -- TinyGLTF not found for editor - glTF export disabled (JSON/DXF still available)
```

## Notes

This uses the unified `CADGF_HAS_TINYGLTF` macro that was proposed in PR1's stable boundary documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)