### PR TITLE
refactor: share selection editability helpers

### DIFF
--- a/docs/STEP348_SELECTION_EDITABILITY_HELPERS_DESIGN.md
+++ b/docs/STEP348_SELECTION_EDITABILITY_HELPERS_DESIGN.md
@@ -1,0 +1,113 @@
+# Step348 Selection Editability Helpers Design
+
+## Goal
+
+Extract the duplicated insert-text editability and layer lookup helpers into a
+shared leaf module, while keeping behavior unchanged.
+
+Suggested new module:
+
+- `tools/web_viewer/ui/selection_editability_helpers.js`
+
+## Why This Seam
+
+After Step347:
+
+- `selection_presenter.js` still owns `supportsInsertTextPositionEditing(...)`
+- `property_panel_note_helpers.js` contains its own copy of:
+  - `supportsInsertTextPositionEditing(...)`
+  - `resolveLayer(...)`
+- `property_panel_note_plan.js` contains its own copy of:
+  - `supportsInsertTextPositionEditing(...)`
+  - `resolveLayer(...)`
+
+This is the cleanest next seam because:
+
+- it removes repeated logic without broadening behavior scope
+- it lets `selection_presenter.js` become a pure facade
+- it reduces future drift risk between note helpers, note plan, and presenter exports
+
+## Required Scope
+
+Move only the duplicated helper behavior into the shared module:
+
+- `supportsInsertTextPositionEditing(entity)`
+- a layer lookup helper equivalent to current `resolveLayer(getLayer, layerId)`
+
+Then update:
+
+- `selection_presenter.js`
+- `property_panel_note_helpers.js`
+- `property_panel_note_plan.js`
+
+to import from the shared helper.
+
+`selection_presenter.js` must continue to export
+`supportsInsertTextPositionEditing(...)` so the public contract remains stable.
+
+## Explicit Non-Goals
+
+Do not change:
+
+- `buildSelectionPresentation(...)`
+- `buildPropertyPanelReadOnlyNote(...)`
+- `buildPropertyPanelReleasedArchiveNote(...)`
+- `buildPropertyPanelLockedLayerNote(...)`
+- `buildPropertyPanelNotePlan(...)`
+- any note wording
+- any locked-layer semantics
+- any direct source-text / insert-text gating semantics
+
+Do not change:
+
+- `selection_badges.js`
+- `selection_detail_facts.js`
+- `selection_contract.js`
+- `property_metadata_facts.js`
+- `selection_action_context.js`
+
+## Dependency Rules
+
+The new module must be a leaf helper.
+
+Allowed direction:
+
+- `selection_editability_helpers.js` imports from:
+  - `insert_group.js`
+
+- `selection_presenter.js`, `property_panel_note_helpers.js`,
+  `property_panel_note_plan.js` import from it
+
+The new helper must not import:
+
+- `selection_presenter.js`
+- `property_panel_note_helpers.js`
+- `property_panel_note_plan.js`
+
+No new cycle is allowed.
+
+## Testing Expectations
+
+Add a focused helper test file covering at least:
+
+- `supportsInsertTextPositionEditing(...)` returns true for unlocked editable insert text proxies
+- it returns false for lock-positioned insert text proxies
+- it returns false for non-insert-text entities
+- the layer lookup helper returns null for invalid ids / missing getter
+- the layer lookup helper returns a layer object for valid getter/id pairs
+
+Keep these integration guards unchanged:
+
+- `tools/web_viewer/tests/property_panel_note_plan.test.js`
+- `tools/web_viewer/tests/property_panel_note_helpers.test.js`
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+## Done Criteria
+
+Step348 is done when:
+
+1. duplicated helper logic lives in `selection_editability_helpers.js`
+2. `selection_presenter.js` becomes a pure facade with re-exported `supportsInsertTextPositionEditing(...)`
+3. note helpers and note plan import the shared helper instead of owning duplicates
+4. no new dependency cycle exists
+5. focused and integration tests pass unchanged

--- a/docs/STEP348_SELECTION_EDITABILITY_HELPERS_VERIFICATION.md
+++ b/docs/STEP348_SELECTION_EDITABILITY_HELPERS_VERIFICATION.md
@@ -1,0 +1,56 @@
+# Step348 Selection Editability Helpers Verification
+
+## Required Checks
+
+Run `node --check` on:
+
+- `tools/web_viewer/ui/selection_editability_helpers.js`
+- `tools/web_viewer/ui/selection_presenter.js`
+- `tools/web_viewer/ui/property_panel_note_helpers.js`
+- `tools/web_viewer/ui/property_panel_note_plan.js`
+- the new focused helper test file
+
+Run focused tests:
+
+- the new selection editability helper test file
+- `tools/web_viewer/tests/property_panel_note_helpers.test.js`
+- `tools/web_viewer/tests/property_panel_note_plan.test.js`
+
+Run integration guard:
+
+- `tools/web_viewer/tests/editor_commands.test.js`
+
+Run formatting guard:
+
+- `git diff --check`
+
+## Suggested Commands
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_editability_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_plan.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_editability_helpers.test.js
+
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_editability_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_plan.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+
+git diff --check
+```
+
+## Expected Reporting
+
+Report:
+
+- changed files
+- focused helper test result
+- `property_panel_note_helpers.test.js` result
+- `property_panel_note_plan.test.js` result
+- `editor_commands.test.js` result
+- `git diff --check` result
+
+Browser smoke is not required for this seam unless the implementation unexpectedly
+touches broader render behavior.

--- a/tools/web_viewer/tests/selection_editability_helpers.test.js
+++ b/tools/web_viewer/tests/selection_editability_helpers.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveLayer,
+  supportsInsertTextPositionEditing,
+} from '../ui/selection_editability_helpers.js';
+
+test('supportsInsertTextPositionEditing returns true for unlocked editable insert text proxies', () => {
+  assert.equal(
+    supportsInsertTextPositionEditing({
+      type: 'text',
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      attributeConstant: false,
+      attributeLockPosition: false,
+    }),
+    true,
+  );
+});
+
+test('supportsInsertTextPositionEditing returns false for lock-positioned insert text proxies', () => {
+  assert.equal(
+    supportsInsertTextPositionEditing({
+      type: 'text',
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      attributeConstant: false,
+      attributeLockPosition: true,
+    }),
+    false,
+  );
+});
+
+test('supportsInsertTextPositionEditing returns false for non-insert-text entities', () => {
+  assert.equal(
+    supportsInsertTextPositionEditing({
+      type: 'line',
+      attributeLockPosition: false,
+    }),
+    false,
+  );
+});
+
+test('resolveLayer returns null when getter is missing or layerId is invalid', () => {
+  assert.equal(resolveLayer(null, 1), null);
+  assert.equal(resolveLayer(() => ({ id: 1 }), Number.NaN), null);
+  assert.equal(resolveLayer(() => ({ id: 1 }), undefined), null);
+});
+
+test('resolveLayer returns null when getter result is not an object', () => {
+  assert.equal(resolveLayer(() => 'L1', 1), null);
+  assert.equal(resolveLayer(() => null, 1), null);
+});
+
+test('resolveLayer returns layer object for valid getter and layerId', () => {
+  const layer = { id: 3, name: 'Notes', locked: true };
+  assert.deepEqual(resolveLayer((id) => (id === 3 ? layer : null), 3), layer);
+  assert.deepEqual(resolveLayer((id) => (id === 3 ? layer : null), 3.9), layer);
+});

--- a/tools/web_viewer/ui/property_panel_note_helpers.js
+++ b/tools/web_viewer/ui/property_panel_note_helpers.js
@@ -12,18 +12,10 @@ import {
 import {
   formatReleasedInsertArchiveOrigin,
 } from './selection_released_archive_helpers.js';
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
-
-function supportsInsertTextPositionEditing(entity) {
-  return isDirectEditableInsertTextProxyEntity(entity)
-    && typeof entity?.attributeLockPosition === 'boolean'
-    && entity.attributeLockPosition !== true;
-}
+import {
+  resolveLayer,
+  supportsInsertTextPositionEditing,
+} from './selection_editability_helpers.js';
 
 export function buildPropertyPanelReadOnlyNote(entities, primary, actionContext = null) {
   const list = Array.isArray(entities) ? entities.filter(Boolean) : [];

--- a/tools/web_viewer/ui/property_panel_note_plan.js
+++ b/tools/web_viewer/ui/property_panel_note_plan.js
@@ -8,18 +8,10 @@ import {
   buildPropertyPanelReleasedArchiveNote,
   buildPropertyPanelLockedLayerNote,
 } from './property_panel_note_helpers.js';
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
-
-function supportsInsertTextPositionEditing(entity) {
-  return isDirectEditableInsertTextProxyEntity(entity)
-    && typeof entity?.attributeLockPosition === 'boolean'
-    && entity.attributeLockPosition !== true;
-}
+import {
+  resolveLayer,
+  supportsInsertTextPositionEditing,
+} from './selection_editability_helpers.js';
 
 export function buildPropertyPanelNotePlan(entities, primary, options = {}) {
   const list = Array.isArray(entities) ? entities.filter(Boolean) : [];

--- a/tools/web_viewer/ui/selection_editability_helpers.js
+++ b/tools/web_viewer/ui/selection_editability_helpers.js
@@ -1,0 +1,15 @@
+import {
+  isDirectEditableInsertTextProxyEntity,
+} from '../insert_group.js';
+
+export function supportsInsertTextPositionEditing(entity) {
+  return isDirectEditableInsertTextProxyEntity(entity)
+    && typeof entity?.attributeLockPosition === 'boolean'
+    && entity.attributeLockPosition !== true;
+}
+
+export function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}

--- a/tools/web_viewer/ui/selection_presenter.js
+++ b/tools/web_viewer/ui/selection_presenter.js
@@ -1,7 +1,3 @@
-import {
-  isDirectEditableInsertTextProxyEntity,
-} from '../insert_group.js';
-
 export { formatSpaceLabel } from '../space_layout.js';
 export { resolveReleasedInsertArchive } from '../insert_group.js';
 export {
@@ -16,11 +12,7 @@ export {
 } from './selection_meta_helpers.js';
 export { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 
-export function supportsInsertTextPositionEditing(entity) {
-  return isDirectEditableInsertTextProxyEntity(entity)
-    && typeof entity?.attributeLockPosition === 'boolean'
-    && entity.attributeLockPosition !== true;
-}
+export { supportsInsertTextPositionEditing } from './selection_editability_helpers.js';
 
 export {
   formatReleasedInsertArchiveOrigin,


### PR DESCRIPTION
## Summary
- add `selection_editability_helpers.js` as the shared leaf for insert-text editability and layer lookup
- re-export `supportsInsertTextPositionEditing(...)` from `selection_presenter.js`
- deduplicate the helper logic used by property-panel note helpers and note-plan helpers
- add focused coverage for the shared helper

## Verification
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_editability_helpers.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presenter.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_helpers.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_note_plan.js`
- `/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_editability_helpers.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_editability_helpers.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_helpers.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_note_plan.test.js`
- `/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
