### PR TITLE
refactor: extract property metadata facts helper

### DIFF
--- a/docs/STEP342_PROPERTY_METADATA_FACTS_EXTRACTION_DESIGN.md
+++ b/docs/STEP342_PROPERTY_METADATA_FACTS_EXTRACTION_DESIGN.md
@@ -1,0 +1,90 @@
+# Step342: Property Metadata Facts Extraction
+
+## Goal
+
+Extract `buildPropertyMetadataFacts(...)` from
+`tools/web_viewer/ui/selection_presenter.js` into a dedicated helper module
+while keeping behavior and public exports unchanged.
+
+## Why This Step
+
+After Step341, `selection_presenter.js` still owns several separate concerns:
+
+- property metadata fact assembly
+- selection action context assembly
+- property panel note planning
+- final selection presentation assembly
+
+`buildPropertyMetadataFacts(...)` is the narrowest next seam because it already
+layers on top of `buildSelectionDetailFacts(...)` and only appends
+property-panel-specific fact groups.
+
+## Scope
+
+In scope:
+
+- create a new helper module for property metadata facts
+- move the implementation of `buildPropertyMetadataFacts(...)` into that module
+- keep `selection_presenter.js` importing and re-exporting
+  `buildPropertyMetadataFacts(...)`
+- add focused tests for the new helper module
+
+Out of scope:
+
+- `buildSelectionActionContext(...)`
+- `buildPropertyPanelReadOnlyNote(...)`
+- `buildPropertyPanelNotePlan(...)`
+- `buildSelectionPresentation(...)`
+- any property panel rendering code
+
+## Target Files
+
+Expected new file:
+
+- `tools/web_viewer/ui/property_metadata_facts.js`
+
+Expected touched files:
+
+- `tools/web_viewer/ui/selection_presenter.js`
+- `tools/web_viewer/tests/property_metadata_facts.test.js`
+
+## Required Behavior
+
+The extraction must preserve all current `buildPropertyMetadataFacts(...)`
+behavior:
+
+- same public return shape
+- same base facts from `buildSelectionDetailFacts(...)`
+- same inserted provenance facts:
+  - `source-type`
+  - `edit-mode`
+  - `proxy-kind`
+- same inserted hatch facts:
+  - `hatch-id`
+  - `hatch-pattern`
+- same inserted dim facts:
+  - `dim-type`
+  - `dim-style`
+- same inserted dim text facts:
+  - `dim-text-pos`
+  - `dim-text-rotation`
+- same insertion anchors and ordering
+
+`selection_presenter.js` must continue exporting
+`buildPropertyMetadataFacts(...)` so downstream imports do not change.
+
+## Dependency Rules
+
+The new helper may import from leaf/shared modules and from
+`selection_detail_facts.js`, but it must not import from `selection_presenter.js`.
+
+No new cycle back into `selection_presenter.js` is allowed.
+
+## Acceptance
+
+Step342 is complete when:
+
+1. `buildPropertyMetadataFacts(...)` lives outside `selection_presenter.js`
+2. `selection_presenter.js` re-exports it without behavior drift
+3. focused tests cover base-fact passthrough and property-only fact insertion
+4. existing integration tests remain green

--- a/docs/STEP342_PROPERTY_METADATA_FACTS_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP342_PROPERTY_METADATA_FACTS_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,42 @@
+# Step342: Property Metadata Facts Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step342-property-metadata-facts`
+
+## Static Checks
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_metadata_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/property_metadata_facts.test.js
+```
+
+## Focused Tests
+
+```bash
+/opt/homebrew/bin/node --test \
+  tools/web_viewer/tests/property_metadata_facts.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js \
+  tools/web_viewer/tests/selection_released_archive_helpers.test.js
+```
+
+## Integration Gate
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+git diff --check
+```
+
+## Optional Smoke
+
+Only rerun smoke if the extraction unexpectedly affects selection/property-panel
+wiring. If smoke is rerun, report exact `summary.json` paths.
+
+## Expected Result
+
+- syntax checks pass
+- focused tests pass
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean
+- no new dependency cycle back into `selection_presenter.js`

--- a/tools/web_viewer/tests/property_metadata_facts.test.js
+++ b/tools/web_viewer/tests/property_metadata_facts.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPropertyMetadataFacts } from '../ui/property_metadata_facts.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 1,
+    visible: true,
+    color: '#9ca3af',
+    colorSource: 'BYLAYER',
+    lineType: 'CONTINUOUS',
+    lineWeight: 0,
+    lineTypeScale: 1,
+    start: { x: 0, y: 0 },
+    end: { x: 10, y: 0 },
+    space: 0,
+    layout: 'Model',
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'L1',
+    color: '#9ca3af',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+function makeOptions(layers = [], entities = []) {
+  const layerMap = new Map(layers.map((l) => [l.id, l]));
+  return {
+    getLayer: (id) => layerMap.get(id) || null,
+    listEntities: () => entities,
+  };
+}
+
+test('returns empty array for null entity', () => {
+  assert.deepEqual(buildPropertyMetadataFacts(null), []);
+});
+
+test('includes base selection detail facts', () => {
+  const entity = makeEntity();
+  const layer = makeLayer();
+  const facts = buildPropertyMetadataFacts(entity, makeOptions([layer], [entity]));
+  const keys = facts.map((f) => f.key);
+
+  assert.ok(keys.includes('layer'), 'missing base layer fact');
+  assert.ok(keys.includes('effective-color'), 'missing base effective-color fact');
+  assert.ok(keys.includes('line-type'), 'missing base line-type fact');
+});
+
+test('inserts provenance facts after entity-visibility', () => {
+  const entity = makeEntity({ sourceType: 'INSERT', editMode: 'proxy', proxyKind: 'fragment' });
+  const layer = makeLayer();
+  const facts = buildPropertyMetadataFacts(entity, makeOptions([layer], [entity]));
+  const keys = facts.map((f) => f.key);
+
+  assert.ok(keys.includes('source-type'));
+  assert.ok(keys.includes('edit-mode'));
+  assert.ok(keys.includes('proxy-kind'));
+
+  const visIdx = keys.indexOf('entity-visibility');
+  const srcIdx = keys.indexOf('source-type');
+  assert.ok(visIdx >= 0 && srcIdx > visIdx, 'provenance facts should follow entity-visibility');
+});
+
+test('inserts hatch facts after line-type-scale-source', () => {
+  const entity = makeEntity({ hatchId: 42, hatchPattern: 'ANSI31' });
+  const layer = makeLayer();
+  const facts = buildPropertyMetadataFacts(entity, makeOptions([layer], [entity]));
+  const keys = facts.map((f) => f.key);
+
+  assert.ok(keys.includes('hatch-id'));
+  assert.ok(keys.includes('hatch-pattern'));
+  assert.equal(facts.find((f) => f.key === 'hatch-id').value, '42');
+  assert.equal(facts.find((f) => f.key === 'hatch-pattern').value, 'ANSI31');
+
+  const ltsIdx = keys.indexOf('line-type-scale-source');
+  const hatchIdx = keys.indexOf('hatch-id');
+  assert.ok(ltsIdx >= 0 && hatchIdx > ltsIdx, 'hatch facts should follow line-type-scale-source');
+});
+
+test('inserts dim facts after attribute-modes anchor', () => {
+  const entity = makeEntity({ dimType: 3, dimStyle: 'ISO-25' });
+  const layer = makeLayer();
+  const facts = buildPropertyMetadataFacts(entity, makeOptions([layer], [entity]));
+  const keys = facts.map((f) => f.key);
+
+  assert.ok(keys.includes('dim-type'));
+  assert.ok(keys.includes('dim-style'));
+  assert.equal(facts.find((f) => f.key === 'dim-type').value, '3');
+  assert.equal(facts.find((f) => f.key === 'dim-style').value, 'ISO-25');
+});
+
+test('inserts dim text facts for entity with dimTextPos', () => {
+  const entity = makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    editMode: 'proxy',
+    type: 'text',
+    sourceTextPos: { x: 5, y: 10 },
+    sourceTextRotation: 0,
+    dimTextPos: { x: 5, y: 10 },
+    dimTextRotation: 45,
+  });
+  const layer = makeLayer();
+  const facts = buildPropertyMetadataFacts(entity, makeOptions([layer], [entity]));
+  const keys = facts.map((f) => f.key);
+
+  assert.ok(keys.includes('dim-text-pos'));
+  assert.ok(keys.includes('dim-text-rotation'));
+  assert.equal(facts.find((f) => f.key === 'dim-text-pos').value, '5, 10');
+  assert.equal(facts.find((f) => f.key === 'dim-text-rotation').value, '45');
+});

--- a/tools/web_viewer/ui/property_metadata_facts.js
+++ b/tools/web_viewer/ui/property_metadata_facts.js
@@ -1,0 +1,78 @@
+import { buildSelectionDetailFacts } from './selection_detail_facts.js';
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function pushFact(facts, key, label, value, extra = {}) {
+  if (value === null || value === undefined || value === '') return;
+  facts.push({
+    key,
+    label,
+    value: String(value),
+    ...extra,
+  });
+}
+
+function insertFactsAfterFirstKey(facts, keys, extraFacts) {
+  if (!Array.isArray(facts) || !Array.isArray(extraFacts) || extraFacts.length === 0) return facts;
+  const anchors = Array.isArray(keys) ? keys : [keys];
+  const index = anchors.reduce((found, key) => {
+    if (found >= 0) return found;
+    return facts.findIndex((fact) => fact?.key === key);
+  }, -1);
+  if (index < 0) {
+    facts.push(...extraFacts);
+    return facts;
+  }
+  facts.splice(index + 1, 0, ...extraFacts);
+  return facts;
+}
+
+function formatCompactNumber(value) {
+  if (!Number.isFinite(value)) return '';
+  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
+  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
+  return text === '-0' ? '0' : text;
+}
+
+function formatPoint(value) {
+  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
+  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
+}
+
+export function buildPropertyMetadataFacts(entity, options = {}) {
+  if (!entity) return [];
+  const facts = [...buildSelectionDetailFacts(entity, options)];
+
+  const provenanceFacts = [];
+  pushFact(provenanceFacts, 'source-type', 'Source Type', normalizeText(entity.sourceType));
+  pushFact(provenanceFacts, 'edit-mode', 'Edit Mode', normalizeText(entity.editMode));
+  pushFact(provenanceFacts, 'proxy-kind', 'Proxy Kind', normalizeText(entity.proxyKind));
+  insertFactsAfterFirstKey(facts, 'entity-visibility', provenanceFacts);
+
+  const hatchFacts = [];
+  if (Number.isFinite(entity.hatchId)) {
+    pushFact(hatchFacts, 'hatch-id', 'Hatch ID', String(Math.trunc(entity.hatchId)));
+  }
+  pushFact(hatchFacts, 'hatch-pattern', 'Hatch Pattern', normalizeText(entity.hatchPattern));
+  insertFactsAfterFirstKey(facts, 'line-type-scale-source', hatchFacts);
+
+  const dimFacts = [];
+  if (Number.isFinite(entity.dimType)) {
+    pushFact(dimFacts, 'dim-type', 'Dim Type', String(entity.dimType));
+  }
+  pushFact(dimFacts, 'dim-style', 'Dim Style', normalizeText(entity.dimStyle));
+  insertFactsAfterFirstKey(facts, ['attribute-modes', 'released-attribute-modes'], dimFacts);
+
+  const dimTextFacts = [];
+  if (entity.dimTextPos && Number.isFinite(entity.dimTextPos.x) && Number.isFinite(entity.dimTextPos.y)) {
+    pushFact(dimTextFacts, 'dim-text-pos', 'Dim Text Pos', formatPoint(entity.dimTextPos));
+  }
+  if (Number.isFinite(entity.dimTextRotation)) {
+    pushFact(dimTextFacts, 'dim-text-rotation', 'Dim Text Rotation', formatCompactNumber(entity.dimTextRotation));
+  }
+  insertFactsAfterFirstKey(facts, ['current-offset', 'source-text-rotation', 'source-text-pos'], dimTextFacts);
+
+  return facts;
+}

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -163,41 +163,8 @@ export { buildSelectionContract } from './selection_contract.js';
 import { buildSelectionDetailFacts, buildMultiSelectionDetailFacts } from './selection_detail_facts.js';
 export { buildSelectionDetailFacts } from './selection_detail_facts.js';
 
-export function buildPropertyMetadataFacts(entity, options = {}) {
-  if (!entity) return [];
-  const facts = [...buildSelectionDetailFacts(entity, options)];
-
-  const provenanceFacts = [];
-  pushFact(provenanceFacts, 'source-type', 'Source Type', normalizeText(entity.sourceType));
-  pushFact(provenanceFacts, 'edit-mode', 'Edit Mode', normalizeText(entity.editMode));
-  pushFact(provenanceFacts, 'proxy-kind', 'Proxy Kind', normalizeText(entity.proxyKind));
-  insertFactsAfterFirstKey(facts, 'entity-visibility', provenanceFacts);
-
-  const hatchFacts = [];
-  if (Number.isFinite(entity.hatchId)) {
-    pushFact(hatchFacts, 'hatch-id', 'Hatch ID', String(Math.trunc(entity.hatchId)));
-  }
-  pushFact(hatchFacts, 'hatch-pattern', 'Hatch Pattern', normalizeText(entity.hatchPattern));
-  insertFactsAfterFirstKey(facts, 'line-type-scale-source', hatchFacts);
-
-  const dimFacts = [];
-  if (Number.isFinite(entity.dimType)) {
-    pushFact(dimFacts, 'dim-type', 'Dim Type', String(entity.dimType));
-  }
-  pushFact(dimFacts, 'dim-style', 'Dim Style', normalizeText(entity.dimStyle));
-  insertFactsAfterFirstKey(facts, ['attribute-modes', 'released-attribute-modes'], dimFacts);
-
-  const dimTextFacts = [];
-  if (entity.dimTextPos && Number.isFinite(entity.dimTextPos.x) && Number.isFinite(entity.dimTextPos.y)) {
-    pushFact(dimTextFacts, 'dim-text-pos', 'Dim Text Pos', formatPoint(entity.dimTextPos));
-  }
-  if (Number.isFinite(entity.dimTextRotation)) {
-    pushFact(dimTextFacts, 'dim-text-rotation', 'Dim Text Rotation', formatCompactNumber(entity.dimTextRotation));
-  }
-  insertFactsAfterFirstKey(facts, ['current-offset', 'source-text-rotation', 'source-text-pos'], dimTextFacts);
-
-  return facts;
-}
+import { buildPropertyMetadataFacts } from './property_metadata_facts.js';
+export { buildPropertyMetadataFacts } from './property_metadata_facts.js';
 
 function buildPeerTargets(peerSummary) {
   if (!peerSummary || !Array.isArray(peerSummary.peers)) return [];


### PR DESCRIPTION
## Summary
- extract `buildPropertyMetadataFacts(...)` into `property_metadata_facts.js`
- keep `selection_presenter.js` public surface stable via import + re-export
- add focused tests for property-only fact insertion and ordering anchors

## Why
- continues the `selection_presenter.js` seam cleanup after Steps 340-341
- isolates property metadata fact assembly without changing ordering or semantics

## Verification
- `node --check tools/web_viewer/ui/property_metadata_facts.js`
- `node --check tools/web_viewer/ui/selection_presenter.js`
- `node --check tools/web_viewer/tests/property_metadata_facts.test.js`
- `node --test tools/web_viewer/tests/property_metadata_facts.test.js tools/web_viewer/tests/selection_detail_facts.test.js tools/web_viewer/tests/selection_released_archive_helpers.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
