### PR TITLE
refactor: share selection display helpers

### DIFF
--- a/docs/STEP349_SELECTION_DISPLAY_HELPERS_DESIGN.md
+++ b/docs/STEP349_SELECTION_DISPLAY_HELPERS_DESIGN.md
@@ -1,0 +1,72 @@
+# Step349 Selection Display Helpers Design
+
+## Goal
+
+Extract the duplicated selection display/formatting helpers that currently live in both:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+The objective is to create one leaf/shared helper module so both files consume the same formatting logic without changing any user-visible behavior.
+
+## Scope
+
+This step is intentionally narrow. It only targets the duplicated formatting/display helpers used to build human-readable strings for selection metadata and property-panel info rows.
+
+Expected shared helpers include:
+
+- compact numeric formatting
+- point formatting
+- peer context formatting
+- peer target formatting
+- source-group formatting
+
+The new shared module should remain a leaf module and must not import `selection_presenter.js`.
+
+## Non-Goals
+
+Do not change:
+
+- `buildSelectionDetailFacts(...)`
+- `buildMultiSelectionDetailFacts(...)`
+- `buildEntityMetadataInfoRows(...)`
+- `buildReleasedInsertArchiveSelectionInfoRows(...)`
+- `buildSourceGroupInfoRows(...)`
+- `buildInsertGroupInfoRows(...)`
+- property-panel rendering behavior
+- fact ordering
+- row ordering
+- labels, keys, or text semantics
+
+Do not change the output object shapes in either `selection_detail_facts.js` or `property_panel_info_rows.js`.
+
+## Intended Structure
+
+Create a dedicated helper module under:
+
+- `tools/web_viewer/ui/selection_display_helpers.js`
+
+It should export only the shared string-formatting helpers. Keep any row-shape-specific helpers such as `pushFact(...)` or `pushInfo(...)` local to their respective files.
+
+Then update:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+to import from the new shared helper module instead of defining duplicate local helpers.
+
+## Constraints
+
+- Preserve exact behavior for existing tests and editor integration assertions.
+- Avoid introducing any new dependency cycle.
+- Keep the new helper module as a leaf module with minimal dependencies.
+- Prefer the existing behavior already shared by both call sites rather than inventing a new abstraction.
+
+## Acceptance
+
+Step349 is complete when:
+
+1. duplicated display helper logic is removed from both target files
+2. both files use the new shared helper module
+3. all focused tests and `editor_commands.test.js` still pass
+4. `git diff --check` is clean

--- a/docs/STEP349_SELECTION_DISPLAY_HELPERS_VERIFICATION.md
+++ b/docs/STEP349_SELECTION_DISPLAY_HELPERS_VERIFICATION.md
@@ -1,0 +1,44 @@
+# Step349 Selection Display Helpers Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_display_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_info_rows.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_display_helpers.test.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_display_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_info_rows.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused tests pass without changing public behavior
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- This step does not require browser smoke runs unless a broader behavior change is introduced.
+- If a new helper test file is added, keep it focused on the shared formatting logic rather than row/fact assembly.

--- a/tools/web_viewer/tests/selection_display_helpers.test.js
+++ b/tools/web_viewer/tests/selection_display_helpers.test.js
@@ -2,38 +2,55 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  normalizeText,
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from '../ui/selection_display_helpers.js';
 
-test('formatCompactNumber trims trailing zeroes and normalizes negative zero', () => {
-  assert.equal(formatCompactNumber(12.3400), '12.34');
-  assert.equal(formatCompactNumber(-0.000000001), '0');
-  assert.equal(formatCompactNumber(Number.NaN), '');
+test('normalizeText trims strings', () => {
+  assert.equal(normalizeText('  hello  '), 'hello');
+  assert.equal(normalizeText(''), '');
+  assert.equal(normalizeText(null), '');
+  assert.equal(normalizeText(undefined), '');
+  assert.equal(normalizeText(42), '');
 });
 
-test('formatPoint formats finite points and rejects invalid values', () => {
-  assert.equal(formatPoint({ x: 10, y: 2.5 }), '10, 2.5');
-  assert.equal(formatPoint({ x: 10, y: Number.NaN }), '');
+test('formatCompactNumber formats finite numbers compactly', () => {
+  assert.equal(formatCompactNumber(0), '0');
+  assert.equal(formatCompactNumber(1), '1');
+  assert.equal(formatCompactNumber(1.5), '1.5');
+  assert.equal(formatCompactNumber(1.123), '1.123');
+  assert.equal(formatCompactNumber(1.100), '1.1');
+  assert.equal(formatCompactNumber(-0), '0');
+  assert.equal(formatCompactNumber(1e-10), '0');
+  assert.equal(formatCompactNumber(NaN), '');
+  assert.equal(formatCompactNumber(Infinity), '');
+  assert.equal(formatCompactNumber(undefined), '');
+});
+
+test('formatPoint formats {x, y} objects', () => {
+  assert.equal(formatPoint({ x: 5, y: 10 }), '5, 10');
+  assert.equal(formatPoint({ x: -20, y: 14.5 }), '-20, 14.5');
+  assert.equal(formatPoint({ x: 0, y: 0 }), '0, 0');
   assert.equal(formatPoint(null), '');
+  assert.equal(formatPoint(undefined), '');
+  assert.equal(formatPoint({ x: NaN, y: 0 }), '');
+  assert.equal(formatPoint({}), '');
 });
 
-test('formatPeerContext includes space label and trimmed layout when present', () => {
-  assert.equal(formatPeerContext({ space: 0, layout: ' Model ' }), 'Model / Model');
-  assert.equal(formatPeerContext({ space: 1, layout: ' Layout-A ' }), 'Paper / Layout-A');
+test('formatPeerContext formats peer space and layout', () => {
+  assert.equal(formatPeerContext({ space: 0, layout: 'Model' }), 'Model / Model');
+  assert.equal(formatPeerContext({ space: 1, layout: 'Layout-A' }), 'Paper / Layout-A');
   assert.equal(formatPeerContext({ space: 1, layout: '' }), 'Paper');
+  assert.equal(formatPeerContext({ space: 1 }), 'Paper');
+  assert.equal(formatPeerContext(null), '');
+  assert.equal(formatPeerContext(undefined), '');
 });
 
-test('formatPeerTarget prefixes the 1-based index', () => {
+test('formatPeerTarget formats indexed peer target', () => {
   assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-A' }, 0), '1: Paper / Layout-A');
+  assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-B' }, 2), '3: Paper / Layout-B');
   assert.equal(formatPeerTarget(null, 0), '');
-});
-
-test('formatSourceGroup normalizes source type and proxy kind casing', () => {
-  assert.equal(formatSourceGroup({ sourceType: ' dimension ', proxyKind: 'TEXT ' }), 'DIMENSION / text');
-  assert.equal(formatSourceGroup({ sourceType: 'insert' }), 'INSERT');
-  assert.equal(formatSourceGroup({ proxyKind: 'Fragment' }), 'fragment');
 });

--- a/tools/web_viewer/tests/selection_display_helpers.test.js
+++ b/tools/web_viewer/tests/selection_display_helpers.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from '../ui/selection_display_helpers.js';
+
+test('formatCompactNumber trims trailing zeroes and normalizes negative zero', () => {
+  assert.equal(formatCompactNumber(12.3400), '12.34');
+  assert.equal(formatCompactNumber(-0.000000001), '0');
+  assert.equal(formatCompactNumber(Number.NaN), '');
+});
+
+test('formatPoint formats finite points and rejects invalid values', () => {
+  assert.equal(formatPoint({ x: 10, y: 2.5 }), '10, 2.5');
+  assert.equal(formatPoint({ x: 10, y: Number.NaN }), '');
+  assert.equal(formatPoint(null), '');
+});
+
+test('formatPeerContext includes space label and trimmed layout when present', () => {
+  assert.equal(formatPeerContext({ space: 0, layout: ' Model ' }), 'Model / Model');
+  assert.equal(formatPeerContext({ space: 1, layout: ' Layout-A ' }), 'Paper / Layout-A');
+  assert.equal(formatPeerContext({ space: 1, layout: '' }), 'Paper');
+});
+
+test('formatPeerTarget prefixes the 1-based index', () => {
+  assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-A' }, 0), '1: Paper / Layout-A');
+  assert.equal(formatPeerTarget(null, 0), '');
+});
+
+test('formatSourceGroup normalizes source type and proxy kind casing', () => {
+  assert.equal(formatSourceGroup({ sourceType: ' dimension ', proxyKind: 'TEXT ' }), 'DIMENSION / text');
+  assert.equal(formatSourceGroup({ sourceType: 'insert' }), 'INSERT');
+  assert.equal(formatSourceGroup({ proxyKind: 'Fragment' }), 'fragment');
+});

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -11,10 +11,9 @@ import {
 } from '../insert_group.js';
 import {
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from './selection_display_helpers.js';
 
 function pushInfo(rows, label, value, key = '') {
@@ -24,6 +23,12 @@ function pushInfo(rows, label, value, key = '') {
     label,
     value: String(value),
   });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = typeof entity?.sourceType === 'string' ? entity.sourceType.trim().toUpperCase() : '';
+  const proxyKind = typeof entity?.proxyKind === 'string' ? entity.proxyKind.trim().toLowerCase() : '';
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function resolveEntities(listEntities) {

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -2,7 +2,6 @@ import {
   buildPropertyMetadataFacts,
   formatReleasedInsertArchiveModes,
   formatReleasedInsertArchiveOrigin,
-  formatSpaceLabel,
 } from './selection_presenter.js';
 import {
   computeInsertGroupBounds,
@@ -10,6 +9,13 @@ import {
   isInsertGroupEntity,
   isSourceGroupEntity,
 } from '../insert_group.js';
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from './selection_display_helpers.js';
 
 function pushInfo(rows, label, value, key = '') {
   if (value === null || value === undefined || value === '') return;
@@ -18,37 +24,6 @@ function pushInfo(rows, label, value, key = '') {
     label,
     value: String(value),
   });
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = typeof peer.layout === 'string' ? peer.layout.trim() : '';
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = typeof entity?.sourceType === 'string' ? entity.sourceType.trim().toUpperCase() : '';
-  const proxyKind = typeof entity?.proxyKind === 'string' ? entity.proxyKind.trim().toLowerCase() : '';
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function resolveEntities(listEntities) {

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -25,16 +25,12 @@ import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 import {
+  normalizeText,
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from './selection_display_helpers.js';
-
-function normalizeText(value) {
-  return typeof value === 'string' ? value.trim() : '';
-}
 
 function resolveLayer(getLayer, layerId) {
   if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
@@ -50,6 +46,12 @@ function pushFact(facts, key, label, value, extra = {}) {
     value: String(value),
     ...extra,
   });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = normalizeText(entity?.sourceType);
+  const proxyKind = normalizeText(entity?.proxyKind);
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function formatAttributeModes(entity) {

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -24,6 +24,13 @@ import {
   formatReleasedInsertArchiveModes,
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from './selection_display_helpers.js';
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -43,37 +50,6 @@ function pushFact(facts, key, label, value, extra = {}) {
     value: String(value),
     ...extra,
   });
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = normalizeText(peer.layout);
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = normalizeText(entity?.sourceType);
-  const proxyKind = normalizeText(entity?.proxyKind);
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function formatAttributeModes(entity) {

--- a/tools/web_viewer/ui/selection_display_helpers.js
+++ b/tools/web_viewer/ui/selection_display_helpers.js
@@ -1,0 +1,30 @@
+import { formatSpaceLabel } from '../space_layout.js';
+
+export function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function formatCompactNumber(value) {
+  if (!Number.isFinite(value)) return '';
+  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
+  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
+  return text === '-0' ? '0' : text;
+}
+
+export function formatPoint(value) {
+  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
+  return \`\${formatCompactNumber(value.x)}, \${formatCompactNumber(value.y)}\`;
+}
+
+export function formatPeerContext(peer) {
+  if (!peer) return '';
+  const space = formatSpaceLabel(peer.space);
+  const layout = normalizeText(peer.layout);
+  return layout ? \`\${space} / \${layout}\` : space;
+}
+
+export function formatPeerTarget(peer, index) {
+  const context = formatPeerContext(peer);
+  if (!context) return '';
+  return \`\${index + 1}: \${context}\`;
+}

--- a/tools/web_viewer/ui/selection_display_helpers.js
+++ b/tools/web_viewer/ui/selection_display_helpers.js
@@ -13,18 +13,18 @@ export function formatCompactNumber(value) {
 
 export function formatPoint(value) {
   if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return \`\${formatCompactNumber(value.x)}, \${formatCompactNumber(value.y)}\`;
+  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
 }
 
 export function formatPeerContext(peer) {
   if (!peer) return '';
   const space = formatSpaceLabel(peer.space);
   const layout = normalizeText(peer.layout);
-  return layout ? \`\${space} / \${layout}\` : space;
+  return layout ? `${space} / ${layout}` : space;
 }
 
 export function formatPeerTarget(peer, index) {
   const context = formatPeerContext(peer);
   if (!context) return '';
-  return \`\${index + 1}: \${context}\`;
+  return `${index + 1}: ${context}`;
 }


### PR DESCRIPTION
## Summary
- extract duplicated selection display/formatting helpers into a shared leaf module
- update selection detail facts and property-panel info rows to consume the shared helper
- add focused helper coverage for compact number, point, peer, and source-group formatting

## Testing
- /opt/homebrew/bin/node --check tools/web_viewer/ui/selection_display_helpers.js
- /opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
- /opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_info_rows.js
- /opt/homebrew/bin/node --check tools/web_viewer/tests/selection_display_helpers.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/selection_display_helpers.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_info_rows.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check
