### PR TITLE
refactor: share source text guide rows

### DIFF
--- a/docs/STEP358_SOURCE_TEXT_GUIDE_ROWS_DESIGN.md
+++ b/docs/STEP358_SOURCE_TEXT_GUIDE_ROWS_DESIGN.md
@@ -1,0 +1,64 @@
+# Step358: Source Text Guide Rows Extraction
+
+## Goal
+
+Extract the source-text and leader-guide detail-fact assembly from:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to isolate the last source-text guide row block into a dedicated helper without changing any fact keys, values, or ordering.
+
+## Scope
+
+In scope:
+
+- Extract source text position row assembly.
+- Extract source text rotation row assembly.
+- Extract source anchor / leader guide / source offset row assembly.
+- Keep the extracted helper leaf-level and cycle-safe.
+
+Out of scope:
+
+- origin/layer/style fact rows
+- source/insert group rows
+- released archive metadata rows
+- released peer rows
+- selection presentation contract changes
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Preserve exact keys, labels, values, and row ordering for:
+  - `source-text-pos`
+  - `source-text-rotation`
+  - `source-anchor`
+  - `leader-landing`
+  - `leader-elbow`
+  - `leader-landing-length`
+  - `source-anchor-driver`
+  - `source-offset`
+  - `current-offset`
+- Do not change `resolveSourceTextGuide(...)` behavior.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/source_text_guide_rows.js`
+
+Expected responsibility split:
+
+- helper: append source-text and leader-guide rows
+- `selection_detail_facts.js`: decide when guide rows should be included
+
+## Acceptance
+
+Accept Step358 only if:
+
+- `selection_detail_facts.js` no longer hand-builds source-text guide rows
+- output remains fact-for-fact compatible
+- focused tests cover the extracted guide row paths
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP358_SOURCE_TEXT_GUIDE_ROWS_VERIFICATION.md
+++ b/docs/STEP358_SOURCE_TEXT_GUIDE_ROWS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step358: Source Text Guide Rows Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step358-source-text-guide-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/source_text_guide_rows.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/source_text_guide_rows.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_detail_facts.test.js
+++ b/tools/web_viewer/tests/selection_detail_facts.test.js
@@ -170,6 +170,89 @@ test('buildSelectionDetailFacts includes source text position for editable sourc
   assert.equal(facts.find((f) => f.key === 'source-text-pos').value, '5, 10');
 });
 
+test('buildSelectionDetailFacts includes DIMENSION source guide rows for editable source text', () => {
+  const entities = [{
+    id: 31,
+    type: 'line',
+    layerId: 1,
+    color: '#5a6b7c',
+    colorSource: 'TRUECOLOR',
+    space: 1,
+    layout: 'Layout-A',
+    sourceType: 'DIMENSION',
+    editMode: 'proxy',
+    proxyKind: 'dimension',
+    groupId: 700,
+    start: { x: -10, y: 0 },
+    end: { x: 10, y: 0 },
+  }, {
+    id: 34,
+    type: 'text',
+    layerId: 1,
+    color: '#5a6b7c',
+    colorSource: 'TRUECOLOR',
+    space: 1,
+    layout: 'Layout-A',
+    sourceType: 'DIMENSION',
+    editMode: 'proxy',
+    proxyKind: 'dimension',
+    groupId: 700,
+    position: { x: 4, y: 18 },
+    sourceTextPos: { x: 0, y: 14 },
+    sourceTextRotation: 0,
+    rotation: 0.5,
+  }];
+
+  const facts = buildSelectionDetailFacts(entities[1], makeOptions([makeLayer({ id: 1, name: 'REF' })], entities));
+  const byKey = Object.fromEntries(facts.map((fact) => [fact.key, fact.value]));
+
+  assert.equal(byKey['source-anchor'], '0, 0');
+  assert.equal(byKey['source-anchor-driver'], '31:line midpoint');
+  assert.equal(byKey['source-offset'], '0, 14');
+  assert.equal(byKey['current-offset'], '4, 18');
+});
+
+test('buildSelectionDetailFacts includes LEADER landing rows for editable source text', () => {
+  const entities = [{
+    id: 41,
+    type: 'line',
+    layerId: 1,
+    color: '#5a6b7c',
+    colorSource: 'TRUECOLOR',
+    space: 1,
+    layout: 'Layout-A',
+    sourceType: 'LEADER',
+    editMode: 'proxy',
+    proxyKind: 'leader',
+    groupId: 702,
+    start: { x: 50, y: 0 },
+    end: { x: 56, y: 6 },
+  }, {
+    id: 42,
+    type: 'text',
+    layerId: 1,
+    color: '#5a6b7c',
+    colorSource: 'TRUECOLOR',
+    space: 1,
+    layout: 'Layout-A',
+    sourceType: 'LEADER',
+    editMode: 'proxy',
+    proxyKind: 'leader',
+    groupId: 702,
+    position: { x: 63, y: 9 },
+    sourceTextPos: { x: 58, y: 7 },
+    sourceTextRotation: 0,
+    rotation: 0.3926990817,
+  }];
+
+  const facts = buildSelectionDetailFacts(entities[1], makeOptions([makeLayer({ id: 1, name: 'REF' })], entities));
+  const byKey = Object.fromEntries(facts.map((fact) => [fact.key, fact.value]));
+
+  assert.equal(byKey['leader-landing'], '56, 6');
+  assert.equal(byKey['leader-elbow'], '50, 0');
+  assert.equal(byKey['leader-landing-length'], '8.485');
+});
+
 test('buildSelectionDetailFacts adopts shared released peer rows for single-selection released inserts', () => {
   const archive = {
     sourceType: 'INSERT',

--- a/tools/web_viewer/tests/source_text_guide_rows.test.js
+++ b/tools/web_viewer/tests/source_text_guide_rows.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSourceTextGuideRows } from '../ui/source_text_guide_rows.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'text',
+    sourceType: 'DIMENSION',
+    editMode: 'proxy',
+    proxyKind: 'text',
+    sourceTextPos: { x: 5, y: 10 },
+    sourceTextRotation: 0,
+    ...overrides,
+  };
+}
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('appendSourceTextGuideRows does nothing for null entity', () => {
+  const rows = [];
+  appendSourceTextGuideRows(rows, null, null);
+  assert.deepEqual(rows, []);
+});
+
+test('appendSourceTextGuideRows adds source text position and rotation rows', () => {
+  const rows = [];
+  appendSourceTextGuideRows(rows, makeEntity(), null);
+
+  assert.deepEqual(toMap(rows), {
+    'source-text-pos': '5, 10',
+    'source-text-rotation': '0',
+  });
+});
+
+test('appendSourceTextGuideRows omits guide-only rows for non-editable source text entities', () => {
+  const rows = [];
+  appendSourceTextGuideRows(rows, makeEntity({ editMode: '' }), {
+    anchor: { x: 0, y: 0 },
+    sourceOffset: { x: 0, y: 14 },
+  });
+
+  assert.deepEqual(rows.map((row) => row.key), ['source-text-pos', 'source-text-rotation']);
+});
+
+test('appendSourceTextGuideRows appends dimension anchor and offset rows', () => {
+  const rows = [];
+  appendSourceTextGuideRows(rows, makeEntity(), {
+    sourceType: 'DIMENSION',
+    anchor: { x: 0, y: 0 },
+    anchorDriverId: 31,
+    anchorDriverLabel: 'line midpoint',
+    sourceOffset: { x: 0, y: 14 },
+    currentOffset: { x: 4, y: 18 },
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'source-text-pos': '5, 10',
+    'source-text-rotation': '0',
+    'source-anchor': '0, 0',
+    'source-anchor-driver': '31:line midpoint',
+    'source-offset': '0, 14',
+    'current-offset': '4, 18',
+  });
+  assert.deepEqual(rows.map((row) => row.key), [
+    'source-text-pos',
+    'source-text-rotation',
+    'source-anchor',
+    'source-anchor-driver',
+    'source-offset',
+    'current-offset',
+  ]);
+});
+
+test('appendSourceTextGuideRows appends leader landing rows', () => {
+  const rows = [];
+  appendSourceTextGuideRows(rows, makeEntity({ sourceType: 'LEADER' }), {
+    sourceType: 'LEADER',
+    anchor: { x: 56, y: 6 },
+    landingPoint: { x: 56, y: 6 },
+    elbowPoint: { x: 50, y: 0 },
+    landingLength: 8.485281374,
+  });
+
+  assert.deepEqual(toMap(rows), {
+    'source-text-pos': '5, 10',
+    'source-text-rotation': '0',
+    'source-anchor': '56, 6',
+    'leader-landing': '56, 6',
+    'leader-elbow': '50, 0',
+    'leader-landing-length': '8.485',
+  });
+  assert.deepEqual(rows.map((row) => row.key), [
+    'source-text-pos',
+    'source-text-rotation',
+    'source-anchor',
+    'leader-landing',
+    'leader-elbow',
+    'leader-landing-length',
+  ]);
+});

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -1,6 +1,5 @@
 import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
 import {
-  isDirectEditableSourceTextEntity,
   isInsertGroupEntity,
   isSourceGroupEntity,
   resolveSourceTextGuide,
@@ -23,8 +22,6 @@ import {
 } from './selection_released_archive_helpers.js';
 import {
   normalizeText,
-  formatCompactNumber,
-  formatPoint,
 } from './selection_display_helpers.js';
 import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
@@ -38,6 +35,7 @@ import {
   buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
   buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
 } from './group_info_rows.js';
+import { appendSourceTextGuideRows } from './source_text_guide_rows.js';
 
 function pushFact(facts, key, label, value, extra = {}) {
   if (value === null || value === undefined || value === '') return;
@@ -139,35 +137,6 @@ export function buildSelectionDetailFacts(entity, options = {}) {
     pushFact(facts, 'line-type-scale', 'Line Type Scale', String(effectiveStyle.lineTypeScale));
   }
   pushFact(facts, 'line-type-scale-source', 'Line Type Scale Source', styleSources.lineTypeScaleSource);
-  if (entity.sourceTextPos && Number.isFinite(entity.sourceTextPos.x) && Number.isFinite(entity.sourceTextPos.y)) {
-    pushFact(facts, 'source-text-pos', 'Source Text Pos', formatPoint(entity.sourceTextPos));
-  }
-  if (Number.isFinite(entity.sourceTextRotation)) {
-    pushFact(facts, 'source-text-rotation', 'Source Text Rotation', formatCompactNumber(entity.sourceTextRotation));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.anchor) {
-    pushFact(facts, 'source-anchor', 'Source Anchor', formatPoint(sourceTextGuide.anchor));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && sourceTextGuide?.landingPoint) {
-    pushFact(facts, 'leader-landing', 'Leader Landing', formatPoint(sourceTextGuide.landingPoint));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && sourceTextGuide?.elbowPoint) {
-    pushFact(facts, 'leader-elbow', 'Leader Elbow', formatPoint(sourceTextGuide.elbowPoint));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && Number.isFinite(sourceTextGuide?.landingLength)) {
-    pushFact(facts, 'leader-landing-length', 'Leader Landing Length', formatCompactNumber(sourceTextGuide.landingLength));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.anchorDriverId) {
-    const driverValue = sourceTextGuide?.anchorDriverLabel
-      ? `${sourceTextGuide.anchorDriverId}:${sourceTextGuide.anchorDriverLabel}`
-      : String(sourceTextGuide.anchorDriverId);
-    pushFact(facts, 'source-anchor-driver', 'Source Anchor Driver', driverValue);
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceOffset) {
-    pushFact(facts, 'source-offset', 'Source Offset', formatPoint(sourceTextGuide.sourceOffset));
-  }
-  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.currentOffset) {
-    pushFact(facts, 'current-offset', 'Current Offset', formatPoint(sourceTextGuide.currentOffset));
-  }
+  appendSourceTextGuideRows(facts, entity, sourceTextGuide);
   return facts;
 }

--- a/tools/web_viewer/ui/source_text_guide_rows.js
+++ b/tools/web_viewer/ui/source_text_guide_rows.js
@@ -1,0 +1,40 @@
+import { isDirectEditableSourceTextEntity } from '../insert_group.js';
+import { formatCompactNumber, formatPoint } from './selection_display_helpers.js';
+
+function pushRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({ key, label, value: String(value) });
+}
+
+export function appendSourceTextGuideRows(rows, entity, sourceTextGuide) {
+  if (entity?.sourceTextPos && Number.isFinite(entity.sourceTextPos.x) && Number.isFinite(entity.sourceTextPos.y)) {
+    pushRow(rows, 'source-text-pos', 'Source Text Pos', formatPoint(entity.sourceTextPos));
+  }
+  if (Number.isFinite(entity?.sourceTextRotation)) {
+    pushRow(rows, 'source-text-rotation', 'Source Text Rotation', formatCompactNumber(entity.sourceTextRotation));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.anchor) {
+    pushRow(rows, 'source-anchor', 'Source Anchor', formatPoint(sourceTextGuide.anchor));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && sourceTextGuide?.landingPoint) {
+    pushRow(rows, 'leader-landing', 'Leader Landing', formatPoint(sourceTextGuide.landingPoint));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && sourceTextGuide?.elbowPoint) {
+    pushRow(rows, 'leader-elbow', 'Leader Elbow', formatPoint(sourceTextGuide.elbowPoint));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceType === 'LEADER' && Number.isFinite(sourceTextGuide?.landingLength)) {
+    pushRow(rows, 'leader-landing-length', 'Leader Landing Length', formatCompactNumber(sourceTextGuide.landingLength));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.anchorDriverId) {
+    const driverValue = sourceTextGuide?.anchorDriverLabel
+      ? `${sourceTextGuide.anchorDriverId}:${sourceTextGuide.anchorDriverLabel}`
+      : String(sourceTextGuide.anchorDriverId);
+    pushRow(rows, 'source-anchor-driver', 'Source Anchor Driver', driverValue);
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.sourceOffset) {
+    pushRow(rows, 'source-offset', 'Source Offset', formatPoint(sourceTextGuide.sourceOffset));
+  }
+  if (isDirectEditableSourceTextEntity(entity) && sourceTextGuide?.currentOffset) {
+    pushRow(rows, 'current-offset', 'Current Offset', formatPoint(sourceTextGuide.currentOffset));
+  }
+}


### PR DESCRIPTION
## Summary
- extract source-text / leader-guide detail rows into `source_text_guide_rows.js`
- adopt the new helper in `selection_detail_facts.js`
- add Step358 design/verification docs and focused guide-row coverage

## Verification
- node --check tools/web_viewer/ui/source_text_guide_rows.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --test tools/web_viewer/tests/source_text_guide_rows.test.js tools/web_viewer/tests/selection_detail_facts.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check

## Scope
This PR only extracts source-text / leader-guide rows. It does not change released archive rows, peer rows, group rows, or selection presentation contract behavior.
