### PR TITLE
fix(core): allocate group ids in Document

### DIFF
--- a/core/include/core/document.hpp
+++ b/core/include/core/document.hpp
@@ -60,6 +60,7 @@ public:
     bool set_entity_visible(EntityId id, bool visible);
     bool set_entity_color(EntityId id, uint32_t color);
     bool set_entity_group_id(EntityId id, int groupId);
+    int alloc_group_id();
 
     const std::vector<Entity>& entities() const { return entities_; }
     DocumentSettings& settings() { return settings_; }
@@ -71,6 +72,7 @@ private:
     std::vector<Layer> layers_{};
     EntityId next_id_{1};
     int next_layer_id_{1};
+    int next_group_id_{1};
 };
 
 } // namespace core

--- a/core/src/document.cpp
+++ b/core/src/document.cpp
@@ -56,6 +56,7 @@ void Document::clear() {
     layers_.clear();
     next_id_ = 1;
     next_layer_id_ = 1;
+    next_group_id_ = 1;
 
     Layer l0;
     l0.id = 0;
@@ -98,7 +99,15 @@ bool Document::set_entity_group_id(EntityId id, int groupId) {
     auto* e = get_entity(id);
     if (!e) return false;
     e->groupId = groupId;
+    if (groupId >= 0 && groupId >= next_group_id_) {
+        next_group_id_ = groupId + 1;
+    }
     return true;
+}
+
+int Document::alloc_group_id() {
+    if (next_group_id_ < 1) next_group_id_ = 1;
+    return next_group_id_++;
 }
 
 } // namespace core

--- a/editor/qt/src/canvas.cpp
+++ b/editor/qt/src/canvas.cpp
@@ -402,8 +402,6 @@ void CanvasWidget::clearTriMesh() {
     emit selectionChanged({});
 }
 
-int CanvasWidget::newGroupId() { return nextGroupId_++; }
-
 void CanvasWidget::selectGroup(const QPoint& pos) {
     const double thPx = 12.0;
     const double thWorld = thPx / scale_;
@@ -450,7 +448,6 @@ void CanvasWidget::reloadFromDocument() {
 
     polylines_.clear();
     selected_entities_.clear();
-    int maxGroupId = -1;
 
     // Iterate over all entities in Document and create PolyVis for each
     const auto& entities = m_doc->entities();
@@ -472,7 +469,6 @@ void CanvasWidget::reloadFromDocument() {
         pv.groupId = e.groupId;
         pv.layerId = e.layerId;
         pv.entityId = e.id;
-        if (e.groupId >= 0 && e.groupId > maxGroupId) maxGroupId = e.groupId;
 
         // Color: use entity color if set, otherwise inherit from layer
         if (e.color != 0) {
@@ -496,7 +492,6 @@ void CanvasWidget::reloadFromDocument() {
         polylines_.append(pv);
     }
 
-    nextGroupId_ = (maxGroupId >= 0) ? (maxGroupId + 1) : 1;
     update();
     emit selectionChanged({});
 }

--- a/editor/qt/src/canvas.hpp
+++ b/editor/qt/src/canvas.hpp
@@ -50,7 +50,6 @@ public:
     const QVector<unsigned int>& triIndices() const { return triIndices_; }
     void setTriMesh(const QVector<QPointF>& vertices, const QVector<unsigned int>& indices);
     void clearTriMesh();
-    int  newGroupId();
     void setSelection(const QList<qulonglong>& entityIds);
 
 signals:
@@ -81,7 +80,6 @@ private:
     QVector<PolyVis> polylines_;
     QSet<EntityId> selected_entities_;
     bool triSelected_ { false };
-    int  nextGroupId_ { 1 };
     QVector<QPointF> triVerts_;
     QVector<unsigned int> triIndices_;
     core::Document* m_doc{nullptr};


### PR DESCRIPTION
## Summary
- move group-id allocation into core::Document to avoid UI-owned model IDs
- drop Canvas group-id counter and derive group IDs from Document only
- treat missing entity IDs as invalid in the property panel handler

## Testing
- not run (logic-only change)