### PR TITLE
refactor: extract property panel note helpers

### DIFF
--- a/docs/STEP344_PROPERTY_PANEL_NOTE_HELPERS_EXTRACTION_DESIGN.md
+++ b/docs/STEP344_PROPERTY_PANEL_NOTE_HELPERS_EXTRACTION_DESIGN.md
@@ -1,0 +1,108 @@
+# Step344 Property Panel Note Helpers Extraction Design
+
+## Goal
+
+Extract the property-panel note builders from `tools/web_viewer/ui/selection_presenter.js`
+into a dedicated helper module while keeping all public behavior stable.
+
+Target functions:
+
+- `buildPropertyPanelReadOnlyNote(...)`
+- `buildPropertyPanelReleasedArchiveNote(...)`
+- `buildPropertyPanelLockedLayerNote(...)`
+
+Suggested new module:
+
+- `tools/web_viewer/ui/property_panel_note_helpers.js`
+
+## Why This Seam
+
+After Step343, `selection_presenter.js` still carries a dense property-panel note cluster:
+
+- read-only note wording
+- released-archive note wording
+- locked-layer note wording
+
+These helpers are used by `buildPropertyPanelNotePlan(...)`, but they are logically separate
+from selection summary / badges / detail facts / action context assembly.
+
+This is the narrowest next seam that:
+
+- shrinks `selection_presenter.js`
+- keeps `buildPropertyPanelNotePlan(...)` unchanged
+- avoids mixing note-plan orchestration with presentation extraction
+
+## Required Scope
+
+Move only the three note builders into the new helper module.
+
+`selection_presenter.js` must continue to re-export them so the public surface remains stable.
+
+`buildPropertyPanelNotePlan(...)` must keep the same call shape and behavior.
+
+## Allowed Private Helper Movement
+
+If needed to avoid importing back through `selection_presenter.js`, the new module may define
+or own only the minimal private helpers required by the moved note builders, for example:
+
+- layer lookup / layer label formatting helpers
+- note-only text normalization helpers
+- note-only insert text position editability helper logic
+
+These private helpers must not broaden the scope into note-plan or presentation refactors.
+
+## Explicit Non-Goals
+
+Do not change:
+
+- `buildPropertyPanelNotePlan(...)`
+- `buildSelectionPresentation(...)`
+- `buildSelectionActionContext(...)`
+- `buildPropertyMetadataFacts(...)`
+- `buildSelectionContract(...)`
+- `buildSelectionDetailFacts(...)`
+- badge / overview / property fact ordering
+
+Do not change:
+
+- note wording
+- read-only semantics
+- locked-layer semantics
+- released-archive semantics
+- direct insert/source text edit allowances inferred by note-plan
+
+## Dependency Rules
+
+The new module must not import `selection_presenter.js`.
+
+Preferred dependency direction:
+
+- `property_panel_note_helpers.js` imports from leaf/shared modules such as:
+  - `insert_group.js`
+  - `selection_meta_helpers.js`
+  - `selection_released_archive_helpers.js`
+  - any minimal local private helpers placed directly in the new module
+- `selection_presenter.js` imports/re-exports from `property_panel_note_helpers.js`
+
+No new cycle back into `selection_presenter.js` is allowed.
+
+## Testing Expectations
+
+Add a focused test file for the new helper module, covering:
+
+- single read-only INSERT ATTDEF text proxy wording
+- full source-group read-only wording
+- released archive ATTDEF wording
+- locked single-entity wording
+
+Keep existing `editor_commands.test.js` assertions unchanged as the integration guard.
+
+## Done Criteria
+
+Step344 is done when:
+
+1. the three note helpers live in a dedicated module
+2. `selection_presenter.js` only imports/re-exports them
+3. no new dependency cycle exists
+4. focused tests pass
+5. `editor_commands.test.js` still passes unchanged

--- a/docs/STEP344_PROPERTY_PANEL_NOTE_HELPERS_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP344_PROPERTY_PANEL_NOTE_HELPERS_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,46 @@
+# Step344 Property Panel Note Helpers Extraction Verification
+
+## Required Checks
+
+Run `node --check` on:
+
+- `tools/web_viewer/ui/property_panel_note_helpers.js`
+- `tools/web_viewer/ui/selection_presenter.js`
+- the new focused helper test file
+
+Run focused tests:
+
+- the new property-panel note helper test file
+
+Run integration guard:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+Run formatting guard:
+
+- `git diff --check`
+
+## Suggested Commands
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/property_panel_note_helpers.test.js
+
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+
+git diff --check
+```
+
+## Expected Reporting
+
+Report:
+
+- changed files
+- focused test count
+- `editor_commands.test.js` result
+- `git diff --check` result
+
+Browser smoke is not required for this seam unless the implementation unexpectedly touches
+render wiring beyond the three note helpers.

--- a/tools/web_viewer/tests/property_panel_note_helpers.test.js
+++ b/tools/web_viewer/tests/property_panel_note_helpers.test.js
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildPropertyPanelReadOnlyNote,
+  buildPropertyPanelReleasedArchiveNote,
+  buildPropertyPanelLockedLayerNote,
+} from '../ui/property_panel_note_helpers.js';
+
+// --- buildPropertyPanelReadOnlyNote ---
+
+test('readOnlyNote returns empty for no entities', () => {
+  assert.equal(buildPropertyPanelReadOnlyNote([], null), '');
+});
+
+test('readOnlyNote returns empty for non-read-only entity', () => {
+  const entity = { id: 1, type: 'line' };
+  assert.equal(buildPropertyPanelReadOnlyNote([entity], entity), '');
+});
+
+test('readOnlyNote single read-only entity returns generic disabled message', () => {
+  const entity = { id: 1, type: 'unsupported', readOnly: true };
+  const note = buildPropertyPanelReadOnlyNote([entity], entity);
+  assert.ok(note.includes('read-only'));
+  assert.ok(note.includes('editing disabled'));
+});
+
+test('readOnlyNote single INSERT ATTDEF text proxy includes ATTDEF wording', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'INSERT', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true, textKind: 'ATTDEF',
+    attributeLockPosition: false,
+  };
+  const note = buildPropertyPanelReadOnlyNote([entity], entity);
+  assert.ok(note.includes('INSERT ATTDEF text proxy'));
+  assert.ok(note.includes('default text stays editable'));
+});
+
+test('readOnlyNote single source text proxy includes source text wording', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'DIMENSION', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true,
+  };
+  const note = buildPropertyPanelReadOnlyNote([entity], entity);
+  assert.ok(note.includes('source text proxy'));
+  assert.ok(note.includes('text overrides stay editable'));
+});
+
+test('readOnlyNote full source group returns source group wording', () => {
+  const e1 = { id: 1, type: 'text', readOnly: true, groupId: 100, sourceType: 'DIMENSION', proxyKind: 'text', editMode: 'proxy' };
+  const e2 = { id: 2, type: 'line', readOnly: true, groupId: 100 };
+  const actionContext = {
+    sourceGroup: {
+      summary: { readOnlyIds: [1, 2] },
+      selectionMatchesGroup: true,
+    },
+    insertGroup: null,
+  };
+  const note = buildPropertyPanelReadOnlyNote([e1, e2], e1, actionContext);
+  assert.ok(note.includes('source group'));
+  assert.ok(note.includes('bundle-level'));
+});
+
+// --- buildPropertyPanelReleasedArchiveNote ---
+
+test('releasedArchiveNote returns empty for null', () => {
+  assert.equal(buildPropertyPanelReleasedArchiveNote(null), '');
+});
+
+test('releasedArchiveNote ATTDEF returns ATTDEF provenance wording', () => {
+  const archive = { sourceType: 'INSERT', proxyKind: 'fragment', textKind: 'ATTDEF' };
+  const entity = { id: 1, releasedInsertArchive: archive };
+  const note = buildPropertyPanelReleasedArchiveNote(entity);
+  assert.ok(note.includes('ATTDEF provenance'));
+  assert.ok(note.includes('released from imported'));
+});
+
+test('releasedArchiveNote non-ATTDEF returns generic insert provenance wording', () => {
+  const archive = { sourceType: 'INSERT', proxyKind: 'fragment', textKind: 'ATTRIB' };
+  const entity = { id: 1, releasedInsertArchive: archive };
+  const note = buildPropertyPanelReleasedArchiveNote(entity);
+  assert.ok(note.includes('archived insert provenance'));
+  assert.ok(!note.includes('ATTDEF'));
+});
+
+// --- buildPropertyPanelLockedLayerNote ---
+
+test('lockedLayerNote returns empty for no entities', () => {
+  assert.equal(buildPropertyPanelLockedLayerNote([], null), '');
+});
+
+test('lockedLayerNote returns empty when no locked layers', () => {
+  const entity = { id: 1, type: 'line', layerId: 1 };
+  const getLayer = () => ({ id: 1, name: 'L1', locked: false });
+  assert.equal(buildPropertyPanelLockedLayerNote([entity], entity, getLayer), '');
+});
+
+test('lockedLayerNote single entity on locked layer includes layer name', () => {
+  const entity = { id: 1, type: 'line', layerId: 1 };
+  const getLayer = () => ({ id: 1, name: 'L1', locked: true });
+  const note = buildPropertyPanelLockedLayerNote([entity], entity, getLayer);
+  assert.ok(note.includes('locked layer'));
+  assert.ok(note.includes('1:L1'));
+  assert.ok(note.includes('editing disabled'));
+});
+
+test('lockedLayerNote mixed locked returns count wording', () => {
+  const e1 = { id: 1, type: 'line', layerId: 1 };
+  const e2 = { id: 2, type: 'line', layerId: 2 };
+  const layers = new Map([[1, { id: 1, name: 'L1', locked: true }], [2, { id: 2, name: 'L2', locked: false }]]);
+  const getLayer = (id) => layers.get(id) || null;
+  const note = buildPropertyPanelLockedLayerNote([e1, e2], e1, getLayer);
+  assert.ok(note.includes('1 entities on locked layers'));
+  assert.ok(note.includes('edits skip them'));
+});

--- a/tools/web_viewer/ui/property_panel_note_helpers.js
+++ b/tools/web_viewer/ui/property_panel_note_helpers.js
@@ -1,0 +1,103 @@
+import {
+  isDirectEditableInsertTextProxyEntity,
+  isDirectEditableSourceTextEntity,
+  isInsertTextProxyEntity,
+  resolveReleasedInsertArchive,
+} from '../insert_group.js';
+import {
+  describeReadOnlySelectionEntity,
+  formatSelectionLayer,
+  isReadOnlySelectionEntity,
+} from './selection_meta_helpers.js';
+import {
+  formatReleasedInsertArchiveOrigin,
+} from './selection_released_archive_helpers.js';
+
+function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}
+
+function supportsInsertTextPositionEditing(entity) {
+  return isDirectEditableInsertTextProxyEntity(entity)
+    && typeof entity?.attributeLockPosition === 'boolean'
+    && entity.attributeLockPosition !== true;
+}
+
+export function buildPropertyPanelReadOnlyNote(entities, primary, actionContext = null) {
+  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
+  if (list.length === 0 || !primary) return '';
+  const readOnlyCount = list.filter((entity) => isReadOnlySelectionEntity(entity)).length;
+  if (readOnlyCount <= 0) return '';
+
+  const insertGroupSummary = actionContext?.insertGroup?.summary || null;
+  const sourceGroupSummary = actionContext?.sourceGroup?.summary || null;
+  const fullInsertGroupSelected = !!insertGroupSummary
+    && insertGroupSummary.readOnlyIds.length > 0
+    && actionContext?.insertGroup?.selectionMatchesGroup === true;
+  const fullSourceGroupSelected = !insertGroupSummary
+    && !!sourceGroupSummary
+    && sourceGroupSummary.readOnlyIds.length > 0
+    && actionContext?.sourceGroup?.selectionMatchesGroup === true;
+
+  if (readOnlyCount === list.length) {
+    if (list.length === 1) {
+      if (isDirectEditableSourceTextEntity(primary)) {
+        return `Selected entity is a read-only source text proxy (${describeReadOnlySelectionEntity(primary)}); text overrides stay editable while geometry remains proxy-only.`;
+      }
+      if (isDirectEditableInsertTextProxyEntity(primary)) {
+        const positionClause = supportsInsertTextPositionEditing(primary)
+          ? 'text position stays editable while instance geometry remains proxy-only'
+          : (primary?.attributeLockPosition === true
+          ? 'position stays lock-positioned until release'
+          : 'instance geometry remains proxy-only');
+        return String(primary?.textKind || '').trim().toLowerCase() === 'attdef'
+          ? `Selected entity is a read-only INSERT ATTDEF text proxy (${describeReadOnlySelectionEntity(primary)}); default text stays editable while prompt remains read-only, ${positionClause}${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden until focused through insert text selection' : ''}.`
+          : `Selected entity is a read-only INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); text value stays editable, ${positionClause}${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden until focused through insert text selection' : ''}.`;
+      }
+      if (isInsertTextProxyEntity(primary) && primary?.attributeConstant === true) {
+        return `Selected entity is a read-only constant INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); constant attribute values stay importer-authored until release, instance geometry remains proxy-only${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden by default' : ''}.`;
+      }
+      if (isInsertTextProxyEntity(primary) && primary?.attributeInvisible === true) {
+        return `Selected entity is a read-only invisible INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); hidden attribute text is inspectable through insert text focus, but geometry remains proxy-only.`;
+      }
+      return `Selected entity is read-only (${describeReadOnlySelectionEntity(primary)}); editing disabled.`;
+    }
+    return fullInsertGroupSelected
+      ? 'Selected entities are a read-only imported insert group; full-group move/rotate/scale/copy/delete stay instance-level until release.'
+      : (fullSourceGroupSelected
+          ? 'Selected entities are a read-only source group; full-group move/rotate/scale/copy/delete stay bundle-level until release while source-text edit stays available when the bundle has text.'
+          : 'Selected entities are read-only proxies; editing disabled.');
+  }
+
+  return fullInsertGroupSelected
+    ? `Contains ${readOnlyCount} read-only derived/proxy entities; property edits skip them, full-group move/rotate/scale/copy/delete stay instance-level, and release detaches the group to editable geometry.`
+    : (fullSourceGroupSelected
+        ? `Contains ${readOnlyCount} read-only derived/proxy entities; full-group move/rotate/scale/copy/delete stay bundle-level, source-group selection/fit/release stay available, and source-text edit can release straight into editable text when present.`
+        : `Contains ${readOnlyCount} read-only derived/proxy entities; property edits skip them.`);
+}
+
+export function buildPropertyPanelReleasedArchiveNote(entityOrArchive) {
+  const archive = resolveReleasedInsertArchive(entityOrArchive) || entityOrArchive;
+  if (!archive) return '';
+  const archiveOrigin = formatReleasedInsertArchiveOrigin(archive) || 'INSERT / text / proxy';
+  const archiveTextKind = String(archive?.textKind || '').trim().toLowerCase();
+  return archiveTextKind === 'attdef'
+    ? `Selected entity was released from imported ${archiveOrigin}; archived ATTDEF provenance remains visible as read-only context while the detached text now edits like plain text.`
+    : `Selected entity was released from imported ${archiveOrigin}; archived insert provenance remains visible as read-only context while the detached text now edits like plain text.`;
+}
+
+export function buildPropertyPanelLockedLayerNote(entities, primary, getLayer = null) {
+  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
+  if (list.length === 0 || !primary) return '';
+  const lockedCount = list.filter((entity) => resolveLayer(getLayer, entity?.layerId)?.locked === true).length;
+  if (lockedCount <= 0) return '';
+  if (lockedCount === list.length) {
+    const layerSummary = formatSelectionLayer(primary, getLayer);
+    return list.length === 1
+      ? `Selected entity is on locked layer ${layerSummary}; editing disabled until the layer is unlocked.`
+      : 'Selected entities are on locked layers; editing disabled.';
+  }
+  return `Contains ${lockedCount} entities on locked layers; edits skip them.`;
+}

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -156,82 +156,16 @@ export { buildPropertyMetadataFacts } from './property_metadata_facts.js';
 import { buildSelectionActionContext } from './selection_action_context.js';
 export { buildSelectionActionContext } from './selection_action_context.js';
 
-export function buildPropertyPanelReadOnlyNote(entities, primary, actionContext = null) {
-  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
-  if (list.length === 0 || !primary) return '';
-  const readOnlyCount = list.filter((entity) => isReadOnlySelectionEntity(entity)).length;
-  if (readOnlyCount <= 0) return '';
-
-  const insertGroupSummary = actionContext?.insertGroup?.summary || null;
-  const sourceGroupSummary = actionContext?.sourceGroup?.summary || null;
-  const fullInsertGroupSelected = !!insertGroupSummary
-    && insertGroupSummary.readOnlyIds.length > 0
-    && actionContext?.insertGroup?.selectionMatchesGroup === true;
-  const fullSourceGroupSelected = !insertGroupSummary
-    && !!sourceGroupSummary
-    && sourceGroupSummary.readOnlyIds.length > 0
-    && actionContext?.sourceGroup?.selectionMatchesGroup === true;
-
-  if (readOnlyCount === list.length) {
-    if (list.length === 1) {
-      if (isDirectEditableSourceTextEntity(primary)) {
-        return `Selected entity is a read-only source text proxy (${describeReadOnlySelectionEntity(primary)}); text overrides stay editable while geometry remains proxy-only.`;
-      }
-      if (isDirectEditableInsertTextProxyEntity(primary)) {
-        const positionClause = supportsInsertTextPositionEditing(primary)
-          ? 'text position stays editable while instance geometry remains proxy-only'
-          : (primary?.attributeLockPosition === true
-          ? 'position stays lock-positioned until release'
-          : 'instance geometry remains proxy-only');
-        return String(primary?.textKind || '').trim().toLowerCase() === 'attdef'
-          ? `Selected entity is a read-only INSERT ATTDEF text proxy (${describeReadOnlySelectionEntity(primary)}); default text stays editable while prompt remains read-only, ${positionClause}${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden until focused through insert text selection' : ''}.`
-          : `Selected entity is a read-only INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); text value stays editable, ${positionClause}${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden until focused through insert text selection' : ''}.`;
-      }
-      if (isInsertTextProxyEntity(primary) && primary?.attributeConstant === true) {
-        return `Selected entity is a read-only constant INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); constant attribute values stay importer-authored until release, instance geometry remains proxy-only${primary?.attributeInvisible === true ? ', and invisible attributes stay hidden by default' : ''}.`;
-      }
-      if (isInsertTextProxyEntity(primary) && primary?.attributeInvisible === true) {
-        return `Selected entity is a read-only invisible INSERT text proxy (${describeReadOnlySelectionEntity(primary)}); hidden attribute text is inspectable through insert text focus, but geometry remains proxy-only.`;
-      }
-      return `Selected entity is read-only (${describeReadOnlySelectionEntity(primary)}); editing disabled.`;
-    }
-    return fullInsertGroupSelected
-      ? 'Selected entities are a read-only imported insert group; full-group move/rotate/scale/copy/delete stay instance-level until release.'
-      : (fullSourceGroupSelected
-          ? 'Selected entities are a read-only source group; full-group move/rotate/scale/copy/delete stay bundle-level until release while source-text edit stays available when the bundle has text.'
-          : 'Selected entities are read-only proxies; editing disabled.');
-  }
-
-  return fullInsertGroupSelected
-    ? `Contains ${readOnlyCount} read-only derived/proxy entities; property edits skip them, full-group move/rotate/scale/copy/delete stay instance-level, and release detaches the group to editable geometry.`
-    : (fullSourceGroupSelected
-        ? `Contains ${readOnlyCount} read-only derived/proxy entities; full-group move/rotate/scale/copy/delete stay bundle-level, source-group selection/fit/release stay available, and source-text edit can release straight into editable text when present.`
-        : `Contains ${readOnlyCount} read-only derived/proxy entities; property edits skip them.`);
-}
-
-export function buildPropertyPanelReleasedArchiveNote(entityOrArchive) {
-  const archive = resolveReleasedInsertArchive(entityOrArchive) || entityOrArchive;
-  if (!archive) return '';
-  const archiveOrigin = formatReleasedInsertArchiveOrigin(archive) || 'INSERT / text / proxy';
-  const archiveTextKind = String(archive?.textKind || '').trim().toLowerCase();
-  return archiveTextKind === 'attdef'
-    ? `Selected entity was released from imported ${archiveOrigin}; archived ATTDEF provenance remains visible as read-only context while the detached text now edits like plain text.`
-    : `Selected entity was released from imported ${archiveOrigin}; archived insert provenance remains visible as read-only context while the detached text now edits like plain text.`;
-}
-
-export function buildPropertyPanelLockedLayerNote(entities, primary, getLayer = null) {
-  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
-  if (list.length === 0 || !primary) return '';
-  const lockedCount = list.filter((entity) => resolveLayer(getLayer, entity?.layerId)?.locked === true).length;
-  if (lockedCount <= 0) return '';
-  if (lockedCount === list.length) {
-    const layerSummary = formatSelectionLayer(primary, getLayer);
-    return list.length === 1
-      ? `Selected entity is on locked layer ${layerSummary}; editing disabled until the layer is unlocked.`
-      : 'Selected entities are on locked layers; editing disabled.';
-  }
-  return `Contains ${lockedCount} entities on locked layers; edits skip them.`;
-}
+import {
+  buildPropertyPanelReadOnlyNote,
+  buildPropertyPanelReleasedArchiveNote,
+  buildPropertyPanelLockedLayerNote,
+} from './property_panel_note_helpers.js';
+export {
+  buildPropertyPanelReadOnlyNote,
+  buildPropertyPanelReleasedArchiveNote,
+  buildPropertyPanelLockedLayerNote,
+} from './property_panel_note_helpers.js';
 
 export function buildPropertyPanelNotePlan(entities, primary, options = {}) {
   const list = Array.isArray(entities) ? entities.filter(Boolean) : [];


### PR DESCRIPTION
## Summary
- extract property-panel note helpers into `property_panel_note_helpers.js`
- keep `selection_presenter.js` re-exporting the moved note helpers so the public contract stays stable
- add focused coverage for read-only, released-archive, and locked-layer note wording

## Verification
- node --check on the touched source/test files
- focused tests: `13/13`
- `tools/web_viewer/tests/editor_commands.test.js`: `297/297`
- `git diff --check`

## Scope
- no behavior changes to `buildPropertyPanelNotePlan(...)` or `buildSelectionPresentation(...)`
- no Step345 work mixed into this PR
