### PR TITLE
refactor: share released archive selection rows

### DIFF
--- a/docs/STEP353_RELEASED_ARCHIVE_SELECTION_ROWS_DESIGN.md
+++ b/docs/STEP353_RELEASED_ARCHIVE_SELECTION_ROWS_DESIGN.md
@@ -1,0 +1,68 @@
+# Step353 Released Archive Selection Rows Design
+
+## Goal
+
+Extract the duplicated released-archive multi-selection row assembly that is currently repeated in:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+This step should make one shared leaf helper the canonical source while preserving all row keys, labels, order, and text behavior.
+
+## Scope
+
+Create a dedicated shared helper module for released-archive multi-selection rows.
+
+Likely target:
+
+- `tools/web_viewer/ui/released_insert_selection_rows.js`
+
+Canonical logic to share:
+
+- released archive summary rows
+- released attribute rows
+- released peer rows for multi-peer selections
+
+Adopt that helper in:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+Compatibility requirements:
+
+- `buildMultiSelectionDetailFacts(...)` must keep returning the same `key/label/value` rows
+- `buildReleasedInsertArchiveSelectionInfoRows(...)` must remain exported from `property_panel_info_rows.js`
+- wrappers may delegate to the new helper, but public behavior must stay unchanged
+
+## Non-Goals
+
+Do not change:
+
+- single-entity released archive facts in `selection_detail_facts.js`
+- `formatReleasedInsertArchiveOrigin(...)`
+- `formatReleasedInsertArchiveModes(...)`
+- `summarizeReleasedInsertArchiveSelection(...)`
+- property panel rendering flow
+- selection presentation orchestration
+- row object shapes, keys, labels, or ordering
+
+Do not bundle unrelated presenter cleanup into this step.
+
+## Constraints
+
+- No behavior changes.
+- No new dependency cycles.
+- Keep the new helper leaf-level and row-oriented.
+- Preserve the `commonModes || formatReleasedInsertArchiveModes(archive)` fallback semantics.
+- Preserve the `Archived / N` peer instance wording.
+
+## Acceptance
+
+Step353 is complete when:
+
+1. the duplicated released-archive multi-selection row assembly exists in one canonical helper
+2. `selection_detail_facts.js` and `property_panel_info_rows.js` both use it
+3. `buildReleasedInsertArchiveSelectionInfoRows(...)` remains compatible
+4. focused released-row/detail/property-row tests still pass
+5. `editor_commands.test.js` still passes
+6. `git diff --check` is clean

--- a/docs/STEP353_RELEASED_ARCHIVE_SELECTION_ROWS_VERIFICATION.md
+++ b/docs/STEP353_RELEASED_ARCHIVE_SELECTION_ROWS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step353 Released Archive Selection Rows Verification
+
+## Required Checks
+
+Run:
+
+```bash
+/opt/homebrew/bin/node --check tools/web_viewer/ui/released_insert_selection_rows.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/selection_detail_facts.js
+/opt/homebrew/bin/node --check tools/web_viewer/ui/property_panel_info_rows.js
+```
+
+Run focused tests:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/released_insert_selection_rows.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/selection_detail_facts.test.js
+/opt/homebrew/bin/node --test tools/web_viewer/tests/property_panel_info_rows.test.js
+```
+
+Run integration:
+
+```bash
+/opt/homebrew/bin/node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+Run diff hygiene:
+
+```bash
+git diff --check
+```
+
+## Expected Outcome
+
+- all `node --check` commands pass
+- focused released-row/detail/property-row tests pass unchanged
+- `editor_commands.test.js` passes unchanged
+- `git diff --check` exits cleanly
+
+## Notes
+
+- No browser smoke runs are required for this step unless broader behavior is introduced.
+- Keep this step narrowly about released-archive multi-selection rows only.

--- a/tools/web_viewer/tests/released_insert_selection_rows.test.js
+++ b/tools/web_viewer/tests/released_insert_selection_rows.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildReleasedInsertArchiveSelectionRows } from '../ui/released_insert_selection_rows.js';
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('buildReleasedInsertArchiveSelectionRows returns empty for missing archive', () => {
+  assert.deepEqual(buildReleasedInsertArchiveSelectionRows(null), []);
+  assert.deepEqual(buildReleasedInsertArchiveSelectionRows({}), []);
+});
+
+test('buildReleasedInsertArchiveSelectionRows preserves released archive rows', () => {
+  const rows = buildReleasedInsertArchiveSelectionRows({
+    archive: {
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      groupId: 2,
+      blockName: 'AttdefBlock',
+      textKind: 'attdef',
+      attributeTag: 'ATTDEF_TAG',
+      attributeDefault: 'ATTDEF_DEFAULT',
+      attributePrompt: 'ATTDEF_PROMPT',
+      attributeFlags: 12,
+      attributeVerify: true,
+      attributePreset: true,
+    },
+    entityCount: 2,
+    commonModes: 'Verify / Preset',
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'released-from': 'INSERT / text / proxy',
+    'released-group-id': '2',
+    'released-block-name': 'AttdefBlock',
+    'released-selection-members': '2',
+    'released-text-kind': 'attdef',
+    'released-attribute-tag': 'ATTDEF_TAG',
+    'released-attribute-default': 'ATTDEF_DEFAULT',
+    'released-attribute-prompt': 'ATTDEF_PROMPT',
+    'released-attribute-flags': '12',
+    'released-attribute-modes': 'Verify / Preset',
+  });
+});
+
+test('buildReleasedInsertArchiveSelectionRows preserves Archived / N peer wording', () => {
+  const rows = buildReleasedInsertArchiveSelectionRows({
+    archive: {
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      groupId: 2,
+      blockName: 'AttdefBlock',
+    },
+    entityCount: 2,
+    peerSummary: {
+      peerCount: 3,
+      currentIndex: -1,
+      peers: [
+        { space: 1, layout: 'Layout-A' },
+        { space: 1, layout: 'Layout-B' },
+        { space: 1, layout: 'Layout-C' },
+      ],
+    },
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'released-from': 'INSERT / text / proxy',
+    'released-group-id': '2',
+    'released-block-name': 'AttdefBlock',
+    'released-selection-members': '2',
+    'released-peer-instance': 'Archived / 3',
+    'released-peer-instances': '3',
+    'released-peer-layouts': 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C',
+    'released-peer-targets': '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C',
+  });
+});

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -1,7 +1,5 @@
 import {
   buildPropertyMetadataFacts,
-  formatReleasedInsertArchiveModes,
-  formatReleasedInsertArchiveOrigin,
 } from './selection_presenter.js';
 import {
   computeInsertGroupBounds,
@@ -15,6 +13,7 @@ import {
   formatPeerContext,
   formatPeerTarget,
 } from './selection_display_helpers.js';
+import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 
 function pushInfo(rows, label, value, key = '') {
   if (value === null || value === undefined || value === '') return;
@@ -123,48 +122,7 @@ export function buildEntityMetadataInfoRows(entity, { getLayer = null, listEntit
 }
 
 export function buildReleasedInsertArchiveSelectionInfoRows(selectionSummary) {
-  if (!selectionSummary?.archive) return [];
-  const rows = [];
-  const { archive, entityCount, peerSummary, commonModes } = selectionSummary;
-  pushInfo(rows, 'Released From', formatReleasedInsertArchiveOrigin(archive), 'released-from');
-  if (Number.isFinite(archive?.groupId)) {
-    pushInfo(rows, 'Released Group ID', String(Math.trunc(archive.groupId)), 'released-group-id');
-  }
-  pushInfo(rows, 'Released Block Name', archive?.blockName, 'released-block-name');
-  pushInfo(rows, 'Released Selection Members', String(entityCount), 'released-selection-members');
-  pushInfo(rows, 'Released Text Kind', archive?.textKind, 'released-text-kind');
-  pushInfo(rows, 'Released Attribute Tag', archive?.attributeTag, 'released-attribute-tag');
-  pushInfo(rows, 'Released Attribute Default', archive?.attributeDefault, 'released-attribute-default');
-  pushInfo(rows, 'Released Attribute Prompt', archive?.attributePrompt, 'released-attribute-prompt');
-  if (Number.isFinite(archive?.attributeFlags)) {
-    pushInfo(rows, 'Released Attribute Flags', String(Math.trunc(archive.attributeFlags)), 'released-attribute-flags');
-  }
-  pushInfo(
-    rows,
-    'Released Attribute Modes',
-    commonModes || formatReleasedInsertArchiveModes(archive),
-    'released-attribute-modes',
-  );
-  if (peerSummary?.peerCount > 1) {
-    const peerInstance = peerSummary.currentIndex >= 0
-      ? `${peerSummary.currentIndex + 1} / ${peerSummary.peerCount}`
-      : `Archived / ${peerSummary.peerCount}`;
-    pushInfo(rows, 'Released Peer Instance', peerInstance, 'released-peer-instance');
-    pushInfo(rows, 'Released Peer Instances', String(peerSummary.peerCount), 'released-peer-instances');
-    pushInfo(
-      rows,
-      'Released Peer Layouts',
-      peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | '),
-      'released-peer-layouts',
-    );
-    pushInfo(
-      rows,
-      'Released Peer Targets',
-      peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | '),
-      'released-peer-targets',
-    );
-  }
-  return rows;
+  return buildReleasedInsertArchiveSelectionRows(selectionSummary);
 }
 
 export function buildSourceGroupInfoRows(entity, sourceGroupSummary, { listEntities = null } = {}) {

--- a/tools/web_viewer/ui/released_insert_selection_rows.js
+++ b/tools/web_viewer/ui/released_insert_selection_rows.js
@@ -1,0 +1,62 @@
+import {
+  formatReleasedInsertArchiveModes,
+  formatReleasedInsertArchiveOrigin,
+} from './selection_released_archive_helpers.js';
+import {
+  formatPeerContext,
+  formatPeerTarget,
+} from './selection_display_helpers.js';
+
+function pushReleasedSelectionRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({
+    key,
+    label,
+    value: String(value),
+  });
+}
+
+export function buildReleasedInsertArchiveSelectionRows(selectionSummary) {
+  if (!selectionSummary?.archive) return [];
+  const rows = [];
+  const { archive, entityCount, peerSummary, commonModes } = selectionSummary;
+  pushReleasedSelectionRow(rows, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(archive));
+  if (Number.isFinite(archive?.groupId)) {
+    pushReleasedSelectionRow(rows, 'released-group-id', 'Released Group ID', String(Math.trunc(archive.groupId)));
+  }
+  pushReleasedSelectionRow(rows, 'released-block-name', 'Released Block Name', archive?.blockName);
+  pushReleasedSelectionRow(rows, 'released-selection-members', 'Released Selection Members', String(entityCount));
+  pushReleasedSelectionRow(rows, 'released-text-kind', 'Released Text Kind', archive?.textKind);
+  pushReleasedSelectionRow(rows, 'released-attribute-tag', 'Released Attribute Tag', archive?.attributeTag);
+  pushReleasedSelectionRow(rows, 'released-attribute-default', 'Released Attribute Default', archive?.attributeDefault);
+  pushReleasedSelectionRow(rows, 'released-attribute-prompt', 'Released Attribute Prompt', archive?.attributePrompt);
+  if (Number.isFinite(archive?.attributeFlags)) {
+    pushReleasedSelectionRow(rows, 'released-attribute-flags', 'Released Attribute Flags', String(Math.trunc(archive.attributeFlags)));
+  }
+  pushReleasedSelectionRow(
+    rows,
+    'released-attribute-modes',
+    'Released Attribute Modes',
+    commonModes || formatReleasedInsertArchiveModes(archive),
+  );
+  if (peerSummary?.peerCount > 1) {
+    const peerInstance = peerSummary.currentIndex >= 0
+      ? `${peerSummary.currentIndex + 1} / ${peerSummary.peerCount}`
+      : `Archived / ${peerSummary.peerCount}`;
+    pushReleasedSelectionRow(rows, 'released-peer-instance', 'Released Peer Instance', peerInstance);
+    pushReleasedSelectionRow(rows, 'released-peer-instances', 'Released Peer Instances', String(peerSummary.peerCount));
+    pushReleasedSelectionRow(
+      rows,
+      'released-peer-layouts',
+      'Released Peer Layouts',
+      peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | '),
+    );
+    pushReleasedSelectionRow(
+      rows,
+      'released-peer-targets',
+      'Released Peer Targets',
+      peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | '),
+    );
+  }
+  return rows;
+}

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -33,6 +33,7 @@ import {
 } from './selection_display_helpers.js';
 import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
+import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;
@@ -51,44 +52,8 @@ function formatSourceGroup(entity) {
 }
 
 export function buildMultiSelectionDetailFacts(entities, options = {}) {
-  const facts = [];
   const releasedInsertArchiveSelection = summarizeReleasedInsertArchiveSelection(entities, options);
-  if (!releasedInsertArchiveSelection) {
-    return facts;
-  }
-  const { archive, peerSummary, entityCount, commonModes } = releasedInsertArchiveSelection;
-  pushFact(facts, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(archive));
-  pushFact(facts, 'released-group-id', 'Released Group ID', String(archive.groupId));
-  pushFact(facts, 'released-block-name', 'Released Block Name', archive.blockName);
-  pushFact(facts, 'released-selection-members', 'Released Selection Members', String(entityCount));
-  pushFact(facts, 'released-text-kind', 'Released Text Kind', archive.textKind);
-  pushFact(facts, 'released-attribute-tag', 'Released Attribute Tag', archive.attributeTag);
-  pushFact(facts, 'released-attribute-default', 'Released Attribute Default', archive.attributeDefault);
-  pushFact(facts, 'released-attribute-prompt', 'Released Attribute Prompt', archive.attributePrompt);
-  if (Number.isFinite(archive.attributeFlags)) {
-    pushFact(facts, 'released-attribute-flags', 'Released Attribute Flags', String(archive.attributeFlags));
-  }
-  pushFact(facts, 'released-attribute-modes', 'Released Attribute Modes', commonModes);
-  if (peerSummary?.peerCount > 1) {
-    const peerInstance = peerSummary.currentIndex >= 0
-      ? `${peerSummary.currentIndex + 1} / ${peerSummary.peerCount}`
-      : `Archived / ${peerSummary.peerCount}`;
-    pushFact(facts, 'released-peer-instance', 'Released Peer Instance', peerInstance);
-    pushFact(facts, 'released-peer-instances', 'Released Peer Instances', String(peerSummary.peerCount));
-    pushFact(
-      facts,
-      'released-peer-layouts',
-      'Released Peer Layouts',
-      peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | ')
-    );
-    pushFact(
-      facts,
-      'released-peer-targets',
-      'Released Peer Targets',
-      peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | ')
-    );
-  }
-  return facts;
+  return buildReleasedInsertArchiveSelectionRows(releasedInsertArchiveSelection);
 }
 
 export function buildSelectionDetailFacts(entity, options = {}) {


### PR DESCRIPTION
## Summary
- add `released_insert_selection_rows.js` as the canonical builder for released-archive multi-selection rows
- keep `buildReleasedInsertArchiveSelectionInfoRows(...)` as a compatibility wrapper
- reuse the same released-selection row assembly in detail facts and property-panel info rows

## Verification
- `node --check tools/web_viewer/ui/released_insert_selection_rows.js`
- `node --check tools/web_viewer/ui/selection_detail_facts.js`
- `node --check tools/web_viewer/ui/property_panel_info_rows.js`
- `node --test tools/web_viewer/tests/released_insert_selection_rows.test.js`
- `node --test tools/web_viewer/tests/selection_detail_facts.test.js`
- `node --test tools/web_viewer/tests/property_panel_info_rows.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`

## Scope
- no behavior changes
- no row-order changes
- no new dependency cycles