### PR TITLE
refactor: share selection detail context

### DIFF
--- a/docs/STEP361_SELECTION_DETAIL_CONTEXT_DESIGN.md
+++ b/docs/STEP361_SELECTION_DETAIL_CONTEXT_DESIGN.md
@@ -1,0 +1,71 @@
+# Step361: Selection Detail Context Extraction
+
+## Goal
+
+Extract the remaining detail-context resolution from:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to isolate the non-rendering preparation work that resolves layer/style context, entity lists, group summaries, released peer summaries, and source-text guide data before rows are appended.
+
+## Scope
+
+In scope:
+
+- Extract context resolution for:
+  - `getLayer`
+  - `listEntities`
+  - `layer`
+  - `effectiveStyle`
+  - `effectiveColor`
+  - `styleSources`
+  - `entities`
+  - `sourceGroupSummary`
+  - `insertGroupSummary`
+  - `insertPeerSummary`
+  - `releasedInsertPeerSummary`
+  - `sourceTextGuide`
+  - `releasedInsertArchive`
+- Keep the extracted helper leaf-level and cycle-safe.
+
+Out of scope:
+
+- base fact rows
+- released archive row helpers
+- group row helpers
+- peer summary row helpers
+- line-style row helpers
+- source-text guide row helpers
+- multi-selection released archive rows
+- overall row append order
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` behavior unchanged.
+- Keep `buildMultiSelectionDetailFacts(...)` behavior unchanged.
+- Preserve current selection summary semantics, peer summary semantics, and source-text guide resolution behavior.
+- Do not change row keys, labels, values, swatches, or ordering.
+- Do not change `resolveReleasedInsertArchive(...)`, `resolveSourceTextGuide(...)`, or the summary helpers.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/selection_detail_context.js`
+
+Expected responsibility split:
+
+- helper: resolve the single-selection detail context object
+- `selection_detail_facts.js`: append rows using the resolved context plus existing row helpers
+
+## Acceptance
+
+Accept Step361 only if:
+
+- `selection_detail_facts.js` no longer hand-builds the detail context object
+- output remains fact-for-fact compatible
+- focused tests cover plain entities, source groups, insert groups, released inserts, and listEntities/getLayer fallbacks
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP361_SELECTION_DETAIL_CONTEXT_VERIFICATION.md
+++ b/docs/STEP361_SELECTION_DETAIL_CONTEXT_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step361: Selection Detail Context Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step361-selection-detail-context`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/selection_detail_context.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/selection_detail_context.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_detail_context.test.js
+++ b/tools/web_viewer/tests/selection_detail_context.test.js
@@ -1,0 +1,223 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSelectionDetailContext } from '../ui/selection_detail_context.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 1,
+    visible: true,
+    color: '#9ca3af',
+    colorSource: 'BYLAYER',
+    lineType: 'CONTINUOUS',
+    lineWeight: 0,
+    lineTypeScale: 1,
+    start: { x: 0, y: 0 },
+    end: { x: 10, y: 0 },
+    space: 0,
+    layout: 'Model',
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'L1',
+    color: '#9ca3af',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+test('buildSelectionDetailContext normalizes collaborator fallbacks and resolves style context', () => {
+  const layer = makeLayer();
+  const context = buildSelectionDetailContext(makeEntity(), {
+    getLayer: (id) => (id === 1 ? layer : null),
+    listEntities: null,
+  });
+
+  assert.equal(typeof context.getLayer, 'function');
+  assert.equal(context.listEntities, null);
+  assert.equal(context.layer, layer);
+  assert.equal(context.effectiveColor, '#9ca3af');
+  assert.equal(context.styleSources.colorSource, 'BYLAYER');
+  assert.equal(context.entities, null);
+  assert.equal(context.sourceGroupSummary, null);
+  assert.equal(context.insertGroupSummary, null);
+  assert.equal(context.releasedInsertArchive, null);
+  assert.equal(context.sourceTextGuide, null);
+});
+
+test('buildSelectionDetailContext keeps invalid listEntities payload from creating summaries', () => {
+  const entities = { invalid: true };
+  const context = buildSelectionDetailContext(makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    groupId: 100,
+  }), {
+    getLayer: () => makeLayer(),
+    listEntities: () => entities,
+  });
+
+  assert.equal(context.entities, entities);
+  assert.equal(context.sourceGroupSummary, null);
+  assert.equal(context.insertGroupSummary, null);
+  assert.equal(context.sourceTextGuide, null);
+});
+
+test('buildSelectionDetailContext resolves source-group summary for grouped source entities', () => {
+  const entity = makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    groupId: 100,
+    sourceBundleId: 101,
+    editMode: 'proxy',
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    groupId: 100,
+    sourceBundleId: 101,
+    sourceType: 'DIMENSION',
+    start: { x: -20, y: 0 },
+    end: { x: 20, y: 14 },
+  });
+
+  const context = buildSelectionDetailContext(entity, {
+    getLayer: () => makeLayer(),
+    listEntities: () => [entity, member],
+  });
+
+  assert.deepEqual(context.sourceGroupSummary.memberIds, [1, 2]);
+  assert.equal(context.insertGroupSummary, null);
+  assert.equal(context.insertPeerSummary, null);
+});
+
+test('buildSelectionDetailContext resolves insert-group and peer summaries for insert entities', () => {
+  const entity = makeEntity({
+    type: 'text',
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    groupId: 500,
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    sourceType: 'INSERT',
+    groupId: 500,
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+  });
+  const peer = makeEntity({
+    id: 3,
+    type: 'text',
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    groupId: 500,
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-C',
+  });
+
+  const context = buildSelectionDetailContext(entity, {
+    getLayer: () => makeLayer(),
+    listEntities: () => [entity, member, peer],
+  });
+
+  assert.deepEqual(context.insertGroupSummary.memberIds, [1, 2]);
+  assert.equal(context.insertPeerSummary.peerCount, 2);
+  assert.equal(context.insertPeerSummary.currentIndex, 0);
+});
+
+test('buildSelectionDetailContext resolves released insert archive and peer summary', () => {
+  const entity = makeEntity({
+    type: 'text',
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    space: 1,
+    layout: 'Layout-B',
+    releasedInsertArchive: {
+      sourceType: 'INSERT',
+      groupId: 900,
+      blockName: 'DoorTag',
+    },
+  });
+  const peerA = makeEntity({
+    id: 2,
+    type: 'text',
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    groupId: 900,
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+  });
+  const peerB = makeEntity({
+    id: 3,
+    type: 'text',
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    groupId: 900,
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-C',
+  });
+
+  const context = buildSelectionDetailContext(entity, {
+    getLayer: () => makeLayer(),
+    listEntities: () => [peerA, peerB],
+  });
+
+  assert.equal(context.releasedInsertArchive.groupId, 900);
+  assert.equal(context.releasedInsertPeerSummary.peerCount, 2);
+  assert.equal(context.releasedInsertPeerSummary.currentIndex, 0);
+});
+
+test('buildSelectionDetailContext resolves source text guide when grouped text has guide data', () => {
+  const anchor = makeEntity({
+    id: 31,
+    type: 'line',
+    sourceType: 'DIMENSION',
+    editMode: 'proxy',
+    proxyKind: 'dimension',
+    groupId: 700,
+    start: { x: -10, y: 0 },
+    end: { x: 10, y: 0 },
+    space: 1,
+    layout: 'Layout-A',
+  });
+  const text = makeEntity({
+    id: 34,
+    type: 'text',
+    sourceType: 'DIMENSION',
+    editMode: 'proxy',
+    proxyKind: 'dimension',
+    groupId: 700,
+    position: { x: 4, y: 18 },
+    sourceTextPos: { x: 0, y: 14 },
+    sourceTextRotation: 0,
+    rotation: 0.5,
+    space: 1,
+    layout: 'Layout-A',
+  });
+
+  const context = buildSelectionDetailContext(text, {
+    getLayer: () => makeLayer(),
+    listEntities: () => [anchor, text],
+  });
+
+  assert.equal(context.sourceTextGuide.anchor.x, 0);
+  assert.equal(context.sourceTextGuide.anchor.y, 0);
+  assert.equal(context.sourceTextGuide.anchorDriverId, 31);
+});

--- a/tools/web_viewer/ui/selection_detail_context.js
+++ b/tools/web_viewer/ui/selection_detail_context.js
@@ -1,0 +1,46 @@
+import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
+import {
+  isInsertGroupEntity,
+  resolveReleasedInsertArchive,
+  resolveSourceTextGuide,
+  summarizeInsertGroupMembers,
+  summarizeInsertPeerInstances,
+  summarizeReleasedInsertPeerInstances,
+  summarizeSourceGroupMembers,
+} from '../insert_group.js';
+import { resolveLayer } from './selection_layer_helpers.js';
+import { isReadOnlySelectionEntity } from './selection_meta_helpers.js';
+
+export function buildSelectionDetailContext(entity, options = {}) {
+  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
+  const listEntities = typeof options.listEntities === 'function' ? options.listEntities : null;
+  const layer = resolveLayer(getLayer, entity?.layerId);
+  const effectiveStyle = resolveEffectiveEntityStyle(entity, layer);
+  const effectiveColor = resolveEffectiveEntityColor(entity, layer);
+  const styleSources = resolveEntityStyleSources(entity);
+  const entities = listEntities ? listEntities() : null;
+  const summaryOptions = { isReadOnly: isReadOnlySelectionEntity };
+  const releasedInsertArchive = resolveReleasedInsertArchive(entity);
+
+  return {
+    getLayer,
+    listEntities,
+    layer,
+    effectiveStyle,
+    effectiveColor,
+    styleSources,
+    entities,
+    sourceGroupSummary: entities ? summarizeSourceGroupMembers(entities, entity, summaryOptions) : null,
+    insertGroupSummary: isInsertGroupEntity(entity)
+      ? summarizeInsertGroupMembers(entities, entity, summaryOptions)
+      : null,
+    insertPeerSummary: isInsertGroupEntity(entity)
+      ? summarizeInsertPeerInstances(entities, entity, summaryOptions)
+      : null,
+    releasedInsertArchive,
+    releasedInsertPeerSummary: releasedInsertArchive
+      ? summarizeReleasedInsertPeerInstances(entities, entity, summaryOptions)
+      : null,
+    sourceTextGuide: entities ? resolveSourceTextGuide(entities, entity) : null,
+  };
+}

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -1,24 +1,11 @@
-import { resolveEffectiveEntityColor, resolveEffectiveEntityStyle, resolveEntityStyleSources } from '../line_style.js';
-import {
-  isInsertGroupEntity,
-  resolveSourceTextGuide,
-  resolveReleasedInsertArchive,
-  summarizeInsertGroupMembers,
-  summarizeInsertPeerInstances,
-  summarizeReleasedInsertPeerInstances,
-  summarizeSourceGroupMembers,
-} from '../insert_group.js';
-import {
-  isReadOnlySelectionEntity,
-} from './selection_meta_helpers.js';
 import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
-import { resolveLayer } from './selection_layer_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
 import { buildPeerSummaryRows } from './peer_summary_rows.js';
 import { appendSelectionLineStyleRows } from './selection_line_style_rows.js';
 import { appendSelectionBaseFacts } from './selection_base_facts.js';
+import { buildSelectionDetailContext } from './selection_detail_context.js';
 import {
   appendReleasedArchiveIdentityRows,
   appendReleasedArchiveAttributeRows,
@@ -36,44 +23,26 @@ export function buildMultiSelectionDetailFacts(entities, options = {}) {
 
 export function buildSelectionDetailFacts(entity, options = {}) {
   if (!entity) return [];
-  const getLayer = typeof options.getLayer === 'function' ? options.getLayer : null;
-  const listEntities = typeof options.listEntities === 'function' ? options.listEntities : null;
-  const layer = resolveLayer(getLayer, entity?.layerId);
-  const effectiveStyle = resolveEffectiveEntityStyle(entity, layer);
-  const effectiveColor = resolveEffectiveEntityColor(entity, layer);
-  const styleSources = resolveEntityStyleSources(entity);
-  const entities = listEntities ? listEntities() : null;
-  const sourceGroupSummary = entities ? summarizeSourceGroupMembers(entities, entity, { isReadOnly: isReadOnlySelectionEntity }) : null;
-  const insertGroupSummary = isInsertGroupEntity(entity)
-    ? summarizeInsertGroupMembers(entities, entity, { isReadOnly: isReadOnlySelectionEntity })
-    : null;
-  const insertPeerSummary = isInsertGroupEntity(entity)
-    ? summarizeInsertPeerInstances(entities, entity, { isReadOnly: isReadOnlySelectionEntity })
-    : null;
-  const releasedInsertPeerSummary = resolveReleasedInsertArchive(entity)
-    ? summarizeReleasedInsertPeerInstances(entities, entity, { isReadOnly: isReadOnlySelectionEntity })
-    : null;
-  const sourceTextGuide = entities ? resolveSourceTextGuide(entities, entity) : null;
+  const context = buildSelectionDetailContext(entity, options);
   const facts = [];
-  appendSelectionBaseFacts(facts, entity, { getLayer, effectiveColor });
-  const releasedInsertArchive = resolveReleasedInsertArchive(entity);
-  appendReleasedArchiveIdentityRows(facts, releasedInsertArchive);
-  appendReleasedArchiveAttributeRows(facts, releasedInsertArchive);
-  const groupRows = insertGroupSummary
-    ? buildSharedInsertGroupInfoRows(entity, insertGroupSummary, {
-      listEntities,
-      peerSummary: insertPeerSummary,
+  appendSelectionBaseFacts(facts, entity, { getLayer: context.getLayer, effectiveColor: context.effectiveColor });
+  appendReleasedArchiveIdentityRows(facts, context.releasedInsertArchive);
+  appendReleasedArchiveAttributeRows(facts, context.releasedInsertArchive);
+  const groupRows = context.insertGroupSummary
+    ? buildSharedInsertGroupInfoRows(entity, context.insertGroupSummary, {
+      listEntities: context.listEntities,
+      peerSummary: context.insertPeerSummary,
       includeIdentityRows: false,
       includeBlockName: false,
       includeBounds: true,
     })
-    : buildSharedSourceGroupInfoRows(entity, sourceGroupSummary, {
-      listEntities,
+    : buildSharedSourceGroupInfoRows(entity, context.sourceGroupSummary, {
+      listEntities: context.listEntities,
       includeIdentityRows: false,
     });
   facts.push(...groupRows);
-  buildPeerSummaryRows(facts, releasedInsertPeerSummary, { released: true });
-  appendSelectionLineStyleRows(facts, effectiveStyle, styleSources);
-  appendSourceTextGuideRows(facts, entity, sourceTextGuide);
+  buildPeerSummaryRows(facts, context.releasedInsertPeerSummary, { released: true });
+  appendSelectionLineStyleRows(facts, context.effectiveStyle, context.styleSources);
+  appendSourceTextGuideRows(facts, entity, context.sourceTextGuide);
   return facts;
 }


### PR DESCRIPTION
## Summary
- extract single-selection detail context resolution into `selection_detail_context.js`
- keep `selection_detail_facts.js` focused on row assembly and append order
- add focused tests for plain, source-group, insert-group, released-insert, and guide contexts

## Verification
- node --check tools/web_viewer/ui/selection_detail_context.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --test tools/web_viewer/tests/selection_detail_context.test.js tools/web_viewer/tests/selection_detail_facts.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check