### PR TITLE
refactor: clean selection presenter facade

### DIFF
--- a/docs/STEP346_SELECTION_PRESENTER_CLEANUP_DESIGN.md
+++ b/docs/STEP346_SELECTION_PRESENTER_CLEANUP_DESIGN.md
@@ -1,0 +1,107 @@
+# Step346 Selection Presenter Cleanup Design
+
+## Goal
+
+Clean up `tools/web_viewer/ui/selection_presenter.js` after the Step339-Step345
+extractions by removing private helpers and imports that are no longer used by the
+facade, while keeping behavior unchanged.
+
+## Why This Seam
+
+After Step345, `selection_presenter.js` is already a thin facade for:
+
+- selection meta helpers
+- overview helpers
+- released archive helpers
+- selection contract/detail/property metadata/action-context helpers
+- property-panel note helpers and note-plan helper
+- selection badges
+
+What remains beyond the facade surface is:
+
+- `buildSelectionPresentation(...)`
+- a small number of local helpers that it still needs
+- several private helpers left behind by earlier extractions that are no longer
+  used by the file
+
+This makes Step346 the safest next seam:
+
+- it shrinks `selection_presenter.js` further without introducing new modules
+- it does not broaden scope into `buildSelectionPresentation(...)`
+- it reduces maintenance noise before any later presentation-level extraction
+
+## Required Scope
+
+Remove only the private helpers and now-unused imports that are no longer needed by
+`selection_presenter.js`.
+
+This cleanup may include helpers such as:
+
+- `normalizeText(...)`
+- `pushFact(...)`
+- `insertFactsAfterFirstKey(...)`
+- `formatCompactNumber(...)`
+- `formatPoint(...)`
+- `formatPeerContext(...)`
+- `formatPeerTarget(...)`
+- `formatSourceGroup(...)`
+- `formatAttributeModes(...)`
+
+if and only if they are truly unused by the post-Step345 facade.
+
+## Explicit Non-Goals
+
+Do not change:
+
+- `buildSelectionPresentation(...)`
+- `supportsInsertTextPositionEditing(...)`
+- any existing public re-export
+- `selection_badges.js`
+- `selection_overview.js`
+- `selection_detail_facts.js`
+- `selection_contract.js`
+- `property_metadata_facts.js`
+- `selection_action_context.js`
+- `property_panel_note_helpers.js`
+- `property_panel_note_plan.js`
+
+Do not change:
+
+- summary text
+- status text
+- badge order or content
+- detail fact ordering or semantics
+- property panel behavior
+
+## Dependency Rules
+
+Step346 is a cleanup-only seam. It must not introduce any new module and must not
+change dependency direction.
+
+In particular:
+
+- no new import from `selection_presenter.js` is allowed anywhere else
+- no new helper extraction is required
+- no new cycle is allowed
+
+## Testing Expectations
+
+There may be no new test file for this step if the change is strictly dead-helper
+removal.
+
+At minimum, keep the existing presentation coverage green:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+If the cleanup touches any direct presentation seam, also run the focused test file
+that already exercises the presenter contract.
+
+## Done Criteria
+
+Step346 is done when:
+
+1. `selection_presenter.js` no longer contains dead private helpers from earlier seams
+2. related dead imports are removed
+3. public exports remain stable
+4. existing tests pass unchanged
+5. `git diff --check` stays clean

--- a/docs/STEP346_SELECTION_PRESENTER_CLEANUP_VERIFICATION.md
+++ b/docs/STEP346_SELECTION_PRESENTER_CLEANUP_VERIFICATION.md
@@ -1,0 +1,40 @@
+# Step346 Selection Presenter Cleanup Verification
+
+## Required Checks
+
+Run `node --check` on:
+
+- `tools/web_viewer/ui/selection_presenter.js`
+
+Run focused tests:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+If the cleanup touches any presenter-focused test seam, also run that focused test
+file.
+
+Run formatting guard:
+
+- `git diff --check`
+
+## Suggested Commands
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+
+git diff --check
+```
+
+## Expected Reporting
+
+Report:
+
+- changed files
+- confirmation of which dead helpers/imports were removed
+- `editor_commands.test.js` result
+- `git diff --check` result
+
+Browser smoke is not required for this cleanup-only seam unless the implementation
+unexpectedly changes render behavior.

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -1,35 +1,8 @@
-import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
 import {
-  classifyInsertSelectionScope,
-  computeSourceGroupBounds,
-  computeInsertGroupBounds,
   isDirectEditableInsertTextProxyEntity,
-  isDirectEditableSourceTextEntity,
-  isInsertGroupEntity,
-  isInsertTextProxyEntity,
-  isSourceGroupEntity,
-  listEditableInsertTextMembers,
-  listInsertGroupTextMembers,
-  resolveSourceTextGuide,
-  resolveReleasedInsertArchive,
-  summarizeReleasedInsertGroupMembers,
-  summarizeInsertGroupMembers,
-  summarizeInsertPeerInstances,
-  summarizeReleasedInsertPeerInstances,
-  summarizeSourceGroupMembers,
 } from '../insert_group.js';
-import { formatSpaceLabel } from '../space_layout.js';
-import {
-  describeReadOnlySelectionEntity,
-  describeSelectionOrigin,
-  formatSelectionLayer,
-  formatSelectionLayerColor,
-  formatSelectionLayerFlags,
-  formatSelectionLayerState,
-  isReadOnlySelectionEntity,
-  listSelectionLayerFlags,
-} from './selection_meta_helpers.js';
 import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
+
 export { formatSpaceLabel } from '../space_layout.js';
 export { resolveReleasedInsertArchive } from '../insert_group.js';
 export {
@@ -44,70 +17,10 @@ export {
 } from './selection_meta_helpers.js';
 export { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
-function normalizeText(value) {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
 function resolveLayer(getLayer, layerId) {
   if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
   const layer = getLayer(Math.trunc(layerId));
   return layer && typeof layer === 'object' ? layer : null;
-}
-
-function pushFact(facts, key, label, value, extra = {}) {
-  if (value === null || value === undefined || value === '') return;
-  facts.push({
-    key,
-    label,
-    value: String(value),
-    ...extra,
-  });
-}
-
-function insertFactsAfterFirstKey(facts, keys, extraFacts) {
-  if (!Array.isArray(facts) || !Array.isArray(extraFacts) || extraFacts.length === 0) return facts;
-  const anchors = Array.isArray(keys) ? keys : [keys];
-  const index = anchors.reduce((found, key) => {
-    if (found >= 0) return found;
-    return facts.findIndex((fact) => fact?.key === key);
-  }, -1);
-  if (index < 0) {
-    facts.push(...extraFacts);
-    return facts;
-  }
-  facts.splice(index + 1, 0, ...extraFacts);
-  return facts;
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = normalizeText(peer.layout);
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = normalizeText(entity?.sourceType);
-  const proxyKind = normalizeText(entity?.proxyKind);
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 export function supportsInsertTextPositionEditing(entity) {
@@ -116,58 +29,27 @@ export function supportsInsertTextPositionEditing(entity) {
     && entity.attributeLockPosition !== true;
 }
 
-import {
-  formatReleasedInsertArchiveOrigin,
-  formatReleasedInsertArchiveModes,
-  summarizeReleasedInsertArchiveSelection,
-} from './selection_released_archive_helpers.js';
 export {
   formatReleasedInsertArchiveOrigin,
   formatReleasedInsertArchiveModes,
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 
-function formatAttributeModes(entity) {
-  const hasAttributeMetadata = Number.isFinite(entity?.attributeFlags)
-    || typeof entity?.attributeInvisible === 'boolean'
-    || typeof entity?.attributeConstant === 'boolean'
-    || typeof entity?.attributeVerify === 'boolean'
-    || typeof entity?.attributePreset === 'boolean'
-    || typeof entity?.attributeLockPosition === 'boolean';
-  if (!hasAttributeMetadata) return '';
-  const modes = [];
-  if (entity?.attributeInvisible === true) modes.push('Invisible');
-  if (entity?.attributeConstant === true) modes.push('Constant');
-  if (entity?.attributeVerify === true) modes.push('Verify');
-  if (entity?.attributePreset === true) modes.push('Preset');
-  if (entity?.attributeLockPosition === true) modes.push('Lock Position');
-  return modes.length > 0 ? modes.join(' / ') : 'None';
-}
-
-import { buildSelectionContract } from './selection_contract.js';
 export { buildSelectionContract } from './selection_contract.js';
 
 import { buildSelectionDetailFacts, buildMultiSelectionDetailFacts } from './selection_detail_facts.js';
 export { buildSelectionDetailFacts } from './selection_detail_facts.js';
 
-import { buildPropertyMetadataFacts } from './property_metadata_facts.js';
 export { buildPropertyMetadataFacts } from './property_metadata_facts.js';
 
-import { buildSelectionActionContext } from './selection_action_context.js';
 export { buildSelectionActionContext } from './selection_action_context.js';
 
-import {
-  buildPropertyPanelReadOnlyNote,
-  buildPropertyPanelReleasedArchiveNote,
-  buildPropertyPanelLockedLayerNote,
-} from './property_panel_note_helpers.js';
 export {
   buildPropertyPanelReadOnlyNote,
   buildPropertyPanelReleasedArchiveNote,
   buildPropertyPanelLockedLayerNote,
 } from './property_panel_note_helpers.js';
 
-import { buildPropertyPanelNotePlan } from './property_panel_note_plan.js';
 export { buildPropertyPanelNotePlan } from './property_panel_note_plan.js';
 
 import { buildSelectionBadges } from './selection_badges.js';


### PR DESCRIPTION
## Summary
- remove dead private helpers left in `selection_presenter.js` after the Step339-Step345 extractions
- keep `buildSelectionPresentation(...)` behavior and all public exports unchanged
- reduce the presenter file to a thin facade plus the remaining presentation entrypoint

## Verification
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
