### PR TITLE
refactor: extract selection presentation helper

### DIFF
--- a/docs/STEP347_SELECTION_PRESENTATION_EXTRACTION_DESIGN.md
+++ b/docs/STEP347_SELECTION_PRESENTATION_EXTRACTION_DESIGN.md
@@ -1,0 +1,120 @@
+# Step347 Selection Presentation Extraction Design
+
+## Goal
+
+Extract `buildSelectionPresentation(...)` from
+`tools/web_viewer/ui/selection_presenter.js` into a dedicated helper module while
+keeping behavior unchanged.
+
+Suggested new module:
+
+- `tools/web_viewer/ui/selection_presentation.js`
+
+## Why This Seam
+
+After Step346, `selection_presenter.js` is already a thin facade. The only
+substantial remaining entrypoint logic is:
+
+- `buildSelectionPresentation(...)`
+
+That function now acts as a narrow composition layer over:
+
+- `formatSelectionSummary(...)`
+- `formatSelectionStatus(...)`
+- `buildSelectionBadges(...)`
+- `buildSelectionDetailFacts(...)`
+- `buildMultiSelectionDetailFacts(...)`
+
+This is the cleanest next seam because:
+
+- it completes the presenter thinning work without broadening scope
+- it leaves `supportsInsertTextPositionEditing(...)` untouched
+- it avoids changing downstream callers, since `selection_presenter.js` can keep
+  re-exporting the extracted function
+
+## Required Scope
+
+Move only:
+
+- `buildSelectionPresentation(...)`
+
+into the new helper module.
+
+`selection_presenter.js` must continue to re-export it so the public contract stays
+stable.
+
+## Allowed Private Helper Movement
+
+If needed, the new helper may also own only the minimal private support it uses,
+such as:
+
+- presentation-only primary resolution
+- presentation-only `getLayer` / `primaryLayer` resolution
+
+If `resolveLayer(...)` is only needed by the extracted function after the move, it
+should move with it or become private to the new helper.
+
+## Explicit Non-Goals
+
+Do not change:
+
+- `supportsInsertTextPositionEditing(...)`
+- any existing re-export besides rewiring `buildSelectionPresentation(...)`
+- `selection_badges.js`
+- `selection_overview.js`
+- `selection_detail_facts.js`
+- `selection_contract.js`
+- `property_metadata_facts.js`
+- `selection_action_context.js`
+- `property_panel_note_helpers.js`
+- `property_panel_note_plan.js`
+
+Do not change:
+
+- summary text
+- status text
+- badge order or badge content
+- detail fact ordering or semantics
+- `primary` selection fallback behavior
+- `primaryLayer` resolution behavior
+- `mode` / `entityCount` semantics
+
+## Dependency Rules
+
+The new module must not import `selection_presenter.js`.
+
+Preferred dependency direction:
+
+- `selection_presentation.js` imports from:
+  - `selection_overview.js`
+  - `selection_badges.js`
+  - `selection_detail_facts.js`
+  - any tiny private helper it needs for layer resolution
+- `selection_presenter.js` imports/re-exports from `selection_presentation.js`
+
+No new cycle back into `selection_presenter.js` is allowed.
+
+## Testing Expectations
+
+Add a focused test file for the new helper module, covering at least:
+
+- empty selection returns `mode=empty`, `entityCount=0`, and `primary=null`
+- single selection uses the requested primary and resolves `primaryLayer`
+- single selection falls back to the first entity when `primaryId` misses
+- multi selection returns `mode=multiple`
+- single selection uses `buildSelectionDetailFacts(...)`
+- multi selection uses `buildMultiSelectionDetailFacts(...)`
+
+Keep existing integration assertions unchanged, especially:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+## Done Criteria
+
+Step347 is done when:
+
+1. `buildSelectionPresentation(...)` lives in its own helper module
+2. `selection_presenter.js` only imports/re-exports it
+3. no new dependency cycle exists
+4. focused tests pass
+5. existing integration tests continue to pass unchanged

--- a/docs/STEP347_SELECTION_PRESENTATION_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP347_SELECTION_PRESENTATION_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,46 @@
+# Step347 Selection Presentation Extraction Verification
+
+## Required Checks
+
+Run `node --check` on:
+
+- `tools/web_viewer/ui/selection_presentation.js`
+- `tools/web_viewer/ui/selection_presenter.js`
+- the new focused helper test file
+
+Run focused tests:
+
+- the new selection presentation helper test file
+
+Run integration guard:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+Run formatting guard:
+
+- `git diff --check`
+
+## Suggested Commands
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presentation.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_presentation.test.js
+
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_presentation.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+
+git diff --check
+```
+
+## Expected Reporting
+
+Report:
+
+- changed files
+- focused helper test result
+- `editor_commands.test.js` result
+- `git diff --check` result
+
+Browser smoke is not required for this seam unless the implementation unexpectedly
+changes render flow beyond the presentation helper itself.

--- a/tools/web_viewer/tests/selection_presentation.test.js
+++ b/tools/web_viewer/tests/selection_presentation.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSelectionPresentation } from '../ui/selection_presentation.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 1,
+    visible: true,
+    color: '#fff',
+    colorSource: 'BYLAYER',
+    space: 0,
+    layout: 'Model',
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'L1',
+    color: '#fff',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+function makeOptions(layers = []) {
+  const layerMap = new Map(layers.map((l) => [l.id, l]));
+  return { getLayer: (id) => layerMap.get(id) || null };
+}
+
+test('empty selection returns mode=empty, entityCount=0, primary=null', () => {
+  const result = buildSelectionPresentation([], null);
+  assert.equal(result.mode, 'empty');
+  assert.equal(result.entityCount, 0);
+  assert.equal(result.primary, null);
+  assert.equal(result.primaryLayer, null);
+});
+
+test('single selection uses the requested primary and resolves primaryLayer', () => {
+  const layer = makeLayer({ id: 5, name: 'Walls' });
+  const entity = makeEntity({ id: 10, layerId: 5 });
+  const result = buildSelectionPresentation([entity], 10, makeOptions([layer]));
+  assert.equal(result.mode, 'single');
+  assert.equal(result.entityCount, 1);
+  assert.equal(result.primary, entity);
+  assert.equal(result.primaryLayer, layer);
+});
+
+test('single selection falls back to first entity when primaryId misses', () => {
+  const entity = makeEntity({ id: 10 });
+  const result = buildSelectionPresentation([entity], 999);
+  assert.equal(result.mode, 'single');
+  assert.equal(result.primary, entity);
+});
+
+test('multi selection returns mode=multiple', () => {
+  const a = makeEntity({ id: 1, type: 'line' });
+  const b = makeEntity({ id: 2, type: 'circle' });
+  const result = buildSelectionPresentation([a, b], 1);
+  assert.equal(result.mode, 'multiple');
+  assert.equal(result.entityCount, 2);
+});
+
+test('single selection uses buildSelectionDetailFacts', () => {
+  const entity = makeEntity({ id: 1 });
+  const result = buildSelectionPresentation([entity], 1);
+  assert.ok(Array.isArray(result.detailFacts));
+  // Single-entity detail facts are produced by buildSelectionDetailFacts
+  assert.equal(result.mode, 'single');
+});
+
+test('multi selection uses buildMultiSelectionDetailFacts', () => {
+  const a = makeEntity({ id: 1 });
+  const b = makeEntity({ id: 2 });
+  const result = buildSelectionPresentation([a, b], 1);
+  assert.ok(Array.isArray(result.detailFacts));
+  assert.equal(result.mode, 'multiple');
+});

--- a/tools/web_viewer/ui/selection_presentation.js
+++ b/tools/web_viewer/ui/selection_presentation.js
@@ -1,0 +1,26 @@
+import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
+import { buildSelectionBadges } from './selection_badges.js';
+import { buildSelectionDetailFacts, buildMultiSelectionDetailFacts } from './selection_detail_facts.js';
+
+function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}
+
+export function buildSelectionPresentation(entities, primaryId, options = {}) {
+  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
+  const primary = list.find((entity) => entity && entity.id === primaryId) || list[0] || null;
+  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
+  const primaryLayer = primary ? resolveLayer(getLayer, primary.layerId) : null;
+  return {
+    mode: list.length === 0 ? 'empty' : (list.length === 1 ? 'single' : 'multiple'),
+    entityCount: list.length,
+    summaryText: formatSelectionSummary(list),
+    statusText: formatSelectionStatus(list, primaryId),
+    primary,
+    primaryLayer,
+    badges: buildSelectionBadges(list, primaryId, options),
+    detailFacts: list.length === 1 ? buildSelectionDetailFacts(primary, options) : buildMultiSelectionDetailFacts(list, options),
+  };
+}

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -1,7 +1,6 @@
 import {
   isDirectEditableInsertTextProxyEntity,
 } from '../insert_group.js';
-import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
 export { formatSpaceLabel } from '../space_layout.js';
 export { resolveReleasedInsertArchive } from '../insert_group.js';
@@ -17,12 +16,6 @@ export {
 } from './selection_meta_helpers.js';
 export { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
-
 export function supportsInsertTextPositionEditing(entity) {
   return isDirectEditableInsertTextProxyEntity(entity)
     && typeof entity?.attributeLockPosition === 'boolean'
@@ -37,7 +30,6 @@ export {
 
 export { buildSelectionContract } from './selection_contract.js';
 
-import { buildSelectionDetailFacts, buildMultiSelectionDetailFacts } from './selection_detail_facts.js';
 export { buildSelectionDetailFacts } from './selection_detail_facts.js';
 
 export { buildPropertyMetadataFacts } from './property_metadata_facts.js';
@@ -52,22 +44,6 @@ export {
 
 export { buildPropertyPanelNotePlan } from './property_panel_note_plan.js';
 
-import { buildSelectionBadges } from './selection_badges.js';
 export { buildSelectionBadges } from './selection_badges.js';
 
-export function buildSelectionPresentation(entities, primaryId, options = {}) {
-  const list = Array.isArray(entities) ? entities.filter(Boolean) : [];
-  const primary = list.find((entity) => entity && entity.id === primaryId) || list[0] || null;
-  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
-  const primaryLayer = primary ? resolveLayer(getLayer, primary.layerId) : null;
-  return {
-    mode: list.length === 0 ? 'empty' : (list.length === 1 ? 'single' : 'multiple'),
-    entityCount: list.length,
-    summaryText: formatSelectionSummary(list),
-    statusText: formatSelectionStatus(list, primaryId),
-    primary,
-    primaryLayer,
-    badges: buildSelectionBadges(list, primaryId, options),
-    detailFacts: list.length === 1 ? buildSelectionDetailFacts(primary, options) : buildMultiSelectionDetailFacts(list, options),
-  };
-}
+export { buildSelectionPresentation } from './selection_presentation.js';


### PR DESCRIPTION
## Summary
- extract `buildSelectionPresentation(...)` into `tools/web_viewer/ui/selection_presentation.js`
- keep `selection_presenter.js` as the facade that re-exports the presentation helper
- add focused coverage for the extracted presentation entrypoint

## Verification
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presentation.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_presentation.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_presentation.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
