### PR TITLE
refactor: extract selection meta helpers

### DIFF
--- a/docs/STEP339_SELECTION_META_HELPERS_DESIGN.md
+++ b/docs/STEP339_SELECTION_META_HELPERS_DESIGN.md
@@ -1,0 +1,99 @@
+# Step339 Selection Meta Helpers Design
+
+## Goal
+
+Extract the shared selection meta helpers out of `selection_presenter.js` into a dedicated helper module, so that `selection_badges.js`, `selection_overview.js`, and `property_panel_selection_shell_renderers.js` no longer import presenter internals.
+
+## Why This Step
+
+After Step337 and Step338:
+
+- badge assembly already lives in `selection_badges.js`
+- overview text already lives in `selection_overview.js`
+- selection shell rendering already consumes some presenter helpers
+
+But these extracted modules still depend back on `selection_presenter.js` for shared helper behavior, which leaves an avoidable cycle in the presenter graph.
+
+Today the dependency shape is effectively:
+
+- `selection_presenter.js` -> `selection_badges.js`
+- `selection_presenter.js` -> `selection_overview.js`
+- `selection_badges.js` -> `selection_presenter.js`
+- `selection_overview.js` -> `selection_presenter.js`
+
+That is the cleanest remaining architectural debt in this area, and it is more valuable to remove than continuing to micro-split presenter entrypoints.
+
+## Problem
+
+`selection_presenter.js` still owns helper behavior that has become shared infrastructure:
+
+- `isReadOnlySelectionEntity(...)`
+- `describeReadOnlySelectionEntity(...)`
+- `describeSelectionOrigin(...)`
+- `formatSelectionLayer(...)`
+- `formatSelectionLayerColor(...)`
+- `listSelectionLayerFlags(...)`
+- `formatSelectionLayerFlags(...)`
+- `formatSelectionLayerState(...)`
+
+These are no longer presenter-only concerns. They are cross-cutting formatting/selection-meta helpers.
+
+## Design
+
+Introduce a dedicated helper module:
+
+- `tools/web_viewer/ui/selection_meta_helpers.js`
+
+Move the shared helper implementations there.
+
+Then update:
+
+- `selection_presenter.js`
+- `selection_badges.js`
+- `selection_overview.js`
+- `property_panel_selection_shell_renderers.js`
+- any other direct helper consumers in this area
+
+to import from `selection_meta_helpers.js` instead of back-importing through `selection_presenter.js`.
+
+`selection_presenter.js` should continue to re-export the moved helpers so its public surface remains stable.
+
+## Boundaries
+
+This step must not change:
+
+- helper behavior
+- helper export names
+- `selection_presenter.js` public contract
+- badge behavior
+- overview text behavior
+- detail fact generation
+- property panel rendering behavior
+
+This step is explicitly about dependency cleanup, not semantics.
+
+## Test Plan
+
+Add:
+
+- `tools/web_viewer/tests/selection_meta_helpers.test.js`
+
+Cover at least:
+
+- read-only detection
+- origin formatting with and without read-only suffix
+- layer formatting with named and unnamed layers
+- layer state flag collection and combined state formatting
+
+Keep existing integration assertions unchanged in:
+
+- `editor_commands.test.js`
+- selection overview tests
+- selection badges tests
+- property panel selection shell tests
+
+## Expected Outcome
+
+- helper cycles around `selection_presenter.js` are removed
+- extracted presenter-side helpers become first-class shared infrastructure
+- `selection_presenter.js` becomes more clearly centered on contract/detail-fact/note assembly rather than generic formatting helpers

--- a/docs/STEP339_SELECTION_META_HELPERS_VERIFICATION.md
+++ b/docs/STEP339_SELECTION_META_HELPERS_VERIFICATION.md
@@ -1,0 +1,60 @@
+# Step339 Selection Meta Helpers Verification
+
+## Scope
+
+To verify Step339 after implementation, validate:
+
+- `tools/web_viewer/ui/selection_meta_helpers.js`
+- `tools/web_viewer/ui/selection_presenter.js`
+- `tools/web_viewer/ui/selection_badges.js`
+- `tools/web_viewer/ui/selection_overview.js`
+- `tools/web_viewer/ui/property_panel_selection_shell_renderers.js`
+- `tools/web_viewer/tests/selection_meta_helpers.test.js`
+
+## Static Checks
+
+Expected commands:
+
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/ui/selection_meta_helpers.js`
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/ui/selection_presenter.js`
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/ui/selection_badges.js`
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/ui/selection_overview.js`
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/ui/property_panel_selection_shell_renderers.js`
+- `/opt/homebrew/bin/node --check /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/selection_meta_helpers.test.js`
+
+## Unit Tests
+
+Minimum expected commands:
+
+- `/opt/homebrew/bin/node --test /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/selection_meta_helpers.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/selection_overview.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/selection_badges.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_presentation.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_context_state.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_resolution.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_context.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_shell_state.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_shells.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_selection_shell_renderers.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_render_pipeline.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_render_deps.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_render_branch_execution.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_render_branch_state.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_render.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_active_render.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel_branch_renderers.test.js /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/property_panel.test.js`
+- `/opt/homebrew/bin/node --test /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/tests/editor_commands.test.js`
+
+## Browser Smoke
+
+Expected commands:
+
+- `mkdir -p /tmp/editor-current-layer-step339 /tmp/editor-selection-summary-step339 && /opt/homebrew/bin/node /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/scripts/editor_current_layer_smoke.js --outdir /tmp/editor-current-layer-step339 && /opt/homebrew/bin/node /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/scripts/editor_selection_summary_smoke.js --outdir /tmp/editor-selection-summary-step339`
+- `PATH="/Users/huazhou/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" bash /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion/tools/web_viewer/scripts/editor_ui_flow_smoke.sh --mode observe --outdir /tmp/editor-ui-flow-step339`
+
+Expected gate:
+
+- `ok: true` for current-layer smoke
+- `ok: true` for selection-summary smoke
+- `gate_ok: true`
+- `selection_provenance_summary_ok: true`
+
+## Diff Sanity
+
+Expected command:
+
+- `git -C /Users/huazhou/Downloads/Github/VemCAD/deps/cadgamefusion diff --check`
+
+## Reviewer Focus
+
+When validating Claude Code output, check these failure modes first:
+
+- helper extraction leaves `selection_badges.js` or `selection_overview.js` still importing from `selection_presenter.js`
+- `selection_presenter.js` stops re-exporting moved helpers
+- layer formatting behavior changes
+- origin formatting changes, especially `includeReadOnly`
+- property panel selection shell captions change because `describeSelectionOrigin(...)` drifted

--- a/tools/web_viewer/tests/selection_meta_helpers.test.js
+++ b/tools/web_viewer/tests/selection_meta_helpers.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  describeReadOnlySelectionEntity,
+  describeSelectionOrigin,
+  formatSelectionLayer,
+  formatSelectionLayerColor,
+  formatSelectionLayerFlags,
+  formatSelectionLayerState,
+  isReadOnlySelectionEntity,
+  listSelectionLayerFlags,
+} from '../ui/selection_meta_helpers.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 7,
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 7,
+    name: 'A-WALL',
+    color: '#00ff00',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+function getLayerFactory(layer = null) {
+  return (layerId) => (layer && layer.id === layerId ? layer : null);
+}
+
+test('isReadOnlySelectionEntity detects explicit read-only, unsupported, and proxy entities', () => {
+  assert.equal(isReadOnlySelectionEntity(makeEntity()), false);
+  assert.equal(isReadOnlySelectionEntity(makeEntity({ readOnly: true })), true);
+  assert.equal(isReadOnlySelectionEntity(makeEntity({ type: 'unsupported' })), true);
+  assert.equal(isReadOnlySelectionEntity(makeEntity({ editMode: 'proxy' })), true);
+});
+
+test('describeReadOnlySelectionEntity preserves unsupported and source/proxy descriptions', () => {
+  assert.equal(describeReadOnlySelectionEntity(null), 'read-only proxy');
+  assert.equal(describeReadOnlySelectionEntity(makeEntity({ type: 'unsupported' })), 'unsupported proxy');
+  assert.equal(
+    describeReadOnlySelectionEntity(makeEntity({ sourceType: 'INSERT', proxyKind: 'fragment' })),
+    'INSERT fragment proxy',
+  );
+  assert.equal(
+    describeReadOnlySelectionEntity(makeEntity({ sourceType: 'DIMENSION' })),
+    'DIMENSION derived proxy',
+  );
+});
+
+test('describeSelectionOrigin preserves separator and optional read-only suffix behavior', () => {
+  const entity = makeEntity({ sourceType: 'INSERT', proxyKind: 'fragment', editMode: 'proxy' });
+  assert.equal(describeSelectionOrigin(entity), 'INSERT / fragment / proxy');
+  assert.equal(describeSelectionOrigin(entity, { separator: ' | ' }), 'INSERT | fragment | proxy');
+
+  const readOnlyEntity = makeEntity({ sourceType: 'DIMENSION', readOnly: true });
+  assert.equal(
+    describeSelectionOrigin(readOnlyEntity, { includeReadOnly: true }),
+    'DIMENSION / read-only',
+  );
+});
+
+test('formatSelectionLayer and formatSelectionLayerColor preserve named, unnamed, and missing layer output', () => {
+  const layer = makeLayer();
+  const getLayer = getLayerFactory(layer);
+  assert.equal(formatSelectionLayer(makeEntity(), getLayer), '7:A-WALL');
+  assert.equal(formatSelectionLayerColor(makeEntity(), getLayer), '#00ff00');
+
+  const unnamedLayer = makeLayer({ name: '   ' });
+  assert.equal(formatSelectionLayer(makeEntity(), getLayerFactory(unnamedLayer)), '7');
+
+  assert.equal(formatSelectionLayer(makeEntity({ layerId: null }), getLayer), '');
+  assert.equal(formatSelectionLayerColor(makeEntity(), null), '');
+});
+
+test('listSelectionLayerFlags and formatSelectionLayerFlags preserve layer state flag ordering', () => {
+  const layer = makeLayer({ visible: false, locked: true, frozen: true, printable: false, construction: true });
+  const getLayer = getLayerFactory(layer);
+  assert.deepEqual(listSelectionLayerFlags(makeEntity(), getLayer), [
+    'Hidden',
+    'Locked',
+    'Frozen',
+    'NoPrint',
+    'Construction',
+  ]);
+  assert.equal(
+    formatSelectionLayerFlags(makeEntity(), getLayer),
+    'Hidden / Locked / Frozen / NoPrint / Construction',
+  );
+  assert.equal(
+    formatSelectionLayerFlags(makeEntity(), getLayer, { separator: ' | ' }),
+    'Hidden | Locked | Frozen | NoPrint | Construction',
+  );
+});
+
+test('formatSelectionLayerState preserves combined shown/open/live/print/normal state summary', () => {
+  const layer = makeLayer();
+  assert.equal(
+    formatSelectionLayerState(makeEntity(), getLayerFactory(layer)),
+    'Shown / Open / Live / Print / Normal',
+  );
+  assert.equal(formatSelectionLayerState(makeEntity(), null), '');
+});

--- a/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
+++ b/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
@@ -1,4 +1,4 @@
-import { describeSelectionOrigin } from './selection_presenter.js';
+import { describeSelectionOrigin } from './selection_meta_helpers.js';
 
 function renderSelectionBadgeRow(doc, badges) {
   if (!Array.isArray(badges) || badges.length === 0) {

--- a/tools/web_viewer/ui/selection_badges.js
+++ b/tools/web_viewer/ui/selection_badges.js
@@ -3,7 +3,7 @@ import {
   isReadOnlySelectionEntity,
   formatSelectionLayer,
   listSelectionLayerFlags,
-} from './selection_presenter.js';
+} from './selection_meta_helpers.js';
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';

--- a/tools/web_viewer/ui/selection_meta_helpers.js
+++ b/tools/web_viewer/ui/selection_meta_helpers.js
@@ -1,0 +1,79 @@
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}
+
+export function isReadOnlySelectionEntity(entity) {
+  return !!entity && (entity.readOnly === true || entity.type === 'unsupported' || entity.editMode === 'proxy');
+}
+
+export function describeReadOnlySelectionEntity(entity) {
+  if (!entity) return 'read-only proxy';
+  if (entity.type === 'unsupported') return 'unsupported proxy';
+  const sourceType = normalizeText(entity.sourceType);
+  const proxyKind = normalizeText(entity.proxyKind);
+  if (sourceType && proxyKind) return `${sourceType} ${proxyKind} proxy`;
+  if (sourceType) return `${sourceType} derived proxy`;
+  return 'read-only proxy';
+}
+
+export function describeSelectionOrigin(entity, { separator = ' / ', includeReadOnly = false } = {}) {
+  if (!entity) return '';
+  const sourceType = normalizeText(entity.sourceType);
+  const proxyKind = normalizeText(entity.proxyKind);
+  const editMode = normalizeText(entity.editMode);
+  const parts = [];
+  if (sourceType) parts.push(sourceType);
+  if (proxyKind) parts.push(proxyKind);
+  if (editMode) parts.push(editMode);
+  if (includeReadOnly && isReadOnlySelectionEntity(entity) && editMode !== 'proxy') {
+    parts.push('read-only');
+  }
+  return parts.join(separator);
+}
+
+export function formatSelectionLayer(entity, getLayer = null) {
+  const layerId = Number.isFinite(entity?.layerId) ? Math.trunc(entity.layerId) : null;
+  const layer = resolveLayer(getLayer, layerId);
+  const name = normalizeText(layer?.name);
+  if (layerId === null) return name;
+  return name ? `${layerId}:${name}` : String(layerId);
+}
+
+export function formatSelectionLayerColor(entity, getLayer = null) {
+  const layer = resolveLayer(getLayer, entity?.layerId);
+  return normalizeText(layer?.color);
+}
+
+export function listSelectionLayerFlags(entity, getLayer = null) {
+  const layer = resolveLayer(getLayer, entity?.layerId);
+  if (!layer) return [];
+  const flags = [];
+  if (layer.visible === false) flags.push('Hidden');
+  if (layer.locked === true) flags.push('Locked');
+  if (layer.frozen === true) flags.push('Frozen');
+  if (layer.printable === false) flags.push('NoPrint');
+  if (layer.construction === true) flags.push('Construction');
+  return flags;
+}
+
+export function formatSelectionLayerFlags(entity, getLayer = null, { separator = ' / ' } = {}) {
+  return listSelectionLayerFlags(entity, getLayer).join(separator);
+}
+
+export function formatSelectionLayerState(entity, getLayer = null) {
+  const layer = resolveLayer(getLayer, entity?.layerId);
+  if (!layer) return '';
+  return [
+    layer.visible === false ? 'Hidden' : 'Shown',
+    layer.locked === true ? 'Locked' : 'Open',
+    layer.frozen === true ? 'Frozen' : 'Live',
+    layer.printable === false ? 'NoPrint' : 'Print',
+    layer.construction === true ? 'Construction' : 'Normal',
+  ].join(' / ');
+}

--- a/tools/web_viewer/ui/selection_overview.js
+++ b/tools/web_viewer/ui/selection_overview.js
@@ -1,7 +1,7 @@
 import {
   isReadOnlySelectionEntity,
   describeSelectionOrigin,
-} from './selection_presenter.js';
+} from './selection_meta_helpers.js';
 
 export function formatSelectionSummary(entities) {
   const list = Array.isArray(entities) ? entities.filter(Boolean) : [];

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -19,8 +19,30 @@ import {
   summarizeSourceGroupMembers,
 } from '../insert_group.js';
 import { formatSpaceLabel } from '../space_layout.js';
+import {
+  describeReadOnlySelectionEntity,
+  describeSelectionOrigin,
+  formatSelectionLayer,
+  formatSelectionLayerColor,
+  formatSelectionLayerFlags,
+  formatSelectionLayerState,
+  isReadOnlySelectionEntity,
+  listSelectionLayerFlags,
+} from './selection_meta_helpers.js';
+import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 export { formatSpaceLabel } from '../space_layout.js';
 export { resolveReleasedInsertArchive } from '../insert_group.js';
+export {
+  describeReadOnlySelectionEntity,
+  describeSelectionOrigin,
+  formatSelectionLayer,
+  formatSelectionLayerColor,
+  formatSelectionLayerFlags,
+  formatSelectionLayerState,
+  isReadOnlySelectionEntity,
+  listSelectionLayerFlags,
+} from './selection_meta_helpers.js';
+export { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -209,79 +231,6 @@ function formatAttributeModes(entity) {
   if (entity?.attributeLockPosition === true) modes.push('Lock Position');
   return modes.length > 0 ? modes.join(' / ') : 'None';
 }
-
-export function isReadOnlySelectionEntity(entity) {
-  return !!entity && (entity.readOnly === true || entity.type === 'unsupported' || entity.editMode === 'proxy');
-}
-
-export function describeReadOnlySelectionEntity(entity) {
-  if (!entity) return 'read-only proxy';
-  if (entity.type === 'unsupported') return 'unsupported proxy';
-  const sourceType = normalizeText(entity.sourceType);
-  const proxyKind = normalizeText(entity.proxyKind);
-  if (sourceType && proxyKind) return `${sourceType} ${proxyKind} proxy`;
-  if (sourceType) return `${sourceType} derived proxy`;
-  return 'read-only proxy';
-}
-
-export function describeSelectionOrigin(entity, { separator = ' / ', includeReadOnly = false } = {}) {
-  if (!entity) return '';
-  const sourceType = normalizeText(entity.sourceType);
-  const proxyKind = normalizeText(entity.proxyKind);
-  const editMode = normalizeText(entity.editMode);
-  const parts = [];
-  if (sourceType) parts.push(sourceType);
-  if (proxyKind) parts.push(proxyKind);
-  if (editMode) parts.push(editMode);
-  if (includeReadOnly && isReadOnlySelectionEntity(entity) && editMode !== 'proxy') {
-    parts.push('read-only');
-  }
-  return parts.join(separator);
-}
-
-export function formatSelectionLayer(entity, getLayer = null) {
-  const layerId = Number.isFinite(entity?.layerId) ? Math.trunc(entity.layerId) : null;
-  const layer = resolveLayer(getLayer, layerId);
-  const name = normalizeText(layer?.name);
-  if (layerId === null) return name;
-  return name ? `${layerId}:${name}` : String(layerId);
-}
-
-export function formatSelectionLayerColor(entity, getLayer = null) {
-  const layer = resolveLayer(getLayer, entity?.layerId);
-  return normalizeText(layer?.color);
-}
-
-export function listSelectionLayerFlags(entity, getLayer = null) {
-  const layer = resolveLayer(getLayer, entity?.layerId);
-  if (!layer) return [];
-  const flags = [];
-  if (layer.visible === false) flags.push('Hidden');
-  if (layer.locked === true) flags.push('Locked');
-  if (layer.frozen === true) flags.push('Frozen');
-  if (layer.printable === false) flags.push('NoPrint');
-  if (layer.construction === true) flags.push('Construction');
-  return flags;
-}
-
-export function formatSelectionLayerFlags(entity, getLayer = null, { separator = ' / ' } = {}) {
-  return listSelectionLayerFlags(entity, getLayer).join(separator);
-}
-
-export function formatSelectionLayerState(entity, getLayer = null) {
-  const layer = resolveLayer(getLayer, entity?.layerId);
-  if (!layer) return '';
-  return [
-    layer.visible === false ? 'Hidden' : 'Shown',
-    layer.locked === true ? 'Locked' : 'Open',
-    layer.frozen === true ? 'Frozen' : 'Live',
-    layer.printable === false ? 'NoPrint' : 'Print',
-    layer.construction === true ? 'Construction' : 'Normal',
-  ].join(' / ');
-}
-
-import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
-export { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
 function formatSelectionColor(entity, getLayer = null) {
   const layer = resolveLayer(getLayer, entity?.layerId);


### PR DESCRIPTION
## Summary
- extract shared selection meta helpers into `tools/web_viewer/ui/selection_meta_helpers.js`
- update selection badges, selection overview, and property-panel selection shell renderers to consume the new helper module instead of importing presenter internals
- keep `selection_presenter.js` public exports stable by re-exporting the moved helpers
- add Step339 design/verification docs and focused helper tests

## Why
Step337 and Step338 already moved badge and overview logic out of `selection_presenter.js`, but those extracted modules still depended back on presenter internals for shared helper behavior. This PR removes that avoidable cycle without changing selection presentation semantics.

## Scope
Included:
- `tools/web_viewer/ui/selection_meta_helpers.js`
- `tools/web_viewer/ui/selection_presenter.js`
- `tools/web_viewer/ui/selection_badges.js`
- `tools/web_viewer/ui/selection_overview.js`
- `tools/web_viewer/ui/property_panel_selection_shell_renderers.js`
- `tools/web_viewer/tests/selection_meta_helpers.test.js`
- `docs/STEP339_SELECTION_META_HELPERS_DESIGN.md`
- `docs/STEP339_SELECTION_META_HELPERS_VERIFICATION.md`

Not included:
- property panel render-state refactors
- selection detail-fact extraction
- action-context or note-plan extraction

## Verification
Local verification completed:
- `node --check` on the touched UI files and `selection_meta_helpers.test.js`
- selection/panel targeted suite: `109/109`
- `tools/web_viewer/tests/editor_commands.test.js`: `297/297`
- smoke:
  - `editor_current_layer_smoke` -> `ok=true`
  - `editor_selection_summary_smoke` -> `ok=true`
  - `editor_ui_flow_smoke` -> `gate_ok=true`, `interaction_checks.selection_provenance_summary_ok=true`
- `git diff --check`

Smoke artifacts:
- `/tmp/editor-current-layer-step339/20260401_104347/summary.json`
- `/tmp/editor-selection-summary-step339/20260401_104350/summary.json`
- `/tmp/editor-ui-flow-step339-wrapper/summary.json`
