### PR TITLE
refactor: extract property panel note plan helper

### DIFF
--- a/docs/STEP345_PROPERTY_PANEL_NOTE_PLAN_EXTRACTION_DESIGN.md
+++ b/docs/STEP345_PROPERTY_PANEL_NOTE_PLAN_EXTRACTION_DESIGN.md
@@ -1,0 +1,111 @@
+# Step345 Property Panel Note Plan Extraction Design
+
+## Goal
+
+Extract `buildPropertyPanelNotePlan(...)` from
+`tools/web_viewer/ui/selection_presenter.js` into a dedicated helper module while
+keeping behavior unchanged.
+
+Suggested new module:
+
+- `tools/web_viewer/ui/property_panel_note_plan.js`
+
+## Why This Seam
+
+After Step344, `selection_presenter.js` already delegates the three note builders to
+`property_panel_note_helpers.js`.
+
+What remains in `buildPropertyPanelNotePlan(...)` is now a narrow orchestration layer:
+
+- normalize `entities`
+- read `getLayer` and `actionContext`
+- compute read-only / locked counts
+- derive direct-edit allowances
+- stitch the final note plan object
+
+This is the cleanest next seam because:
+
+- it continues to shrink `selection_presenter.js`
+- it does not require touching `buildSelectionPresentation(...)`
+- it builds directly on Step344 without broadening scope
+
+## Required Scope
+
+Move only:
+
+- `buildPropertyPanelNotePlan(...)`
+
+into the new helper module.
+
+`selection_presenter.js` must continue to re-export it so the public contract stays stable.
+
+## Allowed Private Helper Movement
+
+If needed, the new helper may also own only the minimal private support it uses, such as:
+
+- note-plan-only read-only / locked count helpers
+- note-plan-only direct-edit gating helpers
+
+Do not move broader presenter helpers unless they are strictly required.
+
+## Explicit Non-Goals
+
+Do not change:
+
+- `buildPropertyPanelReadOnlyNote(...)`
+- `buildPropertyPanelReleasedArchiveNote(...)`
+- `buildPropertyPanelLockedLayerNote(...)`
+- `buildSelectionPresentation(...)`
+- `buildSelectionActionContext(...)`
+- `buildPropertyMetadataFacts(...)`
+- `buildSelectionContract(...)`
+- `buildSelectionDetailFacts(...)`
+
+Do not change:
+
+- note wording
+- note plan object shape
+- `blocksFurtherEditing` semantics
+- `allowDirectSourceTextEditing` semantics
+- `allowDirectInsertTextEditing` semantics
+- `allowInsertTextPositionEditing` semantics
+
+## Dependency Rules
+
+The new module must not import `selection_presenter.js`.
+
+Preferred dependency direction:
+
+- `property_panel_note_plan.js` imports from:
+  - `property_panel_note_helpers.js`
+  - `insert_group.js`
+  - `selection_meta_helpers.js`
+  - any tiny local private helpers needed for counting or gating
+- `selection_presenter.js` imports/re-exports from `property_panel_note_plan.js`
+
+No new cycle back into `selection_presenter.js` is allowed.
+
+## Testing Expectations
+
+Add a focused test file for the new helper module, covering at least:
+
+- fully read-only single source-text proxy enables direct source-text edit
+- fully read-only single insert text proxy enables direct insert-text edit
+- fully read-only lock-positioned insert text proxy keeps position editing disabled
+- fully locked selection sets locked `blocksFurtherEditing`
+- mixed read-only / editable selection keeps read-only note text but does not block all editing
+
+Keep existing integration assertions unchanged, especially:
+
+- `tools/web_viewer/tests/property_panel_render_state.test.js`
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+## Done Criteria
+
+Step345 is done when:
+
+1. `buildPropertyPanelNotePlan(...)` lives in its own helper module
+2. `selection_presenter.js` only imports/re-exports it
+3. no new dependency cycle exists
+4. focused tests pass
+5. existing integration tests continue to pass unchanged

--- a/docs/STEP345_PROPERTY_PANEL_NOTE_PLAN_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP345_PROPERTY_PANEL_NOTE_PLAN_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,49 @@
+# Step345 Property Panel Note Plan Extraction Verification
+
+## Required Checks
+
+Run `node --check` on:
+
+- `tools/web_viewer/ui/property_panel_note_plan.js`
+- `tools/web_viewer/ui/selection_presenter.js`
+- the new focused helper test file
+
+Run focused tests:
+
+- the new property-panel note plan helper test file
+- `tools/web_viewer/tests/property_panel_render_state.test.js`
+
+Run integration guard:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+Run formatting guard:
+
+- `git diff --check`
+
+## Suggested Commands
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_plan.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/property_panel_note_plan.test.js
+
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_plan.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_render_state.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+
+git diff --check
+```
+
+## Expected Reporting
+
+Report:
+
+- changed files
+- focused helper test result
+- `property_panel_render_state.test.js` result
+- `editor_commands.test.js` result
+- `git diff --check` result
+
+Browser smoke is not required for this seam unless the implementation unexpectedly
+touches render flow beyond the note-plan helper itself.

--- a/tools/web_viewer/tests/property_panel_note_plan.test.js
+++ b/tools/web_viewer/tests/property_panel_note_plan.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPropertyPanelNotePlan } from '../ui/property_panel_note_plan.js';
+
+function makeLayer(overrides = {}) {
+  return { id: 1, name: 'L1', locked: false, ...overrides };
+}
+
+function makeOptions(layers = []) {
+  const layerMap = new Map(layers.map((l) => [l.id, l]));
+  return { getLayer: (id) => layerMap.get(id) || null };
+}
+
+test('fully read-only single source-text proxy enables direct source-text edit', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'DIMENSION', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true, layerId: 1,
+  };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer()]));
+
+  assert.equal(plan.readOnly.blocksFurtherEditing, true);
+  assert.equal(plan.readOnly.allowDirectSourceTextEditing, true);
+  assert.equal(plan.readOnly.allowDirectInsertTextEditing, false);
+  assert.ok(plan.readOnly.text.includes('source text proxy'));
+});
+
+test('fully read-only single insert text proxy enables direct insert-text edit', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'INSERT', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true, layerId: 1,
+    attributeLockPosition: false,
+  };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer()]));
+
+  assert.equal(plan.readOnly.blocksFurtherEditing, true);
+  assert.equal(plan.readOnly.allowDirectInsertTextEditing, true);
+  assert.equal(plan.readOnly.allowInsertTextPositionEditing, true);
+  assert.equal(plan.readOnly.allowDirectSourceTextEditing, false);
+});
+
+test('fully read-only lock-positioned insert text proxy keeps position editing disabled', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'INSERT', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true, layerId: 1,
+    attributeLockPosition: true,
+  };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer()]));
+
+  assert.equal(plan.readOnly.allowDirectInsertTextEditing, true);
+  assert.equal(plan.readOnly.allowInsertTextPositionEditing, false);
+});
+
+test('fully locked selection sets locked blocksFurtherEditing', () => {
+  const entity = { id: 1, type: 'line', layerId: 1 };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer({ locked: true })]));
+
+  assert.equal(plan.locked.blocksFurtherEditing, true);
+  assert.ok(plan.locked.text.includes('locked layer'));
+});
+
+test('mixed read-only / editable keeps note text but does not block all editing', () => {
+  const e1 = { id: 1, type: 'line', readOnly: true, layerId: 1 };
+  const e2 = { id: 2, type: 'line', layerId: 1 };
+  const plan = buildPropertyPanelNotePlan([e1, e2], e1, makeOptions([makeLayer()]));
+
+  assert.equal(plan.readOnly.blocksFurtherEditing, false);
+  assert.ok(plan.readOnly.text.includes('read-only'));
+  assert.equal(plan.readOnly.allowDirectSourceTextEditing, false);
+  assert.equal(plan.readOnly.allowDirectInsertTextEditing, false);
+});
+
+test('empty entities returns empty note texts and no blocking', () => {
+  const plan = buildPropertyPanelNotePlan([], null, makeOptions([makeLayer()]));
+
+  assert.equal(plan.readOnly.text, '');
+  assert.equal(plan.readOnly.blocksFurtherEditing, false);
+  assert.equal(plan.locked.text, '');
+  assert.equal(plan.locked.blocksFurtherEditing, false);
+  assert.equal(plan.releasedInsert.text, '');
+});
+
+test('released insert archive populates releasedInsert.text', () => {
+  const archive = { sourceType: 'INSERT', proxyKind: 'fragment', textKind: 'ATTDEF' };
+  const entity = { id: 1, type: 'text', releasedInsertArchive: archive, layerId: 1 };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer()]));
+
+  assert.ok(plan.releasedInsert.text.includes('released from imported'));
+});
+
+test('source text on locked layer disables direct source text editing', () => {
+  const entity = {
+    id: 1, type: 'text', sourceType: 'DIMENSION', proxyKind: 'text',
+    editMode: 'proxy', readOnly: true, layerId: 1,
+  };
+  const plan = buildPropertyPanelNotePlan([entity], entity, makeOptions([makeLayer({ locked: true })]));
+
+  assert.equal(plan.readOnly.allowDirectSourceTextEditing, false);
+  assert.equal(plan.locked.blocksFurtherEditing, true);
+});

--- a/tools/web_viewer/ui/property_panel_note_plan.js
+++ b/tools/web_viewer/ui/property_panel_note_plan.js
@@ -1,0 +1,60 @@
+import {
+  isDirectEditableInsertTextProxyEntity,
+  isDirectEditableSourceTextEntity,
+} from '../insert_group.js';
+import { isReadOnlySelectionEntity } from './selection_meta_helpers.js';
+import {
+  buildPropertyPanelReadOnlyNote,
+  buildPropertyPanelReleasedArchiveNote,
+  buildPropertyPanelLockedLayerNote,
+} from './property_panel_note_helpers.js';
+
+function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}
+
+function supportsInsertTextPositionEditing(entity) {
+  return isDirectEditableInsertTextProxyEntity(entity)
+    && typeof entity?.attributeLockPosition === 'boolean'
+    && entity.attributeLockPosition !== true;
+}
+
+export function buildPropertyPanelNotePlan(entities, primary, options = {}) {
+  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
+  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
+  const actionContext = options.actionContext || null;
+  const primaryLayer = primary ? resolveLayer(getLayer, primary.layerId) : null;
+  const readOnlyCount = list.filter((entity) => isReadOnlySelectionEntity(entity)).length;
+  const lockedCount = list.filter((entity) => resolveLayer(getLayer, entity?.layerId)?.locked === true).length;
+  const readOnlyBlocksFurtherEditing = readOnlyCount > 0 && readOnlyCount === list.length;
+  const lockedBlocksFurtherEditing = lockedCount > 0 && lockedCount === list.length;
+  const allowDirectSourceTextEditing = readOnlyBlocksFurtherEditing
+    && list.length === 1
+    && isDirectEditableSourceTextEntity(primary)
+    && primaryLayer?.locked !== true;
+  const allowDirectInsertTextEditing = readOnlyBlocksFurtherEditing
+    && list.length === 1
+    && isDirectEditableInsertTextProxyEntity(primary)
+    && primaryLayer?.locked !== true;
+  const allowInsertTextPositionEditing = allowDirectInsertTextEditing
+    && supportsInsertTextPositionEditing(primary);
+
+  return {
+    readOnly: {
+      text: buildPropertyPanelReadOnlyNote(list, primary, actionContext),
+      blocksFurtherEditing: readOnlyBlocksFurtherEditing,
+      allowDirectSourceTextEditing,
+      allowDirectInsertTextEditing,
+      allowInsertTextPositionEditing,
+    },
+    releasedInsert: {
+      text: buildPropertyPanelReleasedArchiveNote(primary?.releasedInsertArchive ?? primary?.released_insert_archive),
+    },
+    locked: {
+      text: buildPropertyPanelLockedLayerNote(list, primary, getLayer),
+      blocksFurtherEditing: lockedBlocksFurtherEditing,
+    },
+  };
+}

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -167,43 +167,8 @@ export {
   buildPropertyPanelLockedLayerNote,
 } from './property_panel_note_helpers.js';
 
-export function buildPropertyPanelNotePlan(entities, primary, options = {}) {
-  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
-  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
-  const actionContext = options.actionContext || null;
-  const primaryLayer = primary ? resolveLayer(getLayer, primary.layerId) : null;
-  const readOnlyCount = list.filter((entity) => isReadOnlySelectionEntity(entity)).length;
-  const lockedCount = list.filter((entity) => resolveLayer(getLayer, entity?.layerId)?.locked === true).length;
-  const readOnlyBlocksFurtherEditing = readOnlyCount > 0 && readOnlyCount === list.length;
-  const lockedBlocksFurtherEditing = lockedCount > 0 && lockedCount === list.length;
-  const allowDirectSourceTextEditing = readOnlyBlocksFurtherEditing
-    && list.length === 1
-    && isDirectEditableSourceTextEntity(primary)
-    && primaryLayer?.locked !== true;
-  const allowDirectInsertTextEditing = readOnlyBlocksFurtherEditing
-    && list.length === 1
-    && isDirectEditableInsertTextProxyEntity(primary)
-    && primaryLayer?.locked !== true;
-  const allowInsertTextPositionEditing = allowDirectInsertTextEditing
-    && supportsInsertTextPositionEditing(primary);
-
-  return {
-    readOnly: {
-      text: buildPropertyPanelReadOnlyNote(list, primary, actionContext),
-      blocksFurtherEditing: readOnlyBlocksFurtherEditing,
-      allowDirectSourceTextEditing,
-      allowDirectInsertTextEditing,
-      allowInsertTextPositionEditing,
-    },
-    releasedInsert: {
-      text: buildPropertyPanelReleasedArchiveNote(primary?.releasedInsertArchive ?? primary?.released_insert_archive),
-    },
-    locked: {
-      text: buildPropertyPanelLockedLayerNote(list, primary, getLayer),
-      blocksFurtherEditing: lockedBlocksFurtherEditing,
-    },
-  };
-}
+import { buildPropertyPanelNotePlan } from './property_panel_note_plan.js';
+export { buildPropertyPanelNotePlan } from './property_panel_note_plan.js';
 
 import { buildSelectionBadges } from './selection_badges.js';
 export { buildSelectionBadges } from './selection_badges.js';


### PR DESCRIPTION
## Summary
- extract `buildPropertyPanelNotePlan(...)` into a dedicated `property_panel_note_plan.js` helper
- keep `selection_presenter.js` re-exporting the helper so the public contract stays stable
- add focused coverage for note-plan gating and note text passthrough behavior

## Verification
- node --check on the touched source/test files
- focused tests: `8/8`
- `tools/web_viewer/tests/property_panel_render_state.test.js`: `2/2`
- `tools/web_viewer/tests/editor_commands.test.js`: `297/297`
- `git diff --check`

## Scope
- no behavior changes to note wording, note plan shape, or direct-edit gating semantics
- no Step346 work mixed into this PR
