### PR TITLE
refactor: share released archive metadata rows

### DIFF
--- a/docs/STEP357_RELEASED_ARCHIVE_METADATA_ROWS_DESIGN.md
+++ b/docs/STEP357_RELEASED_ARCHIVE_METADATA_ROWS_DESIGN.md
@@ -1,0 +1,56 @@
+# Step357: Released Archive Metadata Rows Extraction
+
+## Goal
+
+Extract shared released-archive metadata row assembly into a dedicated leaf helper used by:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+- `tools/web_viewer/ui/released_insert_selection_rows.js`
+
+The purpose is to remove duplicated released-archive identity and attribute row formatting while preserving current keys, labels, ordering, and wording.
+
+## Scope
+
+In scope:
+
+- Extract shared released-archive identity rows.
+- Extract shared released-archive attribute rows.
+- Adopt the new helper in both single-selection and multi-selection released archive paths.
+- Add focused helper tests for the extracted row assembly.
+
+Out of scope:
+
+- released peer row formatting
+- group info rows
+- selection presentation contract changes
+- note-plan or property-panel behavior
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Keep `buildReleasedInsertArchiveSelectionRows(...)` behavior unchanged.
+- Preserve exact keys, labels, values, and row ordering.
+- Preserve `commonModes` override behavior in multi-selection released archive rows.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new cycle through either caller.
+
+## Expected Shape
+
+Introduce a new leaf helper:
+
+- `tools/web_viewer/ui/released_archive_metadata_rows.js`
+
+Expected responsibility split:
+
+- shared helper: released archive identity + attribute rows
+- callers: choose when to append peer rows or selection-member rows
+
+## Acceptance
+
+Accept Step357 only if:
+
+- the new helper is leaf-level and cycle-safe
+- both callers preserve their exact output contracts
+- focused tests cover helper behavior and ordering
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP357_RELEASED_ARCHIVE_METADATA_ROWS_VERIFICATION.md
+++ b/docs/STEP357_RELEASED_ARCHIVE_METADATA_ROWS_VERIFICATION.md
@@ -1,0 +1,45 @@
+# Step357: Released Archive Metadata Rows Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step357-released-archive-metadata-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/released_archive_metadata_rows.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+node --check tools/web_viewer/ui/released_insert_selection_rows.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/released_archive_metadata_rows.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js \
+  tools/web_viewer/tests/released_insert_selection_rows.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/released_archive_metadata_rows.test.js
+++ b/tools/web_viewer/tests/released_archive_metadata_rows.test.js
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  appendReleasedArchiveIdentityRows,
+  appendReleasedArchiveAttributeRows,
+} from '../ui/released_archive_metadata_rows.js';
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('appendReleasedArchiveIdentityRows does nothing for null archive', () => {
+  const rows = [];
+  appendReleasedArchiveIdentityRows(rows, null);
+  assert.deepEqual(rows, []);
+});
+
+test('appendReleasedArchiveIdentityRows pushes released-from, released-group-id, released-block-name', () => {
+  const rows = [];
+  appendReleasedArchiveIdentityRows(rows, {
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    editMode: 'proxy',
+    groupId: 5,
+    blockName: 'TagBlock',
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'released-from': 'INSERT / text / proxy',
+    'released-group-id': '5',
+    'released-block-name': 'TagBlock',
+  });
+  assert.equal(rows[0].key, 'released-from');
+  assert.equal(rows[1].key, 'released-group-id');
+  assert.equal(rows[2].key, 'released-block-name');
+});
+
+test('appendReleasedArchiveIdentityRows omits optional rows when values are absent', () => {
+  const rows = [];
+  appendReleasedArchiveIdentityRows(rows, {
+    sourceType: 'INSERT',
+  });
+  const keys = rows.map((row) => row.key);
+  assert.ok(keys.includes('released-from'));
+  assert.ok(!keys.includes('released-group-id'));
+  assert.ok(!keys.includes('released-block-name'));
+});
+
+test('appendReleasedArchiveAttributeRows does nothing for null archive', () => {
+  const rows = [];
+  appendReleasedArchiveAttributeRows(rows, null);
+  assert.deepEqual(rows, []);
+});
+
+test('appendReleasedArchiveAttributeRows pushes attribute rows with computed modes', () => {
+  const rows = [];
+  appendReleasedArchiveAttributeRows(rows, {
+    textKind: 'attdef',
+    attributeTag: 'ATTDEF_TAG',
+    attributeDefault: 'ATTDEF_DEFAULT',
+    attributePrompt: 'ATTDEF_PROMPT',
+    attributeFlags: 12,
+    attributeVerify: true,
+    attributePreset: true,
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'released-text-kind': 'attdef',
+    'released-attribute-tag': 'ATTDEF_TAG',
+    'released-attribute-default': 'ATTDEF_DEFAULT',
+    'released-attribute-prompt': 'ATTDEF_PROMPT',
+    'released-attribute-flags': '12',
+    'released-attribute-modes': 'Verify / Preset',
+  });
+});
+
+test('appendReleasedArchiveAttributeRows uses commonModes when provided', () => {
+  const rows = [];
+  appendReleasedArchiveAttributeRows(rows, {
+    textKind: 'attdef',
+    attributeVerify: true,
+    attributePreset: true,
+  }, { commonModes: 'Verify / Preset' });
+
+  assert.equal(toMap(rows)['released-attribute-modes'], 'Verify / Preset');
+});
+
+test('combined single-selection ordering stays stable', () => {
+  const rows = [];
+  const archive = {
+    sourceType: 'INSERT',
+    proxyKind: 'fragment',
+    editMode: '',
+    groupId: 700,
+    blockName: 'TITLEBLOCK',
+    textKind: 'ATTRIB',
+    attributeTag: 'TITLE',
+    attributeDefault: 'My Title',
+    attributePrompt: 'Enter title',
+    attributeFlags: 12,
+    attributeVerify: true,
+    attributePreset: true,
+  };
+
+  appendReleasedArchiveIdentityRows(rows, archive);
+  appendReleasedArchiveAttributeRows(rows, archive);
+
+  assert.deepEqual(rows.map((row) => row.key), [
+    'released-from',
+    'released-group-id',
+    'released-block-name',
+    'released-text-kind',
+    'released-attribute-tag',
+    'released-attribute-default',
+    'released-attribute-prompt',
+    'released-attribute-flags',
+    'released-attribute-modes',
+  ]);
+});
+
+test('combined released-selection ordering stays stable with selection-members row inserted', () => {
+  const rows = [];
+  const archive = {
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    editMode: 'proxy',
+    groupId: 2,
+    blockName: 'AttdefBlock',
+    textKind: 'attdef',
+    attributeTag: 'ATTDEF_TAG',
+    attributeDefault: 'ATTDEF_DEFAULT',
+    attributePrompt: 'ATTDEF_PROMPT',
+    attributeFlags: 12,
+  };
+
+  appendReleasedArchiveIdentityRows(rows, archive);
+  rows.push({ key: 'released-selection-members', label: 'Released Selection Members', value: '2' });
+  appendReleasedArchiveAttributeRows(rows, archive, { commonModes: 'Verify / Preset' });
+
+  assert.deepEqual(rows.map((row) => row.key), [
+    'released-from',
+    'released-group-id',
+    'released-block-name',
+    'released-selection-members',
+    'released-text-kind',
+    'released-attribute-tag',
+    'released-attribute-default',
+    'released-attribute-prompt',
+    'released-attribute-flags',
+    'released-attribute-modes',
+  ]);
+  assert.equal(toMap(rows)['released-attribute-modes'], 'Verify / Preset');
+});

--- a/tools/web_viewer/ui/released_archive_metadata_rows.js
+++ b/tools/web_viewer/ui/released_archive_metadata_rows.js
@@ -1,0 +1,36 @@
+import {
+  formatReleasedInsertArchiveOrigin,
+  formatReleasedInsertArchiveModes,
+} from './selection_released_archive_helpers.js';
+import { normalizeText } from './selection_display_helpers.js';
+
+function pushRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({ key, label, value: String(value) });
+}
+
+export function appendReleasedArchiveIdentityRows(rows, archive) {
+  if (!archive) return;
+  pushRow(rows, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(archive));
+  if (Number.isFinite(archive?.groupId)) {
+    pushRow(rows, 'released-group-id', 'Released Group ID', String(Math.trunc(archive.groupId)));
+  }
+  pushRow(rows, 'released-block-name', 'Released Block Name', normalizeText(archive?.blockName));
+}
+
+export function appendReleasedArchiveAttributeRows(rows, archive, { commonModes } = {}) {
+  if (!archive) return;
+  pushRow(rows, 'released-text-kind', 'Released Text Kind', normalizeText(archive?.textKind));
+  pushRow(rows, 'released-attribute-tag', 'Released Attribute Tag', normalizeText(archive?.attributeTag));
+  pushRow(rows, 'released-attribute-default', 'Released Attribute Default', normalizeText(archive?.attributeDefault));
+  pushRow(rows, 'released-attribute-prompt', 'Released Attribute Prompt', normalizeText(archive?.attributePrompt));
+  if (Number.isFinite(archive?.attributeFlags)) {
+    pushRow(rows, 'released-attribute-flags', 'Released Attribute Flags', String(Math.trunc(archive.attributeFlags)));
+  }
+  pushRow(
+    rows,
+    'released-attribute-modes',
+    'Released Attribute Modes',
+    commonModes || formatReleasedInsertArchiveModes(archive),
+  );
+}

--- a/tools/web_viewer/ui/released_insert_selection_rows.js
+++ b/tools/web_viewer/ui/released_insert_selection_rows.js
@@ -1,7 +1,7 @@
 import {
-  formatReleasedInsertArchiveModes,
-  formatReleasedInsertArchiveOrigin,
-} from './selection_released_archive_helpers.js';
+  appendReleasedArchiveIdentityRows,
+  appendReleasedArchiveAttributeRows,
+} from './released_archive_metadata_rows.js';
 import { buildPeerSummaryRows } from './peer_summary_rows.js';
 
 function pushReleasedSelectionRow(rows, key, label, value) {
@@ -17,25 +17,9 @@ export function buildReleasedInsertArchiveSelectionRows(selectionSummary) {
   if (!selectionSummary?.archive) return [];
   const rows = [];
   const { archive, entityCount, peerSummary, commonModes } = selectionSummary;
-  pushReleasedSelectionRow(rows, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(archive));
-  if (Number.isFinite(archive?.groupId)) {
-    pushReleasedSelectionRow(rows, 'released-group-id', 'Released Group ID', String(Math.trunc(archive.groupId)));
-  }
-  pushReleasedSelectionRow(rows, 'released-block-name', 'Released Block Name', archive?.blockName);
+  appendReleasedArchiveIdentityRows(rows, archive);
   pushReleasedSelectionRow(rows, 'released-selection-members', 'Released Selection Members', String(entityCount));
-  pushReleasedSelectionRow(rows, 'released-text-kind', 'Released Text Kind', archive?.textKind);
-  pushReleasedSelectionRow(rows, 'released-attribute-tag', 'Released Attribute Tag', archive?.attributeTag);
-  pushReleasedSelectionRow(rows, 'released-attribute-default', 'Released Attribute Default', archive?.attributeDefault);
-  pushReleasedSelectionRow(rows, 'released-attribute-prompt', 'Released Attribute Prompt', archive?.attributePrompt);
-  if (Number.isFinite(archive?.attributeFlags)) {
-    pushReleasedSelectionRow(rows, 'released-attribute-flags', 'Released Attribute Flags', String(Math.trunc(archive.attributeFlags)));
-  }
-  pushReleasedSelectionRow(
-    rows,
-    'released-attribute-modes',
-    'Released Attribute Modes',
-    commonModes || formatReleasedInsertArchiveModes(archive),
-  );
+  appendReleasedArchiveAttributeRows(rows, archive, { commonModes });
   buildPeerSummaryRows(rows, peerSummary, { released: true });
   return rows;
 }

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -19,8 +19,6 @@ import {
   isReadOnlySelectionEntity,
 } from './selection_meta_helpers.js';
 import {
-  formatReleasedInsertArchiveOrigin,
-  formatReleasedInsertArchiveModes,
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 import {
@@ -32,6 +30,10 @@ import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 import { buildPeerSummaryRows } from './peer_summary_rows.js';
+import {
+  appendReleasedArchiveIdentityRows,
+  appendReleasedArchiveAttributeRows,
+} from './released_archive_metadata_rows.js';
 import {
   buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
   buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
@@ -111,19 +113,8 @@ export function buildSelectionDetailFacts(entity, options = {}) {
   }
   pushFact(facts, 'attribute-modes', 'Attribute Modes', formatSelectionAttributeModes(entity));
   const releasedInsertArchive = resolveReleasedInsertArchive(entity);
-  pushFact(facts, 'released-from', 'Released From', formatReleasedInsertArchiveOrigin(releasedInsertArchive));
-  if (Number.isFinite(releasedInsertArchive?.groupId)) {
-    pushFact(facts, 'released-group-id', 'Released Group ID', String(Math.trunc(releasedInsertArchive.groupId)));
-  }
-  pushFact(facts, 'released-block-name', 'Released Block Name', normalizeText(releasedInsertArchive?.blockName));
-  pushFact(facts, 'released-text-kind', 'Released Text Kind', normalizeText(releasedInsertArchive?.textKind));
-  pushFact(facts, 'released-attribute-tag', 'Released Attribute Tag', normalizeText(releasedInsertArchive?.attributeTag));
-  pushFact(facts, 'released-attribute-default', 'Released Attribute Default', normalizeText(releasedInsertArchive?.attributeDefault));
-  pushFact(facts, 'released-attribute-prompt', 'Released Attribute Prompt', normalizeText(releasedInsertArchive?.attributePrompt));
-  if (Number.isFinite(releasedInsertArchive?.attributeFlags)) {
-    pushFact(facts, 'released-attribute-flags', 'Released Attribute Flags', String(Math.trunc(releasedInsertArchive.attributeFlags)));
-  }
-  pushFact(facts, 'released-attribute-modes', 'Released Attribute Modes', formatReleasedInsertArchiveModes(releasedInsertArchive));
+  appendReleasedArchiveIdentityRows(facts, releasedInsertArchive);
+  appendReleasedArchiveAttributeRows(facts, releasedInsertArchive);
   const groupRows = insertGroupSummary
     ? buildSharedInsertGroupInfoRows(entity, insertGroupSummary, {
       listEntities,


### PR DESCRIPTION
## Summary
- extract shared released archive identity + attribute rows into `released_archive_metadata_rows.js`
- adopt the new helper in `selection_detail_facts.js` and `released_insert_selection_rows.js`
- add Step357 design/verification docs and focused helper coverage

## Verification
- node --check tools/web_viewer/ui/released_archive_metadata_rows.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --check tools/web_viewer/ui/released_insert_selection_rows.js
- node --test tools/web_viewer/tests/released_archive_metadata_rows.test.js tools/web_viewer/tests/selection_detail_facts.test.js tools/web_viewer/tests/released_insert_selection_rows.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check

## Scope
This PR only extracts released archive metadata rows. Released peer rows stay on the existing shared helper path from Step355/356.
