### PR TITLE
docs: add API stability policy

### DIFF
--- a/core/include/core/core_c_api.h
+++ b/core/include/core/core_c_api.h
@@ -20,6 +20,10 @@
 extern "C" {
 #endif
 
+// ABI stability boundary:
+// - cadgf_* C API exported from core_c is the stable external surface.
+// - C++ APIs (core::Document, etc.) are internal and not ABI-stable across DLL/DSO.
+// - ABI evolution is append-only within a major version; use cadgf_get_version().
 typedef uint64_t core_entity_id;
 
 typedef struct core_vec2 { double x; double y; } core_vec2;

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -1,0 +1,37 @@
+# API Stability Policy
+
+## 1. Stable Boundary
+
+The stable binary boundary for CADGameFusion is the **C ABI** exported by `core_c`:
+
+- Preferred external symbols: `cadgf_*`
+- Header: `core/include/core/core_c_api.h`
+- Dynamic library: `core_c` (`core_c.dll`, `libcore_c.dylib`, `libcore_c.so`)
+
+This boundary is intended for engines, tools, and external languages (Unity, Python, CLI).
+
+## 2. Internal (Non-stable) APIs
+
+The C++ interfaces under `core/include/core/*.hpp` (for example `core::Document`) are
+**internal** source-level APIs. They are **not** ABI-stable across DLL/DSO boundaries,
+compilers, or standard library versions.
+
+If you need to use C++ helpers, keep them in-process with the same compiler/runtime
+and do not export them as a public SDK.
+
+## 3. ABI Evolution Rules
+
+- The C API is **append-only** within a major ABI version.
+- Breaking changes, if unavoidable, require a new ABI version or a major release bump.
+- Use `cadgf_get_version()` and `cadgf_get_feature_flags()` for runtime compatibility checks.
+
+## 4. Plugin ABI
+
+The plugin ABI (`core/include/core/plugin_abi_c_v1.h`) follows the same rule:
+append-only within v1, validated by version/size checks.
+
+## 5. Practical Guidance
+
+- Use `cadgf_*` for all external integrations.
+- Treat `core_*` symbols as compatibility aliases only.
+- Do not rely on C++ ABI stability across shared library boundaries, especially on Windows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,10 @@
 - Roadmap: [Roadmap](Roadmap.md)
 - Editor Usage: [Editor-Usage](Editor-Usage.md)
 - API Reference: [API](API.md)
+- API Stability: [API-Stability](API_STABILITY.md)
 - Unity Guide: [Unity-Guide](Unity-Guide.md)
 - Build From Source: [Build-From-Source](Build-From-Source.md)
 - Troubleshooting: [Troubleshooting](Troubleshooting.md)
 - Contributing: [Contributing](Contributing.md)
 - Changelog: [Changelog](Changelog.md)
 - Design Notes: [Design-Notes](Design-Notes.md)
-


### PR DESCRIPTION
## Summary
- add a clear API stability policy doc for the C ABI boundary
- link the policy from docs index
- note ABI boundary expectations in core C API header

## Testing
- -- Running vcpkg install
Detecting compiler hash for triplet arm64-osx...
Compiler found: /usr/bin/c++
The following packages are already installed:
    clipper2:arm64-osx@1.2.2
    earcut-hpp:arm64-osx@2.2.4
    eigen3:arm64-osx@3.4.0#2
  * nlohmann-json:arm64-osx@3.11.2
  * stb:arm64-osx@2023-04-11#1
    tinygltf:arm64-osx@2.8.4
  * vcpkg-cmake:arm64-osx@2023-05-04
  * vcpkg-cmake-config:arm64-osx@2022-02-06#1
The package clipper2 can be imported via CMake FindPkgConfig module:

    # Clipper2
    find_package(PkgConfig REQUIRED)
    pkg_check_modules(Clipper2 REQUIRED IMPORTED_TARGET Clipper2)
    target_link_libraries(main PkgConfig::Clipper2)

    # Clipper2Z
    find_package(PkgConfig REQUIRED)
    pkg_check_modules(Clipper2Z REQUIRED IMPORTED_TARGET Clipper2Z)
    target_link_libraries(main PkgConfig::Clipper2Z)


earcut-hpp is header-only and can be used from CMake via:

  find_path(EARCUT_HPP_INCLUDE_DIRS "mapbox/earcut.hpp")
  target_include_directories(main PRIVATE ${EARCUT_HPP_INCLUDE_DIRS})

eigen3 provides CMake targets:

  # this is heuristically generated, and may not be correct
  find_package(Eigen3 CONFIG REQUIRED)
  target_link_libraries(main PRIVATE Eigen3::Eigen)

eigen3 provides pkg-config modules:

  # A C++ template library for linear algebra: vectors, matrices, and related algorithms
  eigen3

tinygltf is header-only and can be used from CMake via:

  find_path(TINYGLTF_INCLUDE_DIRS "tiny_gltf.h")
  target_include_directories(main PRIVATE ${TINYGLTF_INCLUDE_DIRS})

All requested installations completed successfully in: 142 us
-- Running vcpkg install - done
-- Earcut found
-- TinyGLTF found
-- Clipper2 found (pkg-config)
-- Clipper2 enabled
-- Eigen3 found and linked
-- GTest not found, test_complex_strict will use basic assertions
-- TinyGLTF found for tools: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/vcpkg_installed/arm64-osx/include
-- Configuring done (3.2s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
- [  3%] Built target test_simple
[ 15%] Built target core
[ 19%] Built target core_c
[ 23%] Built target core_tests_boolean_offset
[ 26%] Built target core_tests_solver_constraints
[ 30%] Built target core_tests_solver_poc
[ 38%] Built target core_tests_triangulation
[ 38%] Built target core_tests_strict
[ 44%] Built target cpp_core_minimal
[ 46%] Built target core_tests_solver_conflicts
[ 53%] Built target solve_demo
[ 53%] Built target solve_from_project
[ 57%] Built target doc_export_example
[ 61%] Built target c_api_minimal
[ 65%] Built target c_core_minimal
[ 69%] Built target core_tests_complex_strict
[ 73%] Built target plugin_host_demo
[ 76%] Built target core_tests_c_api_document_query
[ 80%] Built target cadgf_sample_plugin
[ 88%] Built target test_spec_parsing
[ 90%] Built target export_cli
[ 92%] Built target test_normalization_cpp
[ 96%] Built target test_sort_rings_deterministic
[100%] Built target test_meta_normalize
- UpdateCTestConfiguration  from :/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/DartConfiguration.tcl
Test project /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: c_api_minimal_run

1: Test command: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/c_api_minimal
1: Working Directory: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
1: Test timeout computed to be: 10000000
1: cadgf version: 1.0.0
1: features: EARCUT=on CLIPPER2=on
1: indices (3): 1 2 0
1: OK
1/5 Test #1: c_api_minimal_run ................   Passed    0.00 sec
test 2
    Start 2: c_core_minimal_run

2: Test command: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/c_core_minimal
2: Working Directory: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
2: Test timeout computed to be: 10000000
2: cadgf version: 1.0.0
2: added polyline id=1
2: triangulated indices (3): 1 2 0
2/5 Test #2: c_core_minimal_run ...............   Passed    0.00 sec
test 3
    Start 3: cpp_core_minimal_run

3: Test command: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/cpp_core_minimal
3: Working Directory: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
3: Test timeout computed to be: 10000000
3: vertices=4, indices=6
3: first tri: 2,3,0
3/5 Test #3: cpp_core_minimal_run .............   Passed    0.00 sec
test 4
    Start 4: doc_export_example_run

4: Test command: /opt/homebrew/bin/cmake "-Dexe="/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/doc_export_example"" "-Dout="/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/out_offset.json"" "-P" "/Users/huazhou/Downloads/Github/CADGameFusion/cmake/RunDocExportExample.cmake"
4: Working Directory: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
4: Test timeout computed to be: 10000000
4: -- doc_export_example wrote "/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/out_offset.json" (890 bytes)
4/5 Test #4: doc_export_example_run ...........   Passed    0.01 sec
test 5
    Start 5: plugin_host_demo_run

5: Test command: /opt/homebrew/bin/cmake "-Dexe="/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/tools/plugin_host_demo"" "-Dplugin="/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/plugins/libcadgf_sample_plugin.dylib"" "-Dout="/Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/out_plugin_export.json"" "-P" "/Users/huazhou/Downloads/Github/CADGameFusion/cmake/RunPluginHostDemo.cmake"
5: Working Directory: /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify
5: Test timeout computed to be: 10000000
5: -- plugin_host_demo wrote /Users/huazhou/Downloads/Github/CADGameFusion/build_stability_verify/out_plugin_export.json (457 bytes)
5/5 Test #5: plugin_host_demo_run .............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   0.03 sec