### PR TITLE
refactor: share selection layer helper

### DIFF
--- a/docs/STEP351_SELECTION_LAYER_HELPER_DESIGN.md
+++ b/docs/STEP351_SELECTION_LAYER_HELPER_DESIGN.md
@@ -1,0 +1,71 @@
+# Step351 Selection Layer Helper Design
+
+## Goal
+
+Extract the duplicated `resolveLayer(getLayer, layerId)` helper logic that is currently repeated across multiple selection-related modules into a dedicated shared leaf helper.
+
+This step should reduce duplication without changing any public behavior.
+
+## Scope
+
+Adopt a shared layer helper in the following modules where the local `resolveLayer(...)` logic is identical:
+
+- `tools/web_viewer/ui/selection_meta_helpers.js`
+- `tools/web_viewer/ui/selection_contract.js`
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/selection_presentation.js`
+
+Compatibility requirement:
+
+- `tools/web_viewer/ui/selection_editability_helpers.js` must continue exporting `resolveLayer(...)`
+
+That means the new shared layer helper should become the canonical source, and `selection_editability_helpers.js` should re-export it.
+
+## Non-Goals
+
+Do not change:
+
+- `supportsInsertTextPositionEditing(...)`
+- any selection contract behavior
+- any selection detail fact behavior
+- any selection presentation behavior
+- any selection meta formatting behavior
+- note plan or property panel behavior
+- object shapes, labels, ordering, or text semantics
+
+Do not bundle unrelated helper cleanup into this step.
+
+## Intended Structure
+
+Create a dedicated leaf helper module:
+
+- `tools/web_viewer/ui/selection_layer_helpers.js`
+
+It should export:
+
+- `resolveLayer(getLayer, layerId)`
+
+Then update the target modules to import from that helper instead of defining a local duplicate.
+
+Also update:
+
+- `tools/web_viewer/ui/selection_editability_helpers.js`
+
+to re-export `resolveLayer(...)` from the new shared helper so existing imports keep working.
+
+## Constraints
+
+- No behavior changes.
+- No new dependency cycles.
+- Keep the new helper module leaf-level and minimal.
+- Preserve the existing public contract of `selection_editability_helpers.js`.
+
+## Acceptance
+
+Step351 is complete when:
+
+1. duplicated `resolveLayer(...)` implementations are removed from the target modules
+2. the new leaf helper is the canonical source
+3. `selection_editability_helpers.js` still exports `resolveLayer(...)`
+4. focused tests and `editor_commands.test.js` still pass
+5. `git diff --check` is clean

--- a/docs/STEP351_SELECTION_LAYER_HELPER_VERIFICATION.md
+++ b/docs/STEP351_SELECTION_LAYER_HELPER_VERIFICATION.md
@@ -1,0 +1,47 @@
+# Step351 Selection Layer Helper Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_layer_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_editability_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_meta_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_contract.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_presentation.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_editability_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_contract.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_presentation.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused tests pass with unchanged public behavior
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- No browser smoke runs are required for this step unless broader behavior is introduced.
+- Keep this step narrowly about layer helper deduplication only.

--- a/tools/web_viewer/ui/selection_contract.js
+++ b/tools/web_viewer/ui/selection_contract.js
@@ -14,14 +14,10 @@ import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 
+import { resolveLayer } from './selection_layer_helpers.js';
+
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
-}
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
 }
 
 function formatSelectionColor(entity, getLayer = null) {

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -31,12 +31,7 @@ import {
   formatPeerContext,
   formatPeerTarget,
 } from './selection_display_helpers.js';
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
+import { resolveLayer } from './selection_layer_helpers.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;

--- a/tools/web_viewer/ui/selection_editability_helpers.js
+++ b/tools/web_viewer/ui/selection_editability_helpers.js
@@ -1,6 +1,7 @@
 import {
   isDirectEditableInsertTextProxyEntity,
 } from '../insert_group.js';
+import { resolveLayer } from './selection_layer_helpers.js';
 
 export function supportsInsertTextPositionEditing(entity) {
   return isDirectEditableInsertTextProxyEntity(entity)
@@ -8,8 +9,4 @@ export function supportsInsertTextPositionEditing(entity) {
     && entity.attributeLockPosition !== true;
 }
 
-export function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
+export { resolveLayer };

--- a/tools/web_viewer/ui/selection_layer_helpers.js
+++ b/tools/web_viewer/ui/selection_layer_helpers.js
@@ -1,0 +1,5 @@
+export function resolveLayer(getLayer, layerId) {
+  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
+  const layer = getLayer(Math.trunc(layerId));
+  return layer && typeof layer === 'object' ? layer : null;
+}

--- a/tools/web_viewer/ui/selection_meta_helpers.js
+++ b/tools/web_viewer/ui/selection_meta_helpers.js
@@ -1,11 +1,7 @@
+import { resolveLayer } from './selection_layer_helpers.js';
+
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
-}
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
 }
 
 export function isReadOnlySelectionEntity(entity) {

--- a/tools/web_viewer/ui/selection_presentation.js
+++ b/tools/web_viewer/ui/selection_presentation.js
@@ -1,12 +1,7 @@
 import { formatSelectionSummary, formatSelectionStatus } from './selection_overview.js';
 import { buildSelectionBadges } from './selection_badges.js';
 import { buildSelectionDetailFacts, buildMultiSelectionDetailFacts } from './selection_detail_facts.js';
-
-function resolveLayer(getLayer, layerId) {
-  if (typeof getLayer !== 'function' || !Number.isFinite(layerId)) return null;
-  const layer = getLayer(Math.trunc(layerId));
-  return layer && typeof layer === 'object' ? layer : null;
-}
+import { resolveLayer } from './selection_layer_helpers.js';
 
 export function buildSelectionPresentation(entities, primaryId, options = {}) {
   const list = Array.isArray(entities) ? entities.filter(Boolean) : [];


### PR DESCRIPTION
## Summary
- add `selection_layer_helpers.js` as the canonical source for `resolveLayer(getLayer, layerId)`
- replace duplicated local `resolveLayer(...)` implementations across selection helpers
- keep `selection_editability_helpers.js` exporting `resolveLayer(...)` for compatibility

## Verification
- `node --check` on 6 touched source files
- `node --test tools/web_viewer/tests/selection_editability_helpers.test.js`
- `node --test tools/web_viewer/tests/selection_contract.test.js`
- `node --test tools/web_viewer/tests/selection_detail_facts.test.js`
- `node --test tools/web_viewer/tests/selection_presentation.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`

## Scope
- no behavior changes
- no new dependency cycles
- no note-plan or property-panel behavior changes