### PR TITLE
refactor: adopt selection display helpers

### DIFF
--- a/docs/STEP349_SELECTION_DISPLAY_HELPERS_DESIGN.md
+++ b/docs/STEP349_SELECTION_DISPLAY_HELPERS_DESIGN.md
@@ -1,0 +1,72 @@
+# Step349 Selection Display Helpers Design
+
+## Goal
+
+Extract the duplicated selection display/formatting helpers that currently live in both:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+The objective is to create one leaf/shared helper module so both files consume the same formatting logic without changing any user-visible behavior.
+
+## Scope
+
+This step is intentionally narrow. It only targets the duplicated formatting/display helpers used to build human-readable strings for selection metadata and property-panel info rows.
+
+Expected shared helpers include:
+
+- compact numeric formatting
+- point formatting
+- peer context formatting
+- peer target formatting
+- source-group formatting
+
+The new shared module should remain a leaf module and must not import `selection_presenter.js`.
+
+## Non-Goals
+
+Do not change:
+
+- `buildSelectionDetailFacts(...)`
+- `buildMultiSelectionDetailFacts(...)`
+- `buildEntityMetadataInfoRows(...)`
+- `buildReleasedInsertArchiveSelectionInfoRows(...)`
+- `buildSourceGroupInfoRows(...)`
+- `buildInsertGroupInfoRows(...)`
+- property-panel rendering behavior
+- fact ordering
+- row ordering
+- labels, keys, or text semantics
+
+Do not change the output object shapes in either `selection_detail_facts.js` or `property_panel_info_rows.js`.
+
+## Intended Structure
+
+Create a dedicated helper module under:
+
+- `tools/web_viewer/ui/selection_display_helpers.js`
+
+It should export only the shared string-formatting helpers. Keep any row-shape-specific helpers such as `pushFact(...)` or `pushInfo(...)` local to their respective files.
+
+Then update:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+to import from the new shared helper module instead of defining duplicate local helpers.
+
+## Constraints
+
+- Preserve exact behavior for existing tests and editor integration assertions.
+- Avoid introducing any new dependency cycle.
+- Keep the new helper module as a leaf module with minimal dependencies.
+- Prefer the existing behavior already shared by both call sites rather than inventing a new abstraction.
+
+## Acceptance
+
+Step349 is complete when:
+
+1. duplicated display helper logic is removed from both target files
+2. both files use the new shared helper module
+3. all focused tests and `editor_commands.test.js` still pass
+4. `git diff --check` is clean

--- a/docs/STEP349_SELECTION_DISPLAY_HELPERS_VERIFICATION.md
+++ b/docs/STEP349_SELECTION_DISPLAY_HELPERS_VERIFICATION.md
@@ -1,0 +1,44 @@
+# Step349 Selection Display Helpers Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_display_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_info_rows.js
+/opt/homebrew/bin/node --check tools/web_viewer/tests/selection_display_helpers.test.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_display_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_info_rows.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused tests pass without changing public behavior
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- This step does not require browser smoke runs unless a broader behavior change is introduced.
+- If a new helper test file is added, keep it focused on the shared formatting logic rather than row/fact assembly.

--- a/docs/STEP350_SELECTION_DISPLAY_HELPER_ADOPTION_DESIGN.md
+++ b/docs/STEP350_SELECTION_DISPLAY_HELPER_ADOPTION_DESIGN.md
@@ -1,0 +1,72 @@
+# Step350 Selection Display Helper Adoption Design
+
+## Goal
+
+Adopt the shared selection display helper module introduced in Step349 from two remaining call sites:
+
+- `tools/web_viewer/ui/property_metadata_facts.js`
+- `tools/web_viewer/ui/selection_action_context.js`
+
+This step should reduce the remaining duplicated display-formatting logic without changing any public behavior.
+
+## Scope
+
+Only replace duplicated helper logic that is already represented in:
+
+- `tools/web_viewer/ui/selection_display_helpers.js`
+
+Expected adoption targets:
+
+- compact numeric formatting
+- point formatting
+- peer context formatting
+- peer target formatting
+
+## Non-Goals
+
+Do not change:
+
+- `buildPropertyMetadataFacts(...)`
+- `buildSelectionActionContext(...)`
+- fact ordering
+- action-context object shape
+- peer target text
+- selection matching semantics
+- property panel behavior
+- `selection_display_helpers.js` public behavior
+
+Do not expand this step into a broader presenter or property-panel refactor.
+
+## Intended Structure
+
+Update:
+
+- `tools/web_viewer/ui/property_metadata_facts.js`
+- `tools/web_viewer/ui/selection_action_context.js`
+
+to import shared helpers from `tools/web_viewer/ui/selection_display_helpers.js` instead of defining duplicate local helpers.
+
+Keep call-site-specific logic local. For example:
+
+- `pushFact(...)`
+- `insertFactsAfterFirstKey(...)`
+- `idsEqual(...)`
+- `hasSourceTextPlacement(...)`
+- `buildPeerTargets(...)`
+
+should stay in their current files.
+
+## Constraints
+
+- No new dependency cycles.
+- No text drift in generated facts or peer target labels.
+- Keep the change as a narrow adoption step on top of Step349.
+
+## Acceptance
+
+Step350 is complete when:
+
+1. the duplicated helper logic is removed from both target files
+2. both files import the shared display helper module
+3. focused tests and `editor_commands.test.js` still pass
+4. `git diff --check` is clean

--- a/docs/STEP350_SELECTION_DISPLAY_HELPER_ADOPTION_VERIFICATION.md
+++ b/docs/STEP350_SELECTION_DISPLAY_HELPER_ADOPTION_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step350 Selection Display Helper Adoption Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_display_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_metadata_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_action_context.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_metadata_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_action_context.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_display_helpers.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused tests pass with unchanged public behavior
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- No browser smoke runs are required for this step unless broader behavior is introduced.
+- Keep this step stacked cleanly on top of Step349 only.

--- a/tools/web_viewer/tests/selection_display_helpers.test.js
+++ b/tools/web_viewer/tests/selection_display_helpers.test.js
@@ -2,38 +2,55 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  normalizeText,
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from '../ui/selection_display_helpers.js';
 
-test('formatCompactNumber trims trailing zeroes and normalizes negative zero', () => {
-  assert.equal(formatCompactNumber(12.3400), '12.34');
-  assert.equal(formatCompactNumber(-0.000000001), '0');
-  assert.equal(formatCompactNumber(Number.NaN), '');
+test('normalizeText trims strings', () => {
+  assert.equal(normalizeText('  hello  '), 'hello');
+  assert.equal(normalizeText(''), '');
+  assert.equal(normalizeText(null), '');
+  assert.equal(normalizeText(undefined), '');
+  assert.equal(normalizeText(42), '');
 });
 
-test('formatPoint formats finite points and rejects invalid values', () => {
-  assert.equal(formatPoint({ x: 10, y: 2.5 }), '10, 2.5');
-  assert.equal(formatPoint({ x: 10, y: Number.NaN }), '');
+test('formatCompactNumber formats finite numbers compactly', () => {
+  assert.equal(formatCompactNumber(0), '0');
+  assert.equal(formatCompactNumber(1), '1');
+  assert.equal(formatCompactNumber(1.5), '1.5');
+  assert.equal(formatCompactNumber(1.123), '1.123');
+  assert.equal(formatCompactNumber(1.100), '1.1');
+  assert.equal(formatCompactNumber(-0), '0');
+  assert.equal(formatCompactNumber(1e-10), '0');
+  assert.equal(formatCompactNumber(NaN), '');
+  assert.equal(formatCompactNumber(Infinity), '');
+  assert.equal(formatCompactNumber(undefined), '');
+});
+
+test('formatPoint formats {x, y} objects', () => {
+  assert.equal(formatPoint({ x: 5, y: 10 }), '5, 10');
+  assert.equal(formatPoint({ x: -20, y: 14.5 }), '-20, 14.5');
+  assert.equal(formatPoint({ x: 0, y: 0 }), '0, 0');
   assert.equal(formatPoint(null), '');
+  assert.equal(formatPoint(undefined), '');
+  assert.equal(formatPoint({ x: NaN, y: 0 }), '');
+  assert.equal(formatPoint({}), '');
 });
 
-test('formatPeerContext includes space label and trimmed layout when present', () => {
-  assert.equal(formatPeerContext({ space: 0, layout: ' Model ' }), 'Model / Model');
-  assert.equal(formatPeerContext({ space: 1, layout: ' Layout-A ' }), 'Paper / Layout-A');
+test('formatPeerContext formats peer space and layout', () => {
+  assert.equal(formatPeerContext({ space: 0, layout: 'Model' }), 'Model / Model');
+  assert.equal(formatPeerContext({ space: 1, layout: 'Layout-A' }), 'Paper / Layout-A');
   assert.equal(formatPeerContext({ space: 1, layout: '' }), 'Paper');
+  assert.equal(formatPeerContext({ space: 1 }), 'Paper');
+  assert.equal(formatPeerContext(null), '');
+  assert.equal(formatPeerContext(undefined), '');
 });
 
-test('formatPeerTarget prefixes the 1-based index', () => {
+test('formatPeerTarget formats indexed peer target', () => {
   assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-A' }, 0), '1: Paper / Layout-A');
+  assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-B' }, 2), '3: Paper / Layout-B');
   assert.equal(formatPeerTarget(null, 0), '');
-});
-
-test('formatSourceGroup normalizes source type and proxy kind casing', () => {
-  assert.equal(formatSourceGroup({ sourceType: ' dimension ', proxyKind: 'TEXT ' }), 'DIMENSION / text');
-  assert.equal(formatSourceGroup({ sourceType: 'insert' }), 'INSERT');
-  assert.equal(formatSourceGroup({ proxyKind: 'Fragment' }), 'fragment');
 });

--- a/tools/web_viewer/tests/selection_display_helpers.test.js
+++ b/tools/web_viewer/tests/selection_display_helpers.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from '../ui/selection_display_helpers.js';
+
+test('formatCompactNumber trims trailing zeroes and normalizes negative zero', () => {
+  assert.equal(formatCompactNumber(12.3400), '12.34');
+  assert.equal(formatCompactNumber(-0.000000001), '0');
+  assert.equal(formatCompactNumber(Number.NaN), '');
+});
+
+test('formatPoint formats finite points and rejects invalid values', () => {
+  assert.equal(formatPoint({ x: 10, y: 2.5 }), '10, 2.5');
+  assert.equal(formatPoint({ x: 10, y: Number.NaN }), '');
+  assert.equal(formatPoint(null), '');
+});
+
+test('formatPeerContext includes space label and trimmed layout when present', () => {
+  assert.equal(formatPeerContext({ space: 0, layout: ' Model ' }), 'Model / Model');
+  assert.equal(formatPeerContext({ space: 1, layout: ' Layout-A ' }), 'Paper / Layout-A');
+  assert.equal(formatPeerContext({ space: 1, layout: '' }), 'Paper');
+});
+
+test('formatPeerTarget prefixes the 1-based index', () => {
+  assert.equal(formatPeerTarget({ space: 1, layout: 'Layout-A' }, 0), '1: Paper / Layout-A');
+  assert.equal(formatPeerTarget(null, 0), '');
+});
+
+test('formatSourceGroup normalizes source type and proxy kind casing', () => {
+  assert.equal(formatSourceGroup({ sourceType: ' dimension ', proxyKind: 'TEXT ' }), 'DIMENSION / text');
+  assert.equal(formatSourceGroup({ sourceType: 'insert' }), 'INSERT');
+  assert.equal(formatSourceGroup({ proxyKind: 'Fragment' }), 'fragment');
+});

--- a/tools/web_viewer/ui/property_metadata_facts.js
+++ b/tools/web_viewer/ui/property_metadata_facts.js
@@ -1,8 +1,5 @@
 import { buildSelectionDetailFacts } from './selection_detail_facts.js';
-
-function normalizeText(value) {
-  return typeof value === 'string' ? value.trim() : '';
-}
+import { normalizeText, formatCompactNumber, formatPoint } from './selection_display_helpers.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;
@@ -27,18 +24,6 @@ function insertFactsAfterFirstKey(facts, keys, extraFacts) {
   }
   facts.splice(index + 1, 0, ...extraFacts);
   return facts;
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
 }
 
 export function buildPropertyMetadataFacts(entity, options = {}) {

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -11,10 +11,9 @@ import {
 } from '../insert_group.js';
 import {
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from './selection_display_helpers.js';
 
 function pushInfo(rows, label, value, key = '') {
@@ -24,6 +23,12 @@ function pushInfo(rows, label, value, key = '') {
     label,
     value: String(value),
   });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = typeof entity?.sourceType === 'string' ? entity.sourceType.trim().toUpperCase() : '';
+  const proxyKind = typeof entity?.proxyKind === 'string' ? entity.proxyKind.trim().toLowerCase() : '';
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function resolveEntities(listEntities) {

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -2,7 +2,6 @@ import {
   buildPropertyMetadataFacts,
   formatReleasedInsertArchiveModes,
   formatReleasedInsertArchiveOrigin,
-  formatSpaceLabel,
 } from './selection_presenter.js';
 import {
   computeInsertGroupBounds,
@@ -10,6 +9,13 @@ import {
   isInsertGroupEntity,
   isSourceGroupEntity,
 } from '../insert_group.js';
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from './selection_display_helpers.js';
 
 function pushInfo(rows, label, value, key = '') {
   if (value === null || value === undefined || value === '') return;
@@ -18,37 +24,6 @@ function pushInfo(rows, label, value, key = '') {
     label,
     value: String(value),
   });
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = typeof peer.layout === 'string' ? peer.layout.trim() : '';
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = typeof entity?.sourceType === 'string' ? entity.sourceType.trim().toUpperCase() : '';
-  const proxyKind = typeof entity?.proxyKind === 'string' ? entity.proxyKind.trim().toLowerCase() : '';
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function resolveEntities(listEntities) {

--- a/tools/web_viewer/ui/selection_action_context.js
+++ b/tools/web_viewer/ui/selection_action_context.js
@@ -12,25 +12,8 @@ import {
   summarizeReleasedInsertPeerInstances,
   summarizeSourceGroupMembers,
 } from '../insert_group.js';
-import { formatSpaceLabel } from '../space_layout.js';
 import { isReadOnlySelectionEntity } from './selection_meta_helpers.js';
-
-function normalizeText(value) {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = normalizeText(peer.layout);
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
+import { formatPeerTarget } from './selection_display_helpers.js';
 
 function idsEqual(left, right) {
   if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -25,16 +25,12 @@ import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 import {
+  normalizeText,
   formatCompactNumber,
+  formatPoint,
   formatPeerContext,
   formatPeerTarget,
-  formatPoint,
-  formatSourceGroup,
 } from './selection_display_helpers.js';
-
-function normalizeText(value) {
-  return typeof value === 'string' ? value.trim() : '';
-}
 
 function resolveLayer(getLayer, layerId) {
   if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
@@ -50,6 +46,12 @@ function pushFact(facts, key, label, value, extra = {}) {
     value: String(value),
     ...extra,
   });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = normalizeText(entity?.sourceType);
+  const proxyKind = normalizeText(entity?.proxyKind);
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function formatAttributeModes(entity) {

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -24,6 +24,13 @@ import {
   formatReleasedInsertArchiveModes,
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
+import {
+  formatCompactNumber,
+  formatPeerContext,
+  formatPeerTarget,
+  formatPoint,
+  formatSourceGroup,
+} from './selection_display_helpers.js';
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -43,37 +50,6 @@ function pushFact(facts, key, label, value, extra = {}) {
     value: String(value),
     ...extra,
   });
-}
-
-function formatCompactNumber(value) {
-  if (!Number.isFinite(value)) return '';
-  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
-  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
-  return text === '-0' ? '0' : text;
-}
-
-function formatPoint(value) {
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
-}
-
-function formatPeerContext(peer) {
-  if (!peer) return '';
-  const space = formatSpaceLabel(peer.space);
-  const layout = normalizeText(peer.layout);
-  return layout ? `${space} / ${layout}` : space;
-}
-
-function formatPeerTarget(peer, index) {
-  const context = formatPeerContext(peer);
-  if (!context) return '';
-  return `${index + 1}: ${context}`;
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = normalizeText(entity?.sourceType);
-  const proxyKind = normalizeText(entity?.proxyKind);
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
 }
 
 function formatAttributeModes(entity) {

--- a/tools/web_viewer/ui/selection_display_helpers.js
+++ b/tools/web_viewer/ui/selection_display_helpers.js
@@ -1,0 +1,30 @@
+import { formatSpaceLabel } from '../space_layout.js';
+
+export function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function formatCompactNumber(value) {
+  if (!Number.isFinite(value)) return '';
+  const rounded = Math.abs(value) < 1e-9 ? 0 : value;
+  const text = Number(rounded).toFixed(3).replace(/\.?0+$/, '');
+  return text === '-0' ? '0' : text;
+}
+
+export function formatPoint(value) {
+  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
+  return \`\${formatCompactNumber(value.x)}, \${formatCompactNumber(value.y)}\`;
+}
+
+export function formatPeerContext(peer) {
+  if (!peer) return '';
+  const space = formatSpaceLabel(peer.space);
+  const layout = normalizeText(peer.layout);
+  return layout ? \`\${space} / \${layout}\` : space;
+}
+
+export function formatPeerTarget(peer, index) {
+  const context = formatPeerContext(peer);
+  if (!context) return '';
+  return \`\${index + 1}: \${context}\`;
+}

--- a/tools/web_viewer/ui/selection_display_helpers.js
+++ b/tools/web_viewer/ui/selection_display_helpers.js
@@ -13,18 +13,18 @@ export function formatCompactNumber(value) {
 
 export function formatPoint(value) {
   if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) return '';
-  return \`\${formatCompactNumber(value.x)}, \${formatCompactNumber(value.y)}\`;
+  return `${formatCompactNumber(value.x)}, ${formatCompactNumber(value.y)}`;
 }
 
 export function formatPeerContext(peer) {
   if (!peer) return '';
   const space = formatSpaceLabel(peer.space);
   const layout = normalizeText(peer.layout);
-  return layout ? \`\${space} / \${layout}\` : space;
+  return layout ? `${space} / ${layout}` : space;
 }
 
 export function formatPeerTarget(peer, index) {
   const context = formatPeerContext(peer);
   if (!context) return '';
-  return \`\${index + 1}: \${context}\`;
+  return `${index + 1}: ${context}`;
 }


### PR DESCRIPTION
## Summary
- adopt the shared selection display helper from Step349 in property metadata facts
- adopt the shared selection display helper from Step349 in selection action context
- keep the step stacked narrowly on top of PR #312 without public behavior changes

## Testing
- /opt/homebrew/bin/node --check tools/web_viewer/ui/selection_display_helpers.js
- /opt/homebrew/bin/node --check tools/web_viewer/ui/property_metadata_facts.js
- /opt/homebrew/bin/node --check tools/web_viewer/ui/selection_action_context.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/property_metadata_facts.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/selection_action_context.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/selection_display_helpers.test.js
- /opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check
