### PR TITLE
refactor: adopt shared released peer rows

### DIFF
--- a/docs/STEP356_RELEASED_PEER_ROWS_ADOPTION_DESIGN.md
+++ b/docs/STEP356_RELEASED_PEER_ROWS_ADOPTION_DESIGN.md
@@ -1,0 +1,53 @@
+# Step356: Released Peer Rows Adoption
+
+## Goal
+
+Adopt the existing shared peer-summary helper in the last remaining single-selection released-peer path inside:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to remove the remaining hand-written `released-peer-*` row assembly and route it through `peer_summary_rows.js`, matching the Step355 helper seam.
+
+## Scope
+
+In scope:
+
+- Replace manual released-peer row assembly in `buildSelectionDetailFacts(...)` with `buildPeerSummaryRows(..., { released: true })`.
+- Remove now-unused `formatPeerContext(...)` / `formatPeerTarget(...)` imports from `selection_detail_facts.js`.
+- Add focused test coverage for single-selection released peer rows.
+
+Out of scope:
+
+- released archive metadata row extraction
+- multi-selection released archive rows
+- group info row behavior
+- selection presentation contract changes
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Preserve exact released-peer keys, labels, values, and ordering.
+- Preserve `Archived / N` wording when the current peer is not found.
+- Do not change `buildReleasedInsertArchiveSelectionRows(...)` behavior.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Use the existing helper:
+
+- `tools/web_viewer/ui/peer_summary_rows.js`
+
+Expected responsibility split:
+
+- `peer_summary_rows.js`: build peer summary rows
+- `selection_detail_facts.js`: decide when released peer rows should be appended
+
+## Acceptance
+
+Accept Step356 only if:
+
+- `selection_detail_facts.js` no longer hand-builds released peer rows
+- released peer output remains byte-for-byte compatible at the fact level
+- focused tests cover the single-selection released peer path
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP356_RELEASED_PEER_ROWS_ADOPTION_VERIFICATION.md
+++ b/docs/STEP356_RELEASED_PEER_ROWS_ADOPTION_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step356: Released Peer Rows Adoption Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step356-released-peer-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/selection_detail_facts.js
+node --check tools/web_viewer/ui/peer_summary_rows.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/selection_detail_facts.test.js \
+  tools/web_viewer/tests/peer_summary_rows.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_detail_facts.test.js
+++ b/tools/web_viewer/tests/selection_detail_facts.test.js
@@ -170,6 +170,63 @@ test('buildSelectionDetailFacts includes source text position for editable sourc
   assert.equal(facts.find((f) => f.key === 'source-text-pos').value, '5, 10');
 });
 
+test('buildSelectionDetailFacts adopts shared released peer rows for single-selection released inserts', () => {
+  const archive = {
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    editMode: 'proxy',
+    groupId: 700,
+    blockName: 'AttdefBlock',
+    textKind: 'attdef',
+    attributeTag: 'ATTDEF_TAG',
+  };
+  const entity = makeEntity({
+    id: 1,
+    type: 'text',
+    space: 1,
+    layout: 'Layout-A',
+    releasedInsertArchive: archive,
+  });
+  const peerA = makeEntity({
+    id: 2,
+    type: 'text',
+    groupId: 700,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'AttdefBlock',
+    space: 1,
+    layout: 'Layout-A',
+  });
+  const peerB = makeEntity({
+    id: 3,
+    type: 'text',
+    groupId: 700,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'AttdefBlock',
+    space: 1,
+    layout: 'Layout-B',
+  });
+  const peerC = makeEntity({
+    id: 4,
+    type: 'text',
+    groupId: 700,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'AttdefBlock',
+    space: 1,
+    layout: 'Layout-C',
+  });
+
+  const facts = buildSelectionDetailFacts(entity, makeOptions([makeLayer()], [entity, peerA, peerB, peerC]));
+  const byKey = Object.fromEntries(facts.map((fact) => [fact.key, fact.value]));
+
+  assert.equal(byKey['released-peer-instance'], '1 / 3');
+  assert.equal(byKey['released-peer-instances'], '3');
+  assert.equal(byKey['released-peer-layouts'], 'Paper / Layout-A | Paper / Layout-B | Paper / Layout-C');
+  assert.equal(byKey['released-peer-targets'], '1: Paper / Layout-A | 2: Paper / Layout-B | 3: Paper / Layout-C');
+});
+
 test('buildMultiSelectionDetailFacts returns empty for non-released entities', () => {
   const e1 = makeEntity({ id: 1 });
   const e2 = makeEntity({ id: 2 });

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -27,12 +27,11 @@ import {
   normalizeText,
   formatCompactNumber,
   formatPoint,
-  formatPeerContext,
-  formatPeerTarget,
 } from './selection_display_helpers.js';
 import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
+import { buildPeerSummaryRows } from './peer_summary_rows.js';
 import {
   buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
   buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
@@ -138,25 +137,7 @@ export function buildSelectionDetailFacts(entity, options = {}) {
       includeIdentityRows: false,
     });
   facts.push(...groupRows);
-  if (releasedInsertPeerSummary?.peerCount > 1) {
-    const peerInstance = releasedInsertPeerSummary.currentIndex >= 0
-      ? `${releasedInsertPeerSummary.currentIndex + 1} / ${releasedInsertPeerSummary.peerCount}`
-      : `Archived / ${releasedInsertPeerSummary.peerCount}`;
-    pushFact(facts, 'released-peer-instance', 'Released Peer Instance', peerInstance);
-    pushFact(facts, 'released-peer-instances', 'Released Peer Instances', String(releasedInsertPeerSummary.peerCount));
-    pushFact(
-      facts,
-      'released-peer-layouts',
-      'Released Peer Layouts',
-      releasedInsertPeerSummary.peers.map((peer) => formatPeerContext(peer)).filter(Boolean).join(' | ')
-    );
-    pushFact(
-      facts,
-      'released-peer-targets',
-      'Released Peer Targets',
-      releasedInsertPeerSummary.peers.map((peer, index) => formatPeerTarget(peer, index)).filter(Boolean).join(' | ')
-    );
-  }
+  buildPeerSummaryRows(facts, releasedInsertPeerSummary, { released: true });
   pushFact(facts, 'line-type', 'Line Type', normalizeText(effectiveStyle.lineType));
   pushFact(facts, 'line-type-source', 'Line Type Source', styleSources.lineTypeSource);
   if (styleSources.lineWeightSource === 'EXPLICIT' || (Number.isFinite(effectiveStyle.lineWeight) && Number(effectiveStyle.lineWeight) > 0)) {


### PR DESCRIPTION
## Summary
- adopt `buildPeerSummaryRows(..., { released: true })` in the remaining single-selection released peer path
- remove the last hand-written `released-peer-*` block from `selection_detail_facts.js`
- add Step356 design/verification docs and focused test coverage

## Verification
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --check tools/web_viewer/ui/peer_summary_rows.js
- node --test tools/web_viewer/tests/selection_detail_facts.test.js tools/web_viewer/tests/peer_summary_rows.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check

## Scope
This PR only finishes the Step355 helper adoption for single-selection released peer rows. It does not include the broader released archive metadata-row extraction.
