### PR TITLE
refactor: share selection base facts

### DIFF
--- a/docs/STEP360_SELECTION_BASE_FACTS_DESIGN.md
+++ b/docs/STEP360_SELECTION_BASE_FACTS_DESIGN.md
@@ -1,0 +1,75 @@
+# Step360: Selection Base Facts Extraction
+
+## Goal
+
+Extract the remaining base single-selection fact assembly from:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to isolate the pre-released-archive, pre-group, pre-line-style, pre-guide fact block into a dedicated helper without changing any fact keys, values, ordering, or omission rules.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `origin`
+  - `layer`
+  - `layer-color`
+  - `layer-state`
+  - `entity-visibility`
+  - `effective-color`
+  - `color-source`
+  - `color-aci`
+  - `space`
+  - `layout`
+  - `group-id`
+  - `group-source`
+  - `source-bundle-id`
+  - `block-name`
+  - `text-kind`
+  - `attribute-tag`
+  - `attribute-default`
+  - `attribute-prompt`
+  - `attribute-flags`
+  - `attribute-modes`
+- Keep the extracted helper leaf-level and cycle-safe.
+
+Out of scope:
+
+- released archive rows
+- group rows
+- released peer rows
+- line-style rows
+- source-text guide rows
+- multi-selection released archive rows
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Preserve exact keys, labels, values, swatches, and row ordering.
+- Preserve current omission rules for optional values.
+- Do not change layer resolution, effective-color resolution, or attribute-mode formatting behavior.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/selection_base_facts.js`
+
+Expected responsibility split:
+
+- helper: append base single-selection rows
+- `selection_detail_facts.js`: orchestrate base rows plus extracted released/group/style/guide helpers
+
+## Acceptance
+
+Accept Step360 only if:
+
+- `selection_detail_facts.js` no longer hand-builds the base fact block
+- output remains fact-for-fact compatible
+- focused tests cover ordering, swatch propagation, and omission rules
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP360_SELECTION_BASE_FACTS_VERIFICATION.md
+++ b/docs/STEP360_SELECTION_BASE_FACTS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step360: Selection Base Facts Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step360-selection-base-facts`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/selection_base_facts.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/selection_base_facts.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_base_facts.test.js
+++ b/tools/web_viewer/tests/selection_base_facts.test.js
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSelectionBaseFacts } from '../ui/selection_base_facts.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 1,
+    visible: true,
+    colorSource: 'BYLAYER',
+    space: 0,
+    layout: 'Model',
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'L1',
+    color: '#9ca3af',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+function toMap(rows) {
+  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+}
+
+test('appendSelectionBaseFacts preserves stable base row order and swatches for plain entities', () => {
+  const layer = makeLayer();
+  const rows = [];
+  appendSelectionBaseFacts(rows, makeEntity(), {
+    getLayer: (id) => (id === 1 ? layer : null),
+    effectiveColor: '#9ca3af',
+  });
+
+  assert.deepEqual(rows.map((row) => row.key), [
+    'layer',
+    'layer-color',
+    'layer-state',
+    'entity-visibility',
+    'effective-color',
+    'color-source',
+    'space',
+    'layout',
+  ]);
+  assert.equal(rows.find((row) => row.key === 'layer-color').swatch, '#9ca3af');
+  assert.equal(rows.find((row) => row.key === 'effective-color').swatch, '#9ca3af');
+});
+
+test('appendSelectionBaseFacts includes source-group and source-bundle rows when applicable', () => {
+  const rows = [];
+  appendSelectionBaseFacts(rows, makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'dimension',
+    groupId: 700,
+    sourceBundleId: 701,
+  }), {
+    getLayer: () => makeLayer(),
+    effectiveColor: '#5a6b7c',
+  });
+
+  const byKey = toMap(rows);
+  assert.equal(byKey['group-id'], '700');
+  assert.equal(byKey['group-source'], 'DIMENSION / dimension');
+  assert.equal(byKey['source-bundle-id'], '701');
+});
+
+test('appendSelectionBaseFacts omits source-bundle-id when it matches group-id', () => {
+  const rows = [];
+  appendSelectionBaseFacts(rows, makeEntity({
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    groupId: 500,
+    sourceBundleId: 500,
+  }), {
+    getLayer: () => makeLayer(),
+    effectiveColor: '#5a6b7c',
+  });
+
+  assert.ok(!rows.some((row) => row.key === 'source-bundle-id'));
+});
+
+test('appendSelectionBaseFacts includes attribute rows and modes when present', () => {
+  const rows = [];
+  appendSelectionBaseFacts(rows, makeEntity({
+    type: 'text',
+    textKind: 'attdef',
+    attributeTag: 'ATTDEF_TAG',
+    attributeDefault: 'ATTDEF_DEFAULT',
+    attributePrompt: 'ATTDEF_PROMPT',
+    attributeFlags: 12,
+    attributeVerify: true,
+    attributePreset: true,
+  }), {
+    getLayer: () => makeLayer(),
+    effectiveColor: '#5a6b7c',
+  });
+
+  const byKey = toMap(rows);
+  assert.equal(byKey['text-kind'], 'attdef');
+  assert.equal(byKey['attribute-tag'], 'ATTDEF_TAG');
+  assert.equal(byKey['attribute-default'], 'ATTDEF_DEFAULT');
+  assert.equal(byKey['attribute-prompt'], 'ATTDEF_PROMPT');
+  assert.equal(byKey['attribute-flags'], '12');
+  assert.equal(byKey['attribute-modes'], 'Verify / Preset');
+});
+
+test('appendSelectionBaseFacts omits optional rows for empty values', () => {
+  const rows = [];
+  appendSelectionBaseFacts(rows, makeEntity({
+    colorSource: '',
+    layout: '',
+    blockName: '',
+    textKind: '',
+    attributeTag: '',
+    attributeDefault: '',
+    attributePrompt: '',
+    attributeFlags: null,
+  }), {
+    getLayer: () => makeLayer({ name: '' }),
+    effectiveColor: '',
+  });
+
+  const keys = rows.map((row) => row.key);
+  assert.ok(!keys.includes('effective-color'));
+  assert.ok(!keys.includes('block-name'));
+  assert.ok(!keys.includes('text-kind'));
+  assert.ok(!keys.includes('attribute-flags'));
+});

--- a/tools/web_viewer/ui/selection_base_facts.js
+++ b/tools/web_viewer/ui/selection_base_facts.js
@@ -1,0 +1,61 @@
+import { isSourceGroupEntity } from '../insert_group.js';
+import { formatSpaceLabel } from '../space_layout.js';
+import {
+  describeSelectionOrigin,
+  formatSelectionLayer,
+  formatSelectionLayerColor,
+  formatSelectionLayerState,
+} from './selection_meta_helpers.js';
+import { normalizeText } from './selection_display_helpers.js';
+import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
+
+function pushFact(facts, key, label, value, extra = {}) {
+  if (value === null || value === undefined || value === '') return;
+  facts.push({
+    key,
+    label,
+    value: String(value),
+    ...extra,
+  });
+}
+
+function formatSourceGroup(entity) {
+  const sourceType = normalizeText(entity?.sourceType);
+  const proxyKind = normalizeText(entity?.proxyKind);
+  return [sourceType, proxyKind].filter(Boolean).join(' / ');
+}
+
+export function appendSelectionBaseFacts(facts, entity, { getLayer = null, effectiveColor = null } = {}) {
+  pushFact(facts, 'origin', 'Origin', describeSelectionOrigin(entity, { separator: ' / ', includeReadOnly: true }));
+  pushFact(facts, 'layer', 'Layer', formatSelectionLayer(entity, getLayer));
+  const layerColor = formatSelectionLayerColor(entity, getLayer);
+  pushFact(facts, 'layer-color', 'Layer Color', layerColor, { swatch: layerColor || undefined });
+  pushFact(facts, 'layer-state', 'Layer State', formatSelectionLayerState(entity, getLayer));
+  pushFact(facts, 'entity-visibility', 'Entity Visibility', entity?.visible === false ? 'Hidden' : 'Shown');
+  const normalizedEffectiveColor = normalizeText(effectiveColor);
+  pushFact(facts, 'effective-color', 'Effective Color', normalizedEffectiveColor, { swatch: normalizedEffectiveColor || undefined });
+  pushFact(facts, 'color-source', 'Color Source', normalizeText(entity?.colorSource));
+  if (Number.isFinite(entity?.colorAci)) {
+    pushFact(facts, 'color-aci', 'Color ACI', String(entity.colorAci));
+  }
+  pushFact(facts, 'space', 'Space', formatSpaceLabel(entity?.space));
+  pushFact(facts, 'layout', 'Layout', normalizeText(entity?.layout));
+  if (Number.isFinite(entity?.groupId)) {
+    pushFact(facts, 'group-id', 'Group ID', String(Math.trunc(entity.groupId)));
+  }
+  if (isSourceGroupEntity(entity)) {
+    pushFact(facts, 'group-source', 'Group Source', formatSourceGroup(entity));
+  }
+  if (Number.isFinite(entity?.sourceBundleId) && (!Number.isFinite(entity?.groupId) || Math.trunc(entity.sourceBundleId) !== Math.trunc(entity.groupId))) {
+    pushFact(facts, 'source-bundle-id', 'Source Bundle ID', String(Math.trunc(entity.sourceBundleId)));
+  }
+  pushFact(facts, 'block-name', 'Block Name', normalizeText(entity?.blockName));
+  pushFact(facts, 'text-kind', 'Text Kind', normalizeText(entity?.textKind));
+  pushFact(facts, 'attribute-tag', 'Attribute Tag', normalizeText(entity?.attributeTag));
+  pushFact(facts, 'attribute-default', 'Attribute Default', normalizeText(entity?.attributeDefault));
+  pushFact(facts, 'attribute-prompt', 'Attribute Prompt', normalizeText(entity?.attributePrompt));
+  if (Number.isFinite(entity?.attributeFlags)) {
+    pushFact(facts, 'attribute-flags', 'Attribute Flags', String(Math.trunc(entity.attributeFlags)));
+  }
+  pushFact(facts, 'attribute-modes', 'Attribute Modes', formatSelectionAttributeModes(entity));
+}

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -1,7 +1,6 @@
 import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
 import {
   isInsertGroupEntity,
-  isSourceGroupEntity,
   resolveSourceTextGuide,
   resolveReleasedInsertArchive,
   summarizeInsertGroupMembers,
@@ -9,25 +8,17 @@ import {
   summarizeReleasedInsertPeerInstances,
   summarizeSourceGroupMembers,
 } from '../insert_group.js';
-import { formatSpaceLabel } from '../space_layout.js';
 import {
-  describeSelectionOrigin,
-  formatSelectionLayer,
-  formatSelectionLayerColor,
-  formatSelectionLayerState,
   isReadOnlySelectionEntity,
 } from './selection_meta_helpers.js';
 import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
-import {
-  normalizeText,
-} from './selection_display_helpers.js';
 import { resolveLayer } from './selection_layer_helpers.js';
-import { formatSelectionAttributeModes } from './selection_attribute_mode_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 import { buildPeerSummaryRows } from './peer_summary_rows.js';
 import { appendSelectionLineStyleRows } from './selection_line_style_rows.js';
+import { appendSelectionBaseFacts } from './selection_base_facts.js';
 import {
   appendReleasedArchiveIdentityRows,
   appendReleasedArchiveAttributeRows,
@@ -37,22 +28,6 @@ import {
   buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
 } from './group_info_rows.js';
 import { appendSourceTextGuideRows } from './source_text_guide_rows.js';
-
-function pushFact(facts, key, label, value, extra = {}) {
-  if (value === null || value === undefined || value === '') return;
-  facts.push({
-    key,
-    label,
-    value: String(value),
-    ...extra,
-  });
-}
-
-function formatSourceGroup(entity) {
-  const sourceType = normalizeText(entity?.sourceType);
-  const proxyKind = normalizeText(entity?.proxyKind);
-  return [sourceType, proxyKind].filter(Boolean).join(' / ');
-}
 
 export function buildMultiSelectionDetailFacts(entities, options = {}) {
   const releasedInsertArchiveSelection = summarizeReleasedInsertArchiveSelection(entities, options);
@@ -80,37 +55,7 @@ export function buildSelectionDetailFacts(entity, options = {}) {
     : null;
   const sourceTextGuide = entities ? resolveSourceTextGuide(entities, entity) : null;
   const facts = [];
-  pushFact(facts, 'origin', 'Origin', describeSelectionOrigin(entity, { separator: ' / ', includeReadOnly: true }));
-  pushFact(facts, 'layer', 'Layer', formatSelectionLayer(entity, getLayer));
-  const layerColor = formatSelectionLayerColor(entity, getLayer);
-  pushFact(facts, 'layer-color', 'Layer Color', layerColor, { swatch: layerColor || undefined });
-  pushFact(facts, 'layer-state', 'Layer State', formatSelectionLayerState(entity, getLayer));
-  pushFact(facts, 'entity-visibility', 'Entity Visibility', entity.visible === false ? 'Hidden' : 'Shown');
-  pushFact(facts, 'effective-color', 'Effective Color', normalizeText(effectiveColor), { swatch: normalizeText(effectiveColor) });
-  pushFact(facts, 'color-source', 'Color Source', normalizeText(entity.colorSource));
-  if (Number.isFinite(entity.colorAci)) {
-    pushFact(facts, 'color-aci', 'Color ACI', String(entity.colorAci));
-  }
-  pushFact(facts, 'space', 'Space', formatSpaceLabel(entity.space));
-  pushFact(facts, 'layout', 'Layout', normalizeText(entity.layout));
-  if (Number.isFinite(entity.groupId)) {
-    pushFact(facts, 'group-id', 'Group ID', String(Math.trunc(entity.groupId)));
-  }
-  if (isSourceGroupEntity(entity)) {
-    pushFact(facts, 'group-source', 'Group Source', formatSourceGroup(entity));
-  }
-  if (Number.isFinite(entity.sourceBundleId) && (!Number.isFinite(entity.groupId) || Math.trunc(entity.sourceBundleId) !== Math.trunc(entity.groupId))) {
-    pushFact(facts, 'source-bundle-id', 'Source Bundle ID', String(Math.trunc(entity.sourceBundleId)));
-  }
-  pushFact(facts, 'block-name', 'Block Name', normalizeText(entity.blockName));
-  pushFact(facts, 'text-kind', 'Text Kind', normalizeText(entity.textKind));
-  pushFact(facts, 'attribute-tag', 'Attribute Tag', normalizeText(entity.attributeTag));
-  pushFact(facts, 'attribute-default', 'Attribute Default', normalizeText(entity.attributeDefault));
-  pushFact(facts, 'attribute-prompt', 'Attribute Prompt', normalizeText(entity.attributePrompt));
-  if (Number.isFinite(entity.attributeFlags)) {
-    pushFact(facts, 'attribute-flags', 'Attribute Flags', String(Math.trunc(entity.attributeFlags)));
-  }
-  pushFact(facts, 'attribute-modes', 'Attribute Modes', formatSelectionAttributeModes(entity));
+  appendSelectionBaseFacts(facts, entity, { getLayer, effectiveColor });
   const releasedInsertArchive = resolveReleasedInsertArchive(entity);
   appendReleasedArchiveIdentityRows(facts, releasedInsertArchive);
   appendReleasedArchiveAttributeRows(facts, releasedInsertArchive);


### PR DESCRIPTION
## Summary
- extract the base single-selection fact block into `selection_base_facts.js`
- replace inline base row assembly in `selection_detail_facts.js` with the shared helper
- add focused tests for base fact ordering, omission rules, and source-group/attribute rows

## Verification
- node --check tools/web_viewer/ui/selection_base_facts.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --test tools/web_viewer/tests/selection_base_facts.test.js tools/web_viewer/tests/selection_detail_facts.test.js tools/web_viewer/tests/property_metadata_facts.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check