### PR TITLE
feat(core): extend Entity with editor metadata (visible/groupId/color)

### DIFF
--- a/core/include/core/core_c_api.h
+++ b/core/include/core/core_c_api.h
@@ -45,8 +45,11 @@ typedef struct core_layer_info {
 
 typedef struct core_entity_info {
     core_entity_id id;
-    int type;      // CORE_ENTITY_TYPE_*
+    int type;           // CORE_ENTITY_TYPE_*
     int layer_id;
+    int visible;        // 0/1 (PR4: entity visibility)
+    int group_id;       // -1 = ungrouped (PR4: entity grouping)
+    unsigned int color; // 0xRRGGBB, 0 = inherit from layer (PR4: entity color)
 } core_entity_info;
 
 typedef core_layer_info  cadgf_layer_info;
@@ -121,6 +124,11 @@ CORE_API int core_document_get_polyline_points(const core_document* doc, core_en
                                                core_vec2* out_pts, int out_pts_capacity,
                                                int* out_required_points);
 
+// Entity property setters (PR4: single source of truth)
+CORE_API int core_document_set_entity_visible(core_document* doc, core_entity_id id, int visible);
+CORE_API int core_document_set_entity_color(core_document* doc, core_entity_id id, unsigned int color);
+CORE_API int core_document_set_entity_group_id(core_document* doc, core_entity_id id, int group_id);
+
 CADGF_API int cadgf_document_get_layer_count(const cadgf_document* doc, int* out_count);
 CADGF_API int cadgf_document_get_layer_id_at(const cadgf_document* doc, int index, int* out_layer_id);
 CADGF_API int cadgf_document_get_layer_info(const cadgf_document* doc, int layer_id, cadgf_layer_info* out_info);
@@ -141,6 +149,11 @@ CADGF_API int cadgf_document_get_entity_name(const cadgf_document* doc, cadgf_en
 CADGF_API int cadgf_document_get_polyline_points(const cadgf_document* doc, cadgf_entity_id id,
                                                  cadgf_vec2* out_pts, int out_pts_capacity,
                                                  int* out_required_points);
+
+// Entity property setters (PR4: single source of truth)
+CADGF_API int cadgf_document_set_entity_visible(cadgf_document* doc, cadgf_entity_id id, int visible);
+CADGF_API int cadgf_document_set_entity_color(cadgf_document* doc, cadgf_entity_id id, unsigned int color);
+CADGF_API int cadgf_document_set_entity_group_id(cadgf_document* doc, cadgf_entity_id id, int group_id);
 
 // Triangulation C API (stateless)
 // Two-call pattern:

--- a/core/include/core/document.hpp
+++ b/core/include/core/document.hpp
@@ -20,6 +20,11 @@ struct Entity {
     std::string name;
     int layerId{0}; // 0 is default layer
     std::shared_ptr<void> payload; // simple placeholder, to be replaced by variant
+
+    // Editor metadata (PR4: single source of truth)
+    bool visible{true};           // per-entity visibility override
+    int groupId{-1};              // grouping identifier (-1 = ungrouped)
+    uint32_t color{0};            // per-entity color (0 = inherit from layer)
 };
 
 struct Layer {
@@ -47,6 +52,13 @@ public:
 
     EntityId add_polyline(const Polyline& pl, const std::string& name = "", int layerId = 0);
     bool     remove_entity(EntityId id);
+
+    // Entity property setters (PR4: single source of truth)
+    Entity* get_entity(EntityId id);
+    const Entity* get_entity(EntityId id) const;
+    bool set_entity_visible(EntityId id, bool visible);
+    bool set_entity_color(EntityId id, uint32_t color);
+    bool set_entity_group_id(EntityId id, int groupId);
 
     const std::vector<Entity>& entities() const { return entities_; }
     DocumentSettings& settings() { return settings_; }

--- a/core/src/core_c_api.cpp
+++ b/core/src/core_c_api.cpp
@@ -165,6 +165,9 @@ CORE_API int core_document_get_entity_info(const core_document* doc, core_entity
     out_info->id = static_cast<core_entity_id>(e->id);
     out_info->type = CORE_ENTITY_TYPE_POLYLINE; // currently only polyline exists in Document
     out_info->layer_id = e->layerId;
+    out_info->visible = e->visible ? 1 : 0;
+    out_info->group_id = e->groupId;
+    out_info->color = static_cast<unsigned int>(e->color);
     return 1;
 }
 
@@ -196,6 +199,21 @@ CORE_API int core_document_get_polyline_points(const core_document* doc, core_en
 
     for (int i = 0; i < count; ++i) out_pts[i] = core_vec2{pl->points[static_cast<size_t>(i)].x, pl->points[static_cast<size_t>(i)].y};
     return 1;
+}
+
+CORE_API int core_document_set_entity_visible(core_document* doc, core_entity_id id, int visible) {
+    if (!doc) return 0;
+    return doc->impl.set_entity_visible(static_cast<EntityId>(id), visible != 0) ? 1 : 0;
+}
+
+CORE_API int core_document_set_entity_color(core_document* doc, core_entity_id id, unsigned int color) {
+    if (!doc) return 0;
+    return doc->impl.set_entity_color(static_cast<EntityId>(id), static_cast<uint32_t>(color)) ? 1 : 0;
+}
+
+CORE_API int core_document_set_entity_group_id(core_document* doc, core_entity_id id, int group_id) {
+    if (!doc) return 0;
+    return doc->impl.set_entity_group_id(static_cast<EntityId>(id), group_id) ? 1 : 0;
 }
 
 } // extern C
@@ -422,6 +440,18 @@ CADGF_API int cadgf_document_get_polyline_points(const cadgf_document* doc, cadg
                                                  cadgf_vec2* out_pts, int out_pts_capacity,
                                                  int* out_required_points) {
     return core_document_get_polyline_points(doc, id, out_pts, out_pts_capacity, out_required_points);
+}
+
+CADGF_API int cadgf_document_set_entity_visible(cadgf_document* doc, cadgf_entity_id id, int visible) {
+    return core_document_set_entity_visible(doc, id, visible);
+}
+
+CADGF_API int cadgf_document_set_entity_color(cadgf_document* doc, cadgf_entity_id id, unsigned int color) {
+    return core_document_set_entity_color(doc, id, color);
+}
+
+CADGF_API int cadgf_document_set_entity_group_id(cadgf_document* doc, cadgf_entity_id id, int group_id) {
+    return core_document_set_entity_group_id(doc, id, group_id);
 }
 
 CADGF_API int cadgf_triangulate_polygon(const cadgf_vec2* pts, int n,

--- a/core/src/document.cpp
+++ b/core/src/document.cpp
@@ -55,4 +55,39 @@ bool Document::remove_entity(EntityId id) {
     return false;
 }
 
+Entity* Document::get_entity(EntityId id) {
+    for (auto& e : entities_) {
+        if (e.id == id) return &e;
+    }
+    return nullptr;
+}
+
+const Entity* Document::get_entity(EntityId id) const {
+    for (const auto& e : entities_) {
+        if (e.id == id) return &e;
+    }
+    return nullptr;
+}
+
+bool Document::set_entity_visible(EntityId id, bool visible) {
+    auto* e = get_entity(id);
+    if (!e) return false;
+    e->visible = visible;
+    return true;
+}
+
+bool Document::set_entity_color(EntityId id, uint32_t color) {
+    auto* e = get_entity(id);
+    if (!e) return false;
+    e->color = color;
+    return true;
+}
+
+bool Document::set_entity_group_id(EntityId id, int groupId) {
+    auto* e = get_entity(id);
+    if (!e) return false;
+    e->groupId = groupId;
+    return true;
+}
+
 } // namespace core


### PR DESCRIPTION
## Summary

PR4 of P3 (Editor Single Source of Truth): Extend `core::Entity` and `Document` to support editor-required metadata, establishing Document as the single source of truth for entity state.

### Changes

**`core/include/core/document.hpp`**:
- Added to `Entity` struct:
  - `bool visible{true}` - per-entity visibility override
  - `int groupId{-1}` - grouping identifier (-1 = ungrouped)
  - `uint32_t color{0}` - per-entity color (0 = inherit from layer)
- Added to `Document` class:
  - `get_entity(EntityId)` - find entity by ID
  - `set_entity_visible/color/group_id()` - modify entity properties

**`core/include/core/core_c_api.h`**:
- Extended `core_entity_info` struct with `visible`, `group_id`, `color` fields
- Added C API functions:
  - `core_document_set_entity_visible()`
  - `core_document_set_entity_color()`
  - `core_document_set_entity_group_id()`
- Added corresponding `cadgf_*` aliases

**`core/src/document.cpp`** & **`core/src/core_c_api.cpp`**:
- Implementation of all new methods

### Design Rationale

This PR establishes the foundation for the "Document as truth, Canvas as projection" architecture:
- Entity metadata (visibility, color, grouping) is now stored in `core::Document`
- Editor's `Canvas` will project this state for rendering (PR5)
- Project save/load will serialize `Document` state (PR6)
- Editor commands will operate on `Document` (PR7)

## How to verify

```bash
# Build and test
mkdir build && cd build
cmake .. -DBUILD_EDITOR_QT=OFF
cmake --build . --parallel
ctest --output-on-failure

# Or use local CI
./tools/local_ci.sh --quick
```

## Test plan

- [x] Build passes with core changes
- [x] Existing C API examples work (`c_api_minimal`, `c_core_minimal`)
- [x] New entity_info fields populated correctly
- [ ] Entity property setters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)