### PR TITLE
refactor: share peer summary rows

### DIFF
--- a/docs/STEP355_PEER_SUMMARY_ROWS_EXTRACTION_DESIGN.md
+++ b/docs/STEP355_PEER_SUMMARY_ROWS_EXTRACTION_DESIGN.md
@@ -1,0 +1,60 @@
+# Step355: Peer Summary Rows Extraction
+
+## Goal
+
+Extract shared peer-summary row assembly into a dedicated leaf helper used by:
+
+- `tools/web_viewer/ui/group_info_rows.js`
+- `tools/web_viewer/ui/released_insert_selection_rows.js`
+
+The purpose is to remove duplicated peer row formatting while preserving current keys, labels, ordering, and archived wording.
+
+## Scope
+
+In scope:
+
+- Extract shared peer row assembly into a new helper module.
+- Cover:
+  - peer instance row
+  - peer count row
+  - peer layouts row
+  - peer targets row
+- Support both normal peer wording and released-archive peer wording.
+
+Out of scope:
+
+- group identity rows
+- group member count rows
+- group bounds rows
+- released archive non-peer rows
+- selection presentation contract changes
+
+## Constraints
+
+- Keep `buildInsertGroupInfoRows(...)` behavior unchanged.
+- Keep `buildReleasedInsertArchiveSelectionRows(...)` behavior unchanged.
+- Preserve exact keys, labels, values, and row ordering.
+- Preserve `Archived / N` released-peer wording.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new cycle through `group_info_rows.js` or `released_insert_selection_rows.js`.
+
+## Expected Shape
+
+Introduce a new leaf helper, expected name:
+
+- `tools/web_viewer/ui/peer_summary_rows.js`
+
+Expected responsibility:
+
+- build common peer-summary rows from a `peerSummary` object
+- allow released-archive mode for the released peer labels/instance wording
+
+## Acceptance
+
+Accept Step355 only if:
+
+- the shared helper is leaf-level and cycle-safe
+- both callers preserve their exact output contracts
+- focused tests cover normal and released peer row variants
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP355_PEER_SUMMARY_ROWS_EXTRACTION_VERIFICATION.md
+++ b/docs/STEP355_PEER_SUMMARY_ROWS_EXTRACTION_VERIFICATION.md
@@ -1,0 +1,45 @@
+# Step355: Peer Summary Rows Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step355-peer-summary-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/peer_summary_rows.js
+node --check tools/web_viewer/ui/group_info_rows.js
+node --check tools/web_viewer/ui/released_insert_selection_rows.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/peer_summary_rows.test.js \
+  tools/web_viewer/tests/group_info_rows.test.js \
+  tools/web_viewer/tests/released_insert_selection_rows.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/peer_summary_rows.test.js
+++ b/tools/web_viewer/tests/peer_summary_rows.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPeerSummaryRows } from '../ui/peer_summary_rows.js';
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('buildPeerSummaryRows appends nothing when peerCount <= 1', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, { peerCount: 1, currentIndex: 0, peers: [{ space: 0 }] });
+  assert.deepEqual(rows, []);
+});
+
+test('buildPeerSummaryRows appends nothing for null peerSummary', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, null);
+  assert.deepEqual(rows, []);
+});
+
+test('buildPeerSummaryRows normal mode with currentIndex >= 0', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, {
+    peerCount: 3,
+    currentIndex: 1,
+    peers: [
+      { space: 1, layout: 'Layout-A' },
+      { space: 1, layout: 'Layout-B' },
+      { space: 1, layout: 'Layout-C' },
+    ],
+  });
+  assert.deepEqual(toMap(rows), {
+    'peer-instance': '2 / 3',
+    'peer-instances': '3',
+    'peer-layouts': 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C',
+    'peer-targets': '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C',
+  });
+});
+
+test('buildPeerSummaryRows normal mode with currentIndex < 0 defaults to index 0', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, {
+    peerCount: 2,
+    currentIndex: -1,
+    peers: [
+      { space: 1, layout: 'Layout-X' },
+      { space: 1, layout: 'Layout-Y' },
+    ],
+  });
+  assert.deepEqual(toMap(rows), {
+    'peer-instance': '1 / 2',
+    'peer-instances': '2',
+    'peer-layouts': 'Paper / Layout-X | Paper / Layout-Y',
+    'peer-targets': '1: Paper / Layout-X | 2: Paper / Layout-Y',
+  });
+});
+
+test('buildPeerSummaryRows released mode with currentIndex >= 0', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, {
+    peerCount: 3,
+    currentIndex: 2,
+    peers: [
+      { space: 1, layout: 'Layout-A' },
+      { space: 1, layout: 'Layout-B' },
+      { space: 1, layout: 'Layout-C' },
+    ],
+  }, { released: true });
+  assert.deepEqual(toMap(rows), {
+    'released-peer-instance': '3 / 3',
+    'released-peer-instances': '3',
+    'released-peer-layouts': 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C',
+    'released-peer-targets': '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C',
+  });
+});
+
+test('buildPeerSummaryRows released mode with currentIndex < 0 uses Archived / N wording', () => {
+  const rows = [];
+  buildPeerSummaryRows(rows, {
+    peerCount: 3,
+    currentIndex: -1,
+    peers: [
+      { space: 1, layout: 'Layout-A' },
+      { space: 1, layout: 'Layout-B' },
+      { space: 1, layout: 'Layout-C' },
+    ],
+  }, { released: true });
+  assert.deepEqual(toMap(rows), {
+    'released-peer-instance': 'Archived / 3',
+    'released-peer-instances': '3',
+    'released-peer-layouts': 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C',
+    'released-peer-targets': '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C',
+  });
+});

--- a/tools/web_viewer/ui/group_info_rows.js
+++ b/tools/web_viewer/ui/group_info_rows.js
@@ -7,10 +7,9 @@ import {
 import {
   formatCompactNumber,
   formatPoint,
-  formatPeerContext,
-  formatPeerTarget,
   normalizeText,
 } from './selection_display_helpers.js';
+import { buildPeerSummaryRows } from './peer_summary_rows.js';
 
 function pushRow(rows, key, label, value) {
   if (value === null || value === undefined || value === '') return;
@@ -91,22 +90,7 @@ function appendBoundsRows(rows, groupBounds) {
 }
 
 function appendPeerRows(rows, peerSummary) {
-  if (!peerSummary || peerSummary.peerCount <= 1) return;
-  const currentIndex = peerSummary.currentIndex >= 0 ? peerSummary.currentIndex : 0;
-  pushRow(rows, 'peer-instance', 'Peer Instance', `${currentIndex + 1} / ${peerSummary.peerCount}`);
-  pushRow(rows, 'peer-instances', 'Peer Instances', String(peerSummary.peerCount));
-  pushRow(
-    rows,
-    'peer-layouts',
-    'Peer Layouts',
-    peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | ')
-  );
-  pushRow(
-    rows,
-    'peer-targets',
-    'Peer Targets',
-    peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | ')
-  );
+  buildPeerSummaryRows(rows, peerSummary);
 }
 
 export function buildSourceGroupInfoRows(entity, sourceGroupSummary, {

--- a/tools/web_viewer/ui/peer_summary_rows.js
+++ b/tools/web_viewer/ui/peer_summary_rows.js
@@ -1,0 +1,42 @@
+import {
+  formatPeerContext,
+  formatPeerTarget,
+} from './selection_display_helpers.js';
+
+function pushRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({
+    key,
+    label,
+    value: String(value),
+  });
+}
+
+export function buildPeerSummaryRows(rows, peerSummary, { released = false } = {}) {
+  if (!peerSummary || peerSummary.peerCount <= 1) return;
+  const keyPrefix = released ? 'released-peer' : 'peer';
+  const labelPrefix = released ? 'Released Peer' : 'Peer';
+  let instanceValue;
+  if (released) {
+    instanceValue = peerSummary.currentIndex >= 0
+      ? `${peerSummary.currentIndex + 1} / ${peerSummary.peerCount}`
+      : `Archived / ${peerSummary.peerCount}`;
+  } else {
+    const currentIndex = peerSummary.currentIndex >= 0 ? peerSummary.currentIndex : 0;
+    instanceValue = `${currentIndex + 1} / ${peerSummary.peerCount}`;
+  }
+  pushRow(rows, `${keyPrefix}-instance`, `${labelPrefix} Instance`, instanceValue);
+  pushRow(rows, `${keyPrefix}-instances`, `${labelPrefix} Instances`, String(peerSummary.peerCount));
+  pushRow(
+    rows,
+    `${keyPrefix}-layouts`,
+    `${labelPrefix} Layouts`,
+    peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | '),
+  );
+  pushRow(
+    rows,
+    `${keyPrefix}-targets`,
+    `${labelPrefix} Targets`,
+    peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | '),
+  );
+}

--- a/tools/web_viewer/ui/released_insert_selection_rows.js
+++ b/tools/web_viewer/ui/released_insert_selection_rows.js
@@ -2,10 +2,7 @@ import {
   formatReleasedInsertArchiveModes,
   formatReleasedInsertArchiveOrigin,
 } from './selection_released_archive_helpers.js';
-import {
-  formatPeerContext,
-  formatPeerTarget,
-} from './selection_display_helpers.js';
+import { buildPeerSummaryRows } from './peer_summary_rows.js';
 
 function pushReleasedSelectionRow(rows, key, label, value) {
   if (value === null || value === undefined || value === '') return;
@@ -39,24 +36,6 @@ export function buildReleasedInsertArchiveSelectionRows(selectionSummary) {
     'Released Attribute Modes',
     commonModes || formatReleasedInsertArchiveModes(archive),
   );
-  if (peerSummary?.peerCount > 1) {
-    const peerInstance = peerSummary.currentIndex >= 0
-      ? `${peerSummary.currentIndex + 1} / ${peerSummary.peerCount}`
-      : `Archived / ${peerSummary.peerCount}`;
-    pushReleasedSelectionRow(rows, 'released-peer-instance', 'Released Peer Instance', peerInstance);
-    pushReleasedSelectionRow(rows, 'released-peer-instances', 'Released Peer Instances', String(peerSummary.peerCount));
-    pushReleasedSelectionRow(
-      rows,
-      'released-peer-layouts',
-      'Released Peer Layouts',
-      peerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | '),
-    );
-    pushReleasedSelectionRow(
-      rows,
-      'released-peer-targets',
-      'Released Peer Targets',
-      peerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | '),
-    );
-  }
+  buildPeerSummaryRows(rows, peerSummary, { released: true });
   return rows;
 }


### PR DESCRIPTION
## Summary
- extract shared peer-summary row assembly into a new `peer_summary_rows` leaf helper
- adopt the helper in `group_info_rows` and `released_insert_selection_rows` without changing row ordering or archived wording
- add focused coverage for normal and released peer summary variants

## Verification
- `node --check` on `peer_summary_rows.js`, `group_info_rows.js`, `released_insert_selection_rows.js`
- `node --test` on `peer_summary_rows.test.js`, `group_info_rows.test.js`, `released_insert_selection_rows.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`

## Note
GitHub Actions is currently affected by a repository billing/spending-limit issue that blocks runner start before any job steps execute. Local verification above is the authoritative signal for this PR.
