### PR TITLE
refactor: share group info rows

### DIFF
--- a/docs/STEP354_GROUP_INFO_ROWS_EXTRACTION_DESIGN.md
+++ b/docs/STEP354_GROUP_INFO_ROWS_EXTRACTION_DESIGN.md
@@ -1,0 +1,91 @@
+# Step354: Group Info Rows Extraction
+
+## Goal
+
+Extract shared source-group / insert-group info-row assembly into a dedicated leaf helper used by both:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/property_panel_info_rows.js`
+
+The purpose is to remove duplicated member-count / bounds / peer-row formatting while preserving the current UI contract exactly.
+
+## Scope
+
+In scope:
+
+- Extract group row assembly into a new dedicated helper module.
+- Cover both source-group and insert-group variants.
+- Keep exact row ordering, labels, keys, and value formatting unchanged.
+- Keep `property_panel_info_rows.js` public exports unchanged.
+- Keep `selection_detail_facts.js` public exports unchanged.
+
+Out of scope:
+
+- Released archive row behavior.
+- Property metadata fact behavior.
+- Selection presentation behavior.
+- Property panel rendering behavior.
+- Any wording or semantic change.
+
+## Target Shape
+
+Introduce a leaf helper, expected name:
+
+- `tools/web_viewer/ui/group_info_rows.js`
+
+Expected responsibility:
+
+- Build shared rows for:
+  - group identity rows
+  - group member count rows
+  - group bounds rows
+  - peer summary rows
+
+Expected consumers:
+
+- `selection_detail_facts.js`
+- `property_panel_info_rows.js`
+
+## Constraints
+
+- Do not import `selection_presenter.js` from the new helper.
+- Do not create a new cycle through `property_panel_info_rows.js`.
+- Do not change:
+  - `Group ID`
+  - `Group Source`
+  - `Source Bundle ID`
+  - `Block Name`
+  - member count rows
+  - `Group Center`
+  - `Group Size`
+  - `Group Bounds`
+  - `Peer Instance`
+  - `Peer Instances`
+  - `Peer Layouts`
+  - `Peer Targets`
+- Preserve insert-group-only behaviors:
+  - `Insert Group Members`
+  - `Block Name`
+  - peer rows
+- Preserve source-group-only behaviors:
+  - `Source Group Members`
+  - no block-name row
+  - no peer rows
+
+## Recommended Implementation
+
+1. Extract shared row assembly into `group_info_rows.js`.
+2. Move only the minimal formatting helpers needed by that module, if any.
+3. Update `property_panel_info_rows.js` so its group-row builders delegate to the new helper.
+4. Update `selection_detail_facts.js` so its source/insert group sections reuse the same helper output.
+5. Keep released-archive selection rows on their current helper.
+
+## Acceptance
+
+Accept Step354 only if:
+
+- no behavior changes are introduced
+- no new dependency cycle is created
+- focused tests cover both source-group and insert-group paths
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP354_GROUP_INFO_ROWS_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP354_GROUP_INFO_ROWS_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,45 @@
+# Step354: Group Info Rows Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step354-group-info-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/group_info_rows.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+node --check tools/web_viewer/ui/property_panel_info_rows.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/group_info_rows.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js \
+  tools/web_viewer/tests/property_panel_info_rows.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/group_info_rows.test.js
+++ b/tools/web_viewer/tests/group_info_rows.test.js
@@ -1,0 +1,217 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildInsertGroupInfoRows,
+  buildSourceGroupInfoRows,
+} from '../ui/group_info_rows.js';
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('buildSourceGroupInfoRows preserves identity, member, and bounds rows by default', () => {
+  const entity = {
+    id: 11,
+    type: 'text',
+    groupId: 700,
+    sourceBundleId: 701,
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    space: 0,
+    layout: 'Model',
+    position: { x: 0, y: 0 },
+  };
+  const rows = buildSourceGroupInfoRows(
+    entity,
+    {
+      memberIds: [11, 12],
+      editableIds: [12],
+      readOnlyIds: [11],
+    },
+    {
+      listEntities: () => [
+        entity,
+        {
+          id: 12,
+          type: 'line',
+          groupId: 700,
+          sourceBundleId: 701,
+          sourceType: 'DIMENSION',
+          space: 0,
+          layout: 'Model',
+          start: { x: -20, y: 0 },
+          end: { x: 20, y: 14 },
+        },
+      ],
+    },
+  );
+
+  assert.deepEqual(toMap(rows), {
+    'group-id': '700',
+    'group-source': 'DIMENSION / text',
+    'source-bundle-id': '701',
+    'source-group-members': '2',
+    'editable-members': '1',
+    'read-only-members': '1',
+    'group-center': '0, 7',
+    'group-size': '40 x 14',
+    'group-bounds': '-20, 0 -> 20, 14',
+  });
+});
+
+test('buildSourceGroupInfoRows can omit identity rows for selection detail adoption', () => {
+  const entity = {
+    id: 11,
+    type: 'text',
+    groupId: 700,
+    sourceBundleId: 701,
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    space: 0,
+    layout: 'Model',
+    position: { x: 0, y: 0 },
+  };
+  const rows = buildSourceGroupInfoRows(
+    entity,
+    {
+      memberIds: [11, 12],
+      editableIds: [12],
+      readOnlyIds: [11],
+    },
+    {
+      includeIdentityRows: false,
+      listEntities: () => [
+        entity,
+        {
+          id: 12,
+          type: 'line',
+          groupId: 700,
+          sourceBundleId: 701,
+          sourceType: 'DIMENSION',
+          space: 0,
+          layout: 'Model',
+          start: { x: -20, y: 0 },
+          end: { x: 20, y: 14 },
+        },
+      ],
+    },
+  );
+
+  assert.deepEqual(toMap(rows), {
+    'source-group-members': '2',
+    'editable-members': '1',
+    'read-only-members': '1',
+    'group-center': '0, 7',
+    'group-size': '40 x 14',
+    'group-bounds': '-20, 0 -> 20, 14',
+  });
+});
+
+test('buildInsertGroupInfoRows preserves block, bounds, and peer rows by default', () => {
+  const entity = {
+    id: 21,
+    type: 'text',
+    groupId: 500,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    position: { x: 0, y: 20 },
+  };
+  const rows = buildInsertGroupInfoRows(
+    entity,
+    {
+      memberIds: [21, 22],
+      editableIds: [21],
+      readOnlyIds: [22],
+    },
+    {
+      listEntities: () => [
+        entity,
+        {
+          id: 22,
+          type: 'line',
+          groupId: 500,
+          sourceType: 'INSERT',
+          blockName: 'DoorTag',
+          space: 1,
+          layout: 'Layout-B',
+          start: { x: -18, y: 20 },
+          end: { x: 18, y: 34 },
+        },
+      ],
+      peerSummary: {
+        peerCount: 3,
+        currentIndex: 1,
+        peers: [
+          { space: 1, layout: 'Layout-A' },
+          { space: 1, layout: 'Layout-B' },
+          { space: 1, layout: 'Layout-C' },
+        ],
+      },
+    },
+  );
+
+  assert.deepEqual(toMap(rows), {
+    'group-id': '500',
+    'group-source': 'INSERT / text',
+    'block-name': 'DoorTag',
+    'insert-group-members': '2',
+    'editable-members': '1',
+    'read-only-members': '1',
+    'group-center': '0, 27',
+    'group-size': '36 x 14',
+    'group-bounds': '-18, 20 -> 18, 34',
+    'peer-instance': '2 / 3',
+    'peer-instances': '3',
+    'peer-layouts': 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C',
+    'peer-targets': '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C',
+  });
+});
+
+test('buildInsertGroupInfoRows can omit identity, block, and bounds rows for selection detail adoption', () => {
+  const entity = {
+    id: 21,
+    type: 'text',
+    groupId: 500,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    position: { x: 0, y: 20 },
+  };
+  const rows = buildInsertGroupInfoRows(
+    entity,
+    {
+      memberIds: [21, 22],
+      editableIds: [21],
+      readOnlyIds: [22],
+    },
+    {
+      includeIdentityRows: false,
+      includeBlockName: false,
+      includeBounds: false,
+      peerSummary: {
+        peerCount: 2,
+        currentIndex: 0,
+        peers: [
+          { space: 1, layout: 'Layout-B' },
+          { space: 1, layout: 'Layout-C' },
+        ],
+      },
+    },
+  );
+
+  assert.deepEqual(toMap(rows), {
+    'insert-group-members': '2',
+    'editable-members': '1',
+    'read-only-members': '1',
+    'peer-instance': '1 / 2',
+    'peer-instances': '2',
+    'peer-layouts': 'Paper / Layout-B | Paper / Layout-C',
+    'peer-targets': '1: Paper / Layout-B | 2: Paper / Layout-C',
+  });
+});

--- a/tools/web_viewer/tests/selection_detail_facts.test.js
+++ b/tools/web_viewer/tests/selection_detail_facts.test.js
@@ -71,8 +71,23 @@ test('buildSelectionDetailFacts includes origin, layer, effective-color, style f
 });
 
 test('buildSelectionDetailFacts includes source-group facts for grouped entity', () => {
-  const entity = makeEntity({ sourceType: 'DIMENSION', proxyKind: 'text', groupId: 100, editMode: 'proxy', readOnly: true });
-  const member = makeEntity({ id: 2, type: 'line', groupId: 100 });
+  const entity = makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    groupId: 100,
+    sourceBundleId: 101,
+    editMode: 'proxy',
+    readOnly: true,
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    groupId: 100,
+    sourceBundleId: 101,
+    sourceType: 'DIMENSION',
+    start: { x: -20, y: 0 },
+    end: { x: 20, y: 14 },
+  });
   const layer = makeLayer();
   const facts = buildSelectionDetailFacts(entity, makeOptions([layer], [entity, member]));
 
@@ -80,6 +95,58 @@ test('buildSelectionDetailFacts includes source-group facts for grouped entity',
   assert.ok(keys.includes('origin'), 'missing origin');
   assert.ok(keys.includes('group-id'), 'missing group-id');
   assert.equal(facts.find((f) => f.key === 'group-id').value, '100');
+  assert.equal(facts.find((f) => f.key === 'source-group-members').value, '2');
+  assert.equal(facts.find((f) => f.key === 'group-center').value, '0, 7');
+  assert.equal(facts.find((f) => f.key === 'group-bounds').value, '-20, 0 -> 20, 14');
+});
+
+test('buildSelectionDetailFacts preserves insert-group peer rows without insert-only identity duplicates', () => {
+  const entity = makeEntity({
+    type: 'text',
+    groupId: 500,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    position: { x: 0, y: 20 },
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    groupId: 500,
+    sourceType: 'INSERT',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    start: { x: -18, y: 20 },
+    end: { x: 18, y: 34 },
+  });
+  const peer = makeEntity({
+    id: 3,
+    type: 'text',
+    groupId: 500,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'DoorTag',
+    position: { x: 50, y: 20 },
+    space: 1,
+    layout: 'Layout-C',
+  });
+  const facts = buildSelectionDetailFacts(entity, makeOptions([makeLayer()], [entity, member, peer]));
+  const byKey = Object.fromEntries(facts.map((fact) => [fact.key, fact.value]));
+
+  assert.equal(byKey['insert-group-members'], '2');
+  assert.equal(byKey['group-source'], 'INSERT / text');
+  assert.equal(byKey['group-center'], '0, 27');
+  assert.equal(byKey['group-bounds'], '-18, 20 -> 18, 34');
+  assert.equal(byKey['peer-instance'], '1 / 2');
+  assert.equal(byKey['peer-instances'], '2');
+  assert.equal(byKey['peer-layouts'], 'Paper / Layout-B | Paper / Layout-C');
+  assert.equal(byKey['peer-targets'], '1: Paper / Layout-B | 2: Paper / Layout-C');
+  assert.equal(byKey['block-name'], 'DoorTag');
+  assert.equal(facts.filter((fact) => fact.key === 'group-id').length, 1);
+  assert.equal(facts.filter((fact) => fact.key === 'block-name').length, 1);
 });
 
 test('buildSelectionDetailFacts includes source text position for editable source text', () => {

--- a/tools/web_viewer/ui/group_info_rows.js
+++ b/tools/web_viewer/ui/group_info_rows.js
@@ -1,0 +1,150 @@
+import {
+  computeInsertGroupBounds,
+  computeSourceGroupBounds,
+  isInsertGroupEntity,
+  isSourceGroupEntity,
+} from '../insert_group.js';
+import {
+  formatCompactNumber,
+  formatPoint,
+  formatPeerContext,
+  formatPeerTarget,
+  normalizeText,
+} from './selection_display_helpers.js';
+
+function pushRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({
+    key,
+    label,
+    value: String(value),
+  });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = normalizeText(entity?.sourceType).toUpperCase();
+  const proxyKind = normalizeText(entity?.proxyKind);
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
+}
+
+function resolveEntities(listEntities) {
+  if (typeof listEntities !== 'function') return [];
+  const entities = listEntities();
+  return Array.isArray(entities) ? entities.filter(Boolean) : [];
+}
+
+function resolveSourceGroupBounds(entity, listEntities) {
+  if (!isSourceGroupEntity(entity)) return null;
+  const entities = resolveEntities(listEntities);
+  if (entities.length === 0) return null;
+  return computeSourceGroupBounds(entities, entity);
+}
+
+function resolveInsertGroupBounds(entity, listEntities) {
+  if (!isInsertGroupEntity(entity)) return null;
+  const entities = resolveEntities(listEntities);
+  if (entities.length === 0) return null;
+  return computeInsertGroupBounds(entities, entity);
+}
+
+function appendIdentityRows(rows, entity, { includeGroupSource = true, includeBlockName = false } = {}) {
+  if (Number.isFinite(entity?.groupId)) {
+    pushRow(rows, 'group-id', 'Group ID', String(Math.trunc(entity.groupId)));
+  }
+  if (includeGroupSource) {
+    pushRow(rows, 'group-source', 'Group Source', formatSourceGroup(entity));
+  }
+  if (
+    Number.isFinite(entity?.sourceBundleId)
+    && (!Number.isFinite(entity?.groupId) || Math.trunc(entity.sourceBundleId) !== Math.trunc(entity.groupId))
+  ) {
+    pushRow(rows, 'source-bundle-id', 'Source Bundle ID', String(Math.trunc(entity.sourceBundleId)));
+  }
+  if (includeBlockName) {
+    pushRow(rows, 'block-name', 'Block Name', normalizeText(entity?.blockName));
+  }
+}
+
+function appendMemberRows(rows, groupSummary, {
+  memberLabel = 'Source Group Members',
+  memberKey = 'source-group-members',
+} = {}) {
+  if (Array.isArray(groupSummary?.memberIds) && groupSummary.memberIds.length > 0) {
+    pushRow(rows, memberKey, memberLabel, String(groupSummary.memberIds.length));
+  }
+  if (Array.isArray(groupSummary?.readOnlyIds) && groupSummary.readOnlyIds.length > 0) {
+    pushRow(rows, 'editable-members', 'Editable Members', String(groupSummary.editableIds.length));
+    pushRow(rows, 'read-only-members', 'Read-only Members', String(groupSummary.readOnlyIds.length));
+  }
+}
+
+function appendBoundsRows(rows, groupBounds) {
+  if (!groupBounds) return;
+  pushRow(rows, 'group-center', 'Group Center', formatPoint(groupBounds.center));
+  pushRow(rows, 'group-size', 'Group Size', `${formatCompactNumber(groupBounds.width)} x ${formatCompactNumber(groupBounds.height)}`);
+  pushRow(
+    rows,
+    'group-bounds',
+    'Group Bounds',
+    `${formatCompactNumber(groupBounds.minX)}, ${formatCompactNumber(groupBounds.minY)} -> ${formatCompactNumber(groupBounds.maxX)}, ${formatCompactNumber(groupBounds.maxY)}`,
+  );
+}
+
+function appendPeerRows(rows, peerSummary) {
+  if (!peerSummary || peerSummary.peerCount <= 1) return;
+  const currentIndex = peerSummary.currentIndex >= 0 ? peerSummary.currentIndex : 0;
+  pushRow(rows, 'peer-instance', 'Peer Instance', `${currentIndex + 1} / ${peerSummary.peerCount}`);
+  pushRow(rows, 'peer-instances', 'Peer Instances', String(peerSummary.peerCount));
+  pushRow(
+    rows,
+    'peer-layouts',
+    'Peer Layouts',
+    peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | ')
+  );
+  pushRow(
+    rows,
+    'peer-targets',
+    'Peer Targets',
+    peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | ')
+  );
+}
+
+export function buildSourceGroupInfoRows(entity, sourceGroupSummary, {
+  listEntities = null,
+  includeIdentityRows = true,
+} = {}) {
+  if (!entity || !sourceGroupSummary) return [];
+  const rows = [];
+  if (includeIdentityRows) {
+    appendIdentityRows(rows, entity, { includeGroupSource: true, includeBlockName: false });
+  }
+  appendMemberRows(rows, sourceGroupSummary, {
+    memberLabel: 'Source Group Members',
+    memberKey: 'source-group-members',
+  });
+  appendBoundsRows(rows, resolveSourceGroupBounds(entity, listEntities));
+  return rows;
+}
+
+export function buildInsertGroupInfoRows(entity, insertGroupSummary, {
+  listEntities = null,
+  peerSummary = null,
+  includeIdentityRows = true,
+  includeBlockName = true,
+  includeBounds = true,
+} = {}) {
+  if (!entity || !insertGroupSummary) return [];
+  const rows = [];
+  if (includeIdentityRows) {
+    appendIdentityRows(rows, entity, { includeGroupSource: true, includeBlockName });
+  }
+  appendMemberRows(rows, insertGroupSummary, {
+    memberLabel: 'Insert Group Members',
+    memberKey: 'insert-group-members',
+  });
+  if (includeBounds) {
+    appendBoundsRows(rows, resolveInsertGroupBounds(entity, listEntities));
+  }
+  appendPeerRows(rows, peerSummary);
+  return rows;
+}

--- a/tools/web_viewer/ui/property_panel_info_rows.js
+++ b/tools/web_viewer/ui/property_panel_info_rows.js
@@ -1,120 +1,11 @@
 import {
   buildPropertyMetadataFacts,
 } from './selection_presenter.js';
-import {
-  computeInsertGroupBounds,
-  computeSourceGroupBounds,
-  isInsertGroupEntity,
-  isSourceGroupEntity,
-} from '../insert_group.js';
-import {
-  formatCompactNumber,
-  formatPoint,
-  formatPeerContext,
-  formatPeerTarget,
-} from './selection_display_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
-
-function pushInfo(rows, label, value, key = '') {
-  if (value === null || value === undefined || value === '') return;
-  rows.push({
-    key,
-    label,
-    value: String(value),
-  });
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = typeof entity?.sourceType === 'string' ? entity.sourceType.trim().toUpperCase() : '';
-  const proxyKind = typeof entity?.proxyKind === 'string' ? entity.proxyKind.trim().toLowerCase() : '';
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
-}
-
-function resolveEntities(listEntities) {
-  if (typeof listEntities !== 'function') return [];
-  const entities = listEntities();
-  return Array.isArray(entities) ? entities.filter(Boolean) : [];
-}
-
-function resolveSourceGroupBounds(entity, listEntities) {
-  if (!isSourceGroupEntity(entity)) return null;
-  const entities = resolveEntities(listEntities);
-  if (entities.length === 0) return null;
-  return computeSourceGroupBounds(entities, entity);
-}
-
-function resolveInsertGroupBounds(entity, listEntities) {
-  if (!isInsertGroupEntity(entity)) return null;
-  const entities = resolveEntities(listEntities);
-  if (entities.length === 0) return null;
-  return computeInsertGroupBounds(entities, entity);
-}
-
-function buildGroupInfoRows(entity, groupSummary, {
-  listEntities = null,
-  memberLabel = 'Source Group Members',
-  memberKey = 'source-group-members',
-  includeBlockName = false,
-  includePeers = false,
-  peerSummary = null,
-} = {}) {
-  if (!entity || !groupSummary) return [];
-  const rows = [];
-  const groupBounds = includePeers
-    ? resolveInsertGroupBounds(entity, listEntities)
-    : resolveSourceGroupBounds(entity, listEntities);
-  if (Number.isFinite(entity.groupId)) {
-    pushInfo(rows, 'Group ID', String(Math.trunc(entity.groupId)), 'group-id');
-  }
-  pushInfo(rows, 'Group Source', formatSourceGroup(entity), 'group-source');
-  if (Number.isFinite(entity.sourceBundleId)
-    && (!Number.isFinite(entity.groupId) || Math.trunc(entity.sourceBundleId) !== Math.trunc(entity.groupId))) {
-    pushInfo(rows, 'Source Bundle ID', String(Math.trunc(entity.sourceBundleId)), 'source-bundle-id');
-  }
-  if (includeBlockName) {
-    pushInfo(rows, 'Block Name', entity.blockName, 'block-name');
-  }
-  if (Array.isArray(groupSummary.memberIds) && groupSummary.memberIds.length > 0) {
-    pushInfo(rows, memberLabel, String(groupSummary.memberIds.length), memberKey);
-  }
-  if (Array.isArray(groupSummary.readOnlyIds) && groupSummary.readOnlyIds.length > 0) {
-    pushInfo(rows, 'Editable Members', String(groupSummary.editableIds.length), 'editable-members');
-    pushInfo(rows, 'Read-only Members', String(groupSummary.readOnlyIds.length), 'read-only-members');
-  }
-  if (groupBounds) {
-    pushInfo(rows, 'Group Center', formatPoint(groupBounds.center), 'group-center');
-    pushInfo(
-      rows,
-      'Group Size',
-      `${formatCompactNumber(groupBounds.width)} x ${formatCompactNumber(groupBounds.height)}`,
-      'group-size',
-    );
-    pushInfo(
-      rows,
-      'Group Bounds',
-      `${formatCompactNumber(groupBounds.minX)}, ${formatCompactNumber(groupBounds.minY)} -> ${formatCompactNumber(groupBounds.maxX)}, ${formatCompactNumber(groupBounds.maxY)}`,
-      'group-bounds',
-    );
-  }
-  if (peerSummary?.peerCount > 1) {
-    const currentIndex = peerSummary.currentIndex >= 0 ? peerSummary.currentIndex : 0;
-    pushInfo(rows, 'Peer Instance', `${currentIndex + 1} / ${peerSummary.peerCount}`, 'peer-instance');
-    pushInfo(rows, 'Peer Instances', String(peerSummary.peerCount), 'peer-instances');
-    pushInfo(
-      rows,
-      'Peer Layouts',
-      peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | '),
-      'peer-layouts',
-    );
-    pushInfo(
-      rows,
-      'Peer Targets',
-      peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | '),
-      'peer-targets',
-    );
-  }
-  return rows;
-}
+import {
+  buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
+  buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
+} from './group_info_rows.js';
 
 export function buildEntityMetadataInfoRows(entity, { getLayer = null, listEntities = null } = {}) {
   if (!entity) return [];
@@ -126,16 +17,12 @@ export function buildReleasedInsertArchiveSelectionInfoRows(selectionSummary) {
 }
 
 export function buildSourceGroupInfoRows(entity, sourceGroupSummary, { listEntities = null } = {}) {
-  return buildGroupInfoRows(entity, sourceGroupSummary, { listEntities });
+  return buildSharedSourceGroupInfoRows(entity, sourceGroupSummary, { listEntities });
 }
 
 export function buildInsertGroupInfoRows(entity, insertGroupSummary, { listEntities = null, peerSummary = null } = {}) {
-  return buildGroupInfoRows(entity, insertGroupSummary, {
+  return buildSharedInsertGroupInfoRows(entity, insertGroupSummary, {
     listEntities,
-    memberLabel: 'Insert Group Members',
-    memberKey: 'insert-group-members',
-    includeBlockName: true,
-    includePeers: true,
     peerSummary,
   });
 }

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -1,6 +1,5 @@
 import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
 import {
-  computeSourceGroupBounds,
   isDirectEditableSourceTextEntity,
   isInsertGroupEntity,
   isSourceGroupEntity,
@@ -34,6 +33,10 @@ import {
 import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
+import {
+  buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
+  buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
+} from './group_info_rows.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;
@@ -66,7 +69,6 @@ export function buildSelectionDetailFacts(entity, options = {}) {
   const styleSources = resolveEntityStyleSources(entity);
   const entities = listEntities ? listEntities() : null;
   const sourceGroupSummary = entities ? summarizeSourceGroupMembers(entities, entity, { isReadOnly: isReadOnlySelectionEntity }) : null;
-  const sourceGroupBounds = entities ? computeSourceGroupBounds(entities, entity) : null;
   const insertGroupSummary = isInsertGroupEntity(entity)
     ? summarizeInsertGroupMembers(entities, entity, { isReadOnly: isReadOnlySelectionEntity })
     : null;
@@ -123,46 +125,19 @@ export function buildSelectionDetailFacts(entity, options = {}) {
     pushFact(facts, 'released-attribute-flags', 'Released Attribute Flags', String(Math.trunc(releasedInsertArchive.attributeFlags)));
   }
   pushFact(facts, 'released-attribute-modes', 'Released Attribute Modes', formatReleasedInsertArchiveModes(releasedInsertArchive));
-  if (insertGroupSummary?.memberIds?.length > 0) {
-    pushFact(facts, 'insert-group-members', 'Insert Group Members', String(insertGroupSummary.memberIds.length));
-    if (insertGroupSummary.readOnlyIds.length > 0) {
-      pushFact(facts, 'editable-members', 'Editable Members', String(insertGroupSummary.editableIds.length));
-      pushFact(facts, 'read-only-members', 'Read-only Members', String(insertGroupSummary.readOnlyIds.length));
-    }
-  } else if (sourceGroupSummary?.memberIds?.length > 0) {
-    pushFact(facts, 'source-group-members', 'Source Group Members', String(sourceGroupSummary.memberIds.length));
-    if (sourceGroupSummary.readOnlyIds.length > 0) {
-      pushFact(facts, 'editable-members', 'Editable Members', String(sourceGroupSummary.editableIds.length));
-      pushFact(facts, 'read-only-members', 'Read-only Members', String(sourceGroupSummary.readOnlyIds.length));
-    }
-  }
-  if (sourceGroupBounds) {
-    pushFact(facts, 'group-center', 'Group Center', formatPoint(sourceGroupBounds.center));
-    pushFact(facts, 'group-size', 'Group Size', `${formatCompactNumber(sourceGroupBounds.width)} x ${formatCompactNumber(sourceGroupBounds.height)}`);
-    pushFact(
-      facts,
-      'group-bounds',
-      'Group Bounds',
-      `${formatCompactNumber(sourceGroupBounds.minX)}, ${formatCompactNumber(sourceGroupBounds.minY)} -> ${formatCompactNumber(sourceGroupBounds.maxX)}, ${formatCompactNumber(sourceGroupBounds.maxY)}`,
-    );
-  }
-  if (insertPeerSummary?.peerCount > 1) {
-    const currentIndex = insertPeerSummary.currentIndex >= 0 ? insertPeerSummary.currentIndex : 0;
-    pushFact(facts, 'peer-instance', 'Peer Instance', `${currentIndex + 1} / ${insertPeerSummary.peerCount}`);
-    pushFact(facts, 'peer-instances', 'Peer Instances', String(insertPeerSummary.peerCount));
-    pushFact(
-      facts,
-      'peer-layouts',
-      'Peer Layouts',
-      insertPeerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | ')
-    );
-    pushFact(
-      facts,
-      'peer-targets',
-      'Peer Targets',
-      insertPeerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | ')
-    );
-  }
+  const groupRows = insertGroupSummary
+    ? buildSharedInsertGroupInfoRows(entity, insertGroupSummary, {
+      listEntities,
+      peerSummary: insertPeerSummary,
+      includeIdentityRows: false,
+      includeBlockName: false,
+      includeBounds: true,
+    })
+    : buildSharedSourceGroupInfoRows(entity, sourceGroupSummary, {
+      listEntities,
+      includeIdentityRows: false,
+    });
+  facts.push(...groupRows);
   if (releasedInsertPeerSummary?.peerCount > 1) {
     const peerInstance = releasedInsertPeerSummary.currentIndex >= 0
       ? `${releasedInsertPeerSummary.currentIndex + 1} / ${releasedInsertPeerSummary.peerCount}`


### PR DESCRIPTION
## Summary
- extract shared source/insert group row assembly into a new `group_info_rows` leaf helper
- adopt the helper in `selection_detail_facts` and `property_panel_info_rows` without changing row ordering or wording
- add focused coverage for shared helper behavior and selection-detail adoption

## Verification
- `node --check` on `group_info_rows.js`, `selection_detail_facts.js`, `property_panel_info_rows.js`
- `node --test` on `group_info_rows.test.js`, `selection_detail_facts.test.js`, `property_panel_info_rows.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`

## Note
GitHub Actions is currently affected by a repository billing/spending-limit issue that blocks runner start before any job steps execute. Local verification above is the authoritative signal for this PR.
