### PR TITLE
refactor: share selection line style rows

### DIFF
--- a/docs/STEP359_SELECTION_LINE_STYLE_ROWS_DESIGN.md
+++ b/docs/STEP359_SELECTION_LINE_STYLE_ROWS_DESIGN.md
@@ -1,0 +1,64 @@
+# Step359: Selection Line Style Rows Extraction
+
+## Goal
+
+Extract the line-style detail-fact assembly from:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to isolate the last line-style row block into a dedicated helper without changing any fact keys, values, ordering, or conditional omissions.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `line-type`
+  - `line-type-source`
+  - `line-weight`
+  - `line-weight-source`
+  - `line-type-scale`
+  - `line-type-scale-source`
+- Keep the extracted helper leaf-level and cycle-safe.
+
+Out of scope:
+
+- effective color rows
+- origin/layer/space/layout rows
+- group rows
+- released archive rows
+- source-text guide rows
+- selection presentation contract changes
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Preserve exact keys, labels, values, and row ordering.
+- Preserve the current `line-weight` omission rule:
+  - include when `lineWeightSource === 'EXPLICIT'`
+  - or when `effectiveStyle.lineWeight > 0`
+- Preserve the current `line-type-scale` omission rule.
+- Do not change effective-style resolution or style-source resolution.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/selection_line_style_rows.js`
+
+Expected responsibility split:
+
+- helper: append line-style rows from `effectiveStyle` and `styleSources`
+- `selection_detail_facts.js`: decide where the style-row block appears
+
+## Acceptance
+
+Accept Step359 only if:
+
+- `selection_detail_facts.js` no longer hand-builds line-style rows
+- output remains fact-for-fact compatible
+- focused tests cover omission and ordering rules
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP359_SELECTION_LINE_STYLE_ROWS_VERIFICATION.md
+++ b/docs/STEP359_SELECTION_LINE_STYLE_ROWS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step359: Selection Line Style Rows Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step359-selection-line-style-rows`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/selection_line_style_rows.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/selection_line_style_rows.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_line_style_rows.test.js
+++ b/tools/web_viewer/tests/selection_line_style_rows.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSelectionLineStyleRows } from '../ui/selection_line_style_rows.js';
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('appendSelectionLineStyleRows appends all rows in stable order for explicit style values', () => {
+  const rows = [];
+  appendSelectionLineStyleRows(rows, {
+    lineType: 'CENTER',
+    lineWeight: 0.35,
+    lineTypeScale: 1.25,
+  }, {
+    lineTypeSource: 'EXPLICIT',
+    lineWeightSource: 'EXPLICIT',
+    lineTypeScaleSource: 'EXPLICIT',
+  });
+
+  assert.deepEqual(rows.map((row) => row.key), [
+    'line-type',
+    'line-type-source',
+    'line-weight',
+    'line-weight-source',
+    'line-type-scale',
+    'line-type-scale-source',
+  ]);
+  assert.deepEqual(toMap(rows), {
+    'line-type': 'CENTER',
+    'line-type-source': 'EXPLICIT',
+    'line-weight': '0.35',
+    'line-weight-source': 'EXPLICIT',
+    'line-type-scale': '1.25',
+    'line-type-scale-source': 'EXPLICIT',
+  });
+});
+
+test('appendSelectionLineStyleRows keeps line-weight for positive BYLAYER effective weight', () => {
+  const rows = [];
+  appendSelectionLineStyleRows(rows, {
+    lineType: 'CENTER',
+    lineWeight: 0.35,
+    lineTypeScale: 1,
+  }, {
+    lineTypeSource: 'BYLAYER',
+    lineWeightSource: 'BYLAYER',
+    lineTypeScaleSource: 'DEFAULT',
+  });
+
+  assert.equal(toMap(rows)['line-weight'], '0.35');
+  assert.equal(toMap(rows)['line-weight-source'], 'BYLAYER');
+});
+
+test('appendSelectionLineStyleRows omits line-weight when non-explicit and zero', () => {
+  const rows = [];
+  appendSelectionLineStyleRows(rows, {
+    lineType: 'CONTINUOUS',
+    lineWeight: 0,
+    lineTypeScale: 1,
+  }, {
+    lineTypeSource: 'BYLAYER',
+    lineWeightSource: 'BYLAYER',
+    lineTypeScaleSource: 'DEFAULT',
+  });
+
+  const keys = rows.map((row) => row.key);
+  assert.ok(!keys.includes('line-weight'));
+  assert.ok(keys.includes('line-weight-source'));
+});
+
+test('appendSelectionLineStyleRows omits line-type-scale when not finite', () => {
+  const rows = [];
+  appendSelectionLineStyleRows(rows, {
+    lineType: 'CONTINUOUS',
+    lineWeight: 0,
+    lineTypeScale: null,
+  }, {
+    lineTypeSource: 'BYLAYER',
+    lineWeightSource: 'BYLAYER',
+    lineTypeScaleSource: 'DEFAULT',
+  });
+
+  const keys = rows.map((row) => row.key);
+  assert.ok(!keys.includes('line-type-scale'));
+  assert.ok(keys.includes('line-type-scale-source'));
+});

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -27,6 +27,7 @@ import { resolveLayer } from './selection_layer_helpers.js';
 import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 import { buildPeerSummaryRows } from './peer_summary_rows.js';
+import { appendSelectionLineStyleRows } from './selection_line_style_rows.js';
 import {
   appendReleasedArchiveIdentityRows,
   appendReleasedArchiveAttributeRows,
@@ -127,16 +128,7 @@ export function buildSelectionDetailFacts(entity, options = {}) {
     });
   facts.push(...groupRows);
   buildPeerSummaryRows(facts, releasedInsertPeerSummary, { released: true });
-  pushFact(facts, 'line-type', 'Line Type', normalizeText(effectiveStyle.lineType));
-  pushFact(facts, 'line-type-source', 'Line Type Source', styleSources.lineTypeSource);
-  if (styleSources.lineWeightSource === 'EXPLICIT' || (Number.isFinite(effectiveStyle.lineWeight) && Number(effectiveStyle.lineWeight) > 0)) {
-    pushFact(facts, 'line-weight', 'Line Weight', String(effectiveStyle.lineWeight));
-  }
-  pushFact(facts, 'line-weight-source', 'Line Weight Source', styleSources.lineWeightSource);
-  if (Number.isFinite(effectiveStyle.lineTypeScale)) {
-    pushFact(facts, 'line-type-scale', 'Line Type Scale', String(effectiveStyle.lineTypeScale));
-  }
-  pushFact(facts, 'line-type-scale-source', 'Line Type Scale Source', styleSources.lineTypeScaleSource);
+  appendSelectionLineStyleRows(facts, effectiveStyle, styleSources);
   appendSourceTextGuideRows(facts, entity, sourceTextGuide);
   return facts;
 }

--- a/tools/web_viewer/ui/selection_line_style_rows.js
+++ b/tools/web_viewer/ui/selection_line_style_rows.js
@@ -1,0 +1,23 @@
+import { normalizeText } from './selection_display_helpers.js';
+
+function pushRow(rows, key, label, value) {
+  if (value === null || value === undefined || value === '') return;
+  rows.push({
+    key,
+    label,
+    value: String(value),
+  });
+}
+
+export function appendSelectionLineStyleRows(rows, effectiveStyle, styleSources) {
+  pushRow(rows, 'line-type', 'Line Type', normalizeText(effectiveStyle?.lineType));
+  pushRow(rows, 'line-type-source', 'Line Type Source', styleSources?.lineTypeSource);
+  if (styleSources?.lineWeightSource === 'EXPLICIT' || (Number.isFinite(effectiveStyle?.lineWeight) && Number(effectiveStyle.lineWeight) > 0)) {
+    pushRow(rows, 'line-weight', 'Line Weight', String(effectiveStyle.lineWeight));
+  }
+  pushRow(rows, 'line-weight-source', 'Line Weight Source', styleSources?.lineWeightSource);
+  if (Number.isFinite(effectiveStyle?.lineTypeScale)) {
+    pushRow(rows, 'line-type-scale', 'Line Type Scale', String(effectiveStyle.lineTypeScale));
+  }
+  pushRow(rows, 'line-type-scale-source', 'Line Type Scale Source', styleSources?.lineTypeScaleSource);
+}


### PR DESCRIPTION
## Summary
- extract line-style detail rows into `selection_line_style_rows.js`
- adopt the new helper in `selection_detail_facts.js`
- keep omission rules and row ordering unchanged

## Verification
- node --check tools/web_viewer/ui/selection_line_style_rows.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --test tools/web_viewer/tests/selection_line_style_rows.test.js tools/web_viewer/tests/selection_detail_facts.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check

## Scope
This PR only extracts line-style rows. It does not change released archive rows, peer rows, source-text guide rows, group rows, or selection presentation contract behavior.
