### PR TITLE
refactor: share selection attribute mode formatter

### DIFF
--- a/docs/STEP352_SELECTION_ATTRIBUTE_MODES_DESIGN.md
+++ b/docs/STEP352_SELECTION_ATTRIBUTE_MODES_DESIGN.md
@@ -1,0 +1,72 @@
+# Step352 Selection Attribute Modes Design
+
+## Goal
+
+Extract the duplicated attribute-mode formatting logic that is currently split between:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/selection_released_archive_helpers.js`
+
+This step should make one shared leaf helper the canonical source while preserving all existing text, ordering, and public behavior.
+
+## Scope
+
+Create a dedicated shared helper module for attribute-mode formatting.
+
+Likely target:
+
+- `tools/web_viewer/ui/selection_attribute_mode_helpers.js`
+
+Canonical logic to share:
+
+- detect whether attribute metadata exists
+- format the ordered mode string
+- preserve the `attributeFlags: 0 => "None"` behavior
+
+Adopt that helper in:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/selection_released_archive_helpers.js`
+
+Compatibility requirement:
+
+- `formatReleasedInsertArchiveModes(...)` must remain exported from `selection_released_archive_helpers.js`
+- it may become a wrapper around the shared helper, but its public behavior must stay unchanged
+
+## Non-Goals
+
+Do not change:
+
+- `buildSelectionDetailFacts(...)`
+- `buildMultiSelectionDetailFacts(...)`
+- `summarizeReleasedInsertArchiveSelection(...)`
+- `buildPropertyMetadataFacts(...)`
+- `buildSelectionPresentation(...)`
+- `property_panel_info_rows.js`
+- any row ordering, fact keys, labels, note text, or UI behavior
+
+Do not bundle unrelated display-helper cleanup into this step.
+
+## Constraints
+
+- No behavior changes.
+- No new dependency cycles.
+- Keep the new helper leaf-level and generic.
+- Preserve current public exports from `selection_released_archive_helpers.js`.
+- Preserve mode ordering exactly:
+  - `Invisible`
+  - `Constant`
+  - `Verify`
+  - `Preset`
+  - `Lock Position`
+
+## Acceptance
+
+Step352 is complete when:
+
+1. the duplicated attribute-mode formatter exists in one canonical helper
+2. `selection_detail_facts.js` and `selection_released_archive_helpers.js` both use it
+3. `formatReleasedInsertArchiveModes(...)` remains compatible
+4. focused helper/detail/archive tests still pass
+5. `editor_commands.test.js` still passes
+6. `git diff --check` is clean

--- a/docs/STEP352_SELECTION_ATTRIBUTE_MODES_VERIFICATION.md
+++ b/docs/STEP352_SELECTION_ATTRIBUTE_MODES_VERIFICATION.md
@@ -1,0 +1,44 @@
+# Step352 Selection Attribute Modes Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_attribute_mode_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_released_archive_helpers.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_attribute_mode_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_released_archive_helpers.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_info_rows.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused helper/archive/detail/property-row tests pass unchanged
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- No browser smoke runs are required for this step unless broader behavior is introduced.
+- Keep this step narrowly about shared attribute-mode formatting only.

--- a/tools/web_viewer/tests/selection_attribute_mode_helpers.test.js
+++ b/tools/web_viewer/tests/selection_attribute_mode_helpers.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatSelectionAttributeModes } from '../ui/selection_attribute_mode_helpers.js';
+
+test('formatSelectionAttributeModes returns empty for null', () => {
+  assert.equal(formatSelectionAttributeModes(null), '');
+});
+
+test('formatSelectionAttributeModes returns empty for undefined', () => {
+  assert.equal(formatSelectionAttributeModes(undefined), '');
+});
+
+test('formatSelectionAttributeModes returns empty for object without attribute metadata', () => {
+  assert.equal(formatSelectionAttributeModes({}), '');
+  assert.equal(formatSelectionAttributeModes({ type: 'line' }), '');
+});
+
+test('formatSelectionAttributeModes returns None for attributeFlags 0', () => {
+  assert.equal(formatSelectionAttributeModes({ attributeFlags: 0 }), 'None');
+});
+
+test('formatSelectionAttributeModes returns None when all boolean flags are false', () => {
+  assert.equal(
+    formatSelectionAttributeModes({
+      attributeInvisible: false,
+      attributeConstant: false,
+      attributeVerify: false,
+      attributePreset: false,
+      attributeLockPosition: false,
+    }),
+    'None',
+  );
+});
+
+test('formatSelectionAttributeModes returns single mode', () => {
+  assert.equal(formatSelectionAttributeModes({ attributeInvisible: true }), 'Invisible');
+  assert.equal(formatSelectionAttributeModes({ attributeConstant: true }), 'Constant');
+  assert.equal(formatSelectionAttributeModes({ attributeVerify: true }), 'Verify');
+  assert.equal(formatSelectionAttributeModes({ attributePreset: true }), 'Preset');
+  assert.equal(formatSelectionAttributeModes({ attributeLockPosition: true }), 'Lock Position');
+});
+
+test('formatSelectionAttributeModes returns multiple modes in correct order', () => {
+  assert.equal(
+    formatSelectionAttributeModes({ attributeInvisible: true, attributeConstant: true }),
+    'Invisible / Constant',
+  );
+  assert.equal(
+    formatSelectionAttributeModes({ attributePreset: true, attributeLockPosition: true }),
+    'Preset / Lock Position',
+  );
+  assert.equal(
+    formatSelectionAttributeModes({
+      attributeInvisible: true,
+      attributeConstant: true,
+      attributeVerify: true,
+      attributePreset: true,
+      attributeLockPosition: true,
+    }),
+    'Invisible / Constant / Verify / Preset / Lock Position',
+  );
+});
+
+test('formatSelectionAttributeModes preserves order regardless of input order', () => {
+  assert.equal(
+    formatSelectionAttributeModes({ attributeLockPosition: true, attributeInvisible: true }),
+    'Invisible / Lock Position',
+  );
+});

--- a/tools/web_viewer/ui/selection_attribute_mode_helpers.js
+++ b/tools/web_viewer/ui/selection_attribute_mode_helpers.js
@@ -1,0 +1,16 @@
+export function formatSelectionAttributeModes(entityOrArchive) {
+  const hasAttributeMetadata = Number.isFinite(entityOrArchive?.attributeFlags)
+    || typeof entityOrArchive?.attributeInvisible === 'boolean'
+    || typeof entityOrArchive?.attributeConstant === 'boolean'
+    || typeof entityOrArchive?.attributeVerify === 'boolean'
+    || typeof entityOrArchive?.attributePreset === 'boolean'
+    || typeof entityOrArchive?.attributeLockPosition === 'boolean';
+  if (!hasAttributeMetadata) return '';
+  const modes = [];
+  if (entityOrArchive?.attributeInvisible === true) modes.push('Invisible');
+  if (entityOrArchive?.attributeConstant === true) modes.push('Constant');
+  if (entityOrArchive?.attributeVerify === true) modes.push('Verify');
+  if (entityOrArchive?.attributePreset === true) modes.push('Preset');
+  if (entityOrArchive?.attributeLockPosition === true) modes.push('Lock Position');
+  return modes.length > 0 ? modes.join(' / ') : 'None';
+}

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -32,6 +32,7 @@ import {
   formatPeerTarget,
 } from './selection_display_helpers.js';
 import { resolveLayer } from './selection_layer_helpers.js';
+import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;
@@ -47,23 +48,6 @@ function formatSourceGroup(entity) {
   const sourceType = normalizeText(entity?.sourceType);
   const proxyKind = normalizeText(entity?.proxyKind);
   return [sourceType, proxyKind].filter(Boolean).join(' / ');
-}
-
-function formatAttributeModes(entity) {
-  const hasAttributeMetadata = Number.isFinite(entity?.attributeFlags)
-    || typeof entity?.attributeInvisible === 'boolean'
-    || typeof entity?.attributeConstant === 'boolean'
-    || typeof entity?.attributeVerify === 'boolean'
-    || typeof entity?.attributePreset === 'boolean'
-    || typeof entity?.attributeLockPosition === 'boolean';
-  if (!hasAttributeMetadata) return '';
-  const modes = [];
-  if (entity?.attributeInvisible === true) modes.push('Invisible');
-  if (entity?.attributeConstant === true) modes.push('Constant');
-  if (entity?.attributeVerify === true) modes.push('Verify');
-  if (entity?.attributePreset === true) modes.push('Preset');
-  if (entity?.attributeLockPosition === true) modes.push('Lock Position');
-  return modes.length > 0 ? modes.join(' / ') : 'None';
 }
 
 export function buildMultiSelectionDetailFacts(entities, options = {}) {
@@ -159,7 +143,7 @@ export function buildSelectionDetailFacts(entity, options = {}) {
   if (Number.isFinite(entity.attributeFlags)) {
     pushFact(facts, 'attribute-flags', 'Attribute Flags', String(Math.trunc(entity.attributeFlags)));
   }
-  pushFact(facts, 'attribute-modes', 'Attribute Modes', formatAttributeModes(entity));
+  pushFact(facts, 'attribute-modes', 'Attribute Modes', formatSelectionAttributeModes(entity));
   const releasedInsertArchive = resolveReleasedInsertArchive(entity);
   pushFact(facts, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(releasedInsertArchive));
   if (Number.isFinite(releasedInsertArchive?.groupId)) {

--- a/tools/web_viewer/ui/selection_released_archive_helpers.js
+++ b/tools/web_viewer/ui/selection_released_archive_helpers.js
@@ -3,6 +3,7 @@ import {
   summarizeReleasedInsertPeerInstances,
 } from '../insert_group.js';
 import { isReadOnlySelectionEntity } from './selection_meta_helpers.js';
+import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 
 function normalizeText(value) {
   return typeof value === 'string' ? value.trim() : '';
@@ -34,20 +35,7 @@ export function formatReleasedInsertArchiveOrigin(entityOrArchive) {
 
 export function formatReleasedInsertArchiveModes(entityOrArchive) {
   const archive = resolveReleasedInsertArchive(entityOrArchive) || entityOrArchive;
-  const hasAttributeMetadata = Number.isFinite(archive?.attributeFlags)
-    || typeof archive?.attributeInvisible === 'boolean'
-    || typeof archive?.attributeConstant === 'boolean'
-    || typeof archive?.attributeVerify === 'boolean'
-    || typeof archive?.attributePreset === 'boolean'
-    || typeof archive?.attributeLockPosition === 'boolean';
-  if (!hasAttributeMetadata) return '';
-  const modes = [];
-  if (archive?.attributeInvisible === true) modes.push('Invisible');
-  if (archive?.attributeConstant === true) modes.push('Constant');
-  if (archive?.attributeVerify === true) modes.push('Verify');
-  if (archive?.attributePreset === true) modes.push('Preset');
-  if (archive?.attributeLockPosition === true) modes.push('Lock Position');
-  return modes.length > 0 ? modes.join(' / ') : 'None';
+  return formatSelectionAttributeModes(archive);
 }
 
 export function summarizeReleasedInsertArchiveSelection(entities, options = {}) {


### PR DESCRIPTION
## Summary
- add `selection_attribute_mode_helpers.js` as the canonical attribute-mode formatter
- keep `formatReleasedInsertArchiveModes(...)` as a compatibility wrapper
- remove duplicated attribute-mode formatting logic from selection detail/archive helpers

## Verification
- `node --check tools/web_viewer/ui/selection_attribute_mode_helpers.js`
- `node --check tools/web_viewer/ui/selection_released_archive_helpers.js`
- `node --check tools/web_viewer/ui/selection_detail_facts.js`
- `node --test tools/web_viewer/tests/selection_attribute_mode_helpers.test.js`
- `node --test tools/web_viewer/tests/selection_released_archive_helpers.test.js`
- `node --test tools/web_viewer/tests/selection_detail_facts.test.js`
- `node --test tools/web_viewer/tests/property_panel_info_rows.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`

## Scope
- no behavior changes
- no row-order changes
- no new dependency cycles