### PR TITLE
refactor: share selection detail pipeline

### DIFF
--- a/docs/STEP362_SELECTION_DETAIL_PIPELINE_DESIGN.md
+++ b/docs/STEP362_SELECTION_DETAIL_PIPELINE_DESIGN.md
@@ -1,0 +1,69 @@
+# Step362: Selection Detail Pipeline Extraction
+
+## Goal
+
+Extract the remaining row-append sequencing from:
+
+- `tools/web_viewer/ui/selection_detail_facts.js`
+
+The purpose is to isolate the final single-selection detail pipeline so `selection_detail_facts.js` becomes a thin wrapper around:
+
+- null guard
+- context resolution
+- pipeline execution
+
+without changing any row keys, values, swatches, or ordering.
+
+## Scope
+
+In scope:
+
+- Extract the single-selection append sequence for:
+  - base facts
+  - released archive identity rows
+  - released archive attribute rows
+  - source/insert group rows
+  - released peer summary rows
+  - line-style rows
+  - source-text guide rows
+- Keep the extracted helper cycle-safe.
+
+Out of scope:
+
+- `buildSelectionDetailContext(...)` behavior
+- `buildMultiSelectionDetailFacts(...)` behavior
+- any row helper behavior
+- released archive selection rows
+- line-style resolution
+- source-text guide resolution
+
+## Constraints
+
+- Keep `buildSelectionDetailFacts(...)` public contract unchanged.
+- Keep `buildSelectionDetailContext(...)` behavior unchanged.
+- Preserve exact row order and omission behavior.
+- Do not change group-vs-insert branching semantics.
+- Do not change released peer summary semantics.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/selection_detail_pipeline.js`
+
+Expected responsibility split:
+
+- helper: append the final single-selection detail rows in the current order
+- `selection_detail_facts.js`: null guard + context resolution + pipeline call
+
+## Acceptance
+
+Accept Step362 only if:
+
+- `selection_detail_facts.js` no longer hand-assembles the single-selection row sequence
+- output remains fact-for-fact compatible
+- focused tests cover append order, insert/source branching, released peer passthrough, and source guide passthrough
+- `editor_commands.test.js` stays green
+- `git diff --check` stays clean

--- a/docs/STEP362_SELECTION_DETAIL_PIPELINE_VERIFICATION.md
+++ b/docs/STEP362_SELECTION_DETAIL_PIPELINE_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step362: Selection Detail Pipeline Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step362-selection-detail-pipeline`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/selection_detail_pipeline.js
+node --check tools/web_viewer/ui/selection_detail_facts.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/selection_detail_pipeline.test.js \
+  tools/web_viewer/tests/selection_detail_facts.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/selection_detail_pipeline.test.js
+++ b/tools/web_viewer/tests/selection_detail_pipeline.test.js
@@ -1,0 +1,287 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSelectionDetailPipeline } from '../ui/selection_detail_pipeline.js';
+
+function makeEntity(overrides = {}) {
+  return {
+    id: 1,
+    type: 'line',
+    layerId: 1,
+    visible: true,
+    color: '#9ca3af',
+    colorSource: 'BYLAYER',
+    lineType: 'CONTINUOUS',
+    lineWeight: 0,
+    lineTypeScale: 1,
+    start: { x: 0, y: 0 },
+    end: { x: 10, y: 0 },
+    space: 0,
+    layout: 'Model',
+    ...overrides,
+  };
+}
+
+function makeLayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'L1',
+    color: '#9ca3af',
+    visible: true,
+    locked: false,
+    frozen: false,
+    printable: true,
+    construction: false,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides = {}) {
+  return {
+    getLayer: () => null,
+    listEntities: () => [],
+    effectiveColor: '#9ca3af',
+    effectiveStyle: { lineType: 'CONTINUOUS', lineWeight: 0, lineTypeScale: 1 },
+    styleSources: { lineTypeSource: 'entity', lineWeightSource: 'entity', lineTypeScaleSource: 'entity' },
+    releasedInsertArchive: null,
+    sourceGroupSummary: null,
+    insertGroupSummary: null,
+    insertPeerSummary: null,
+    releasedInsertPeerSummary: null,
+    sourceTextGuide: null,
+    ...overrides,
+  };
+}
+
+test('pipeline returns base facts in expected order', () => {
+  const entity = makeEntity();
+  const layer = makeLayer();
+  const context = makeContext({ getLayer: () => layer });
+  const facts = buildSelectionDetailPipeline(entity, context);
+
+  const keys = facts.map((f) => f.key);
+  assert.ok(keys.includes('layer'), 'missing layer');
+  assert.ok(keys.includes('effective-color'), 'missing effective-color');
+  assert.ok(keys.includes('line-type'), 'missing line-type');
+  assert.ok(keys.indexOf('layer') < keys.indexOf('effective-color'), 'layer should come before effective-color');
+  assert.ok(keys.indexOf('effective-color') < keys.indexOf('line-type'), 'effective-color should come before line-type');
+});
+
+test('pipeline uses source-group branch when insertGroupSummary is null', () => {
+  const entity = makeEntity({
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    groupId: 100,
+    sourceBundleId: 101,
+    editMode: 'proxy',
+    readOnly: true,
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    groupId: 100,
+    sourceBundleId: 101,
+    sourceType: 'DIMENSION',
+    start: { x: -20, y: 0 },
+    end: { x: 20, y: 14 },
+  });
+  const allEntities = [entity, member];
+  const context = makeContext({
+    getLayer: () => makeLayer(),
+    listEntities: () => allEntities,
+    sourceGroupSummary: {
+      groupId: 100,
+      sourceBundleId: 101,
+      sourceType: 'DIMENSION',
+      memberIds: [1, 2],
+      editableIds: [1, 2],
+      readOnlyIds: [],
+    },
+    insertGroupSummary: null,
+  });
+
+  const facts = buildSelectionDetailPipeline(entity, context);
+  const keys = facts.map((f) => f.key);
+  assert.ok(keys.includes('group-id'), 'missing group-id');
+  assert.ok(keys.includes('source-group-members'), 'missing source-group-members');
+  assert.ok(!keys.includes('insert-group-members'), 'should not have insert-group-members');
+});
+
+test('pipeline uses insert-group branch when insertGroupSummary is present', () => {
+  const entity = makeEntity({
+    type: 'text',
+    groupId: 500,
+    sourceType: 'INSERT',
+    proxyKind: 'text',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    position: { x: 0, y: 20 },
+  });
+  const member = makeEntity({
+    id: 2,
+    type: 'line',
+    groupId: 500,
+    sourceType: 'INSERT',
+    blockName: 'DoorTag',
+    space: 1,
+    layout: 'Layout-B',
+    start: { x: -18, y: 20 },
+    end: { x: 18, y: 34 },
+  });
+  const allEntities = [entity, member];
+  const context = makeContext({
+    getLayer: () => makeLayer(),
+    listEntities: () => allEntities,
+    insertGroupSummary: {
+      groupId: 500,
+      sourceType: 'INSERT',
+      blockName: 'DoorTag',
+      memberIds: [1, 2],
+      editableIds: [1, 2],
+      readOnlyIds: [],
+    },
+    insertPeerSummary: null,
+  });
+
+  const facts = buildSelectionDetailPipeline(entity, context);
+  const keys = facts.map((f) => f.key);
+  assert.ok(keys.includes('insert-group-members'), 'missing insert-group-members');
+  assert.ok(!keys.includes('source-group-members'), 'should not have source-group-members');
+});
+
+test('pipeline passes through released peer summary rows', () => {
+  const entity = makeEntity({
+    id: 1,
+    type: 'text',
+    space: 1,
+    layout: 'Layout-A',
+  });
+  const context = makeContext({
+    getLayer: () => makeLayer(),
+    releasedInsertPeerSummary: {
+      peerCount: 3,
+      currentIndex: 0,
+      peers: [
+        { space: 1, layout: 'Layout-A' },
+        { space: 1, layout: 'Layout-B' },
+        { space: 1, layout: 'Layout-C' },
+      ],
+    },
+  });
+
+  const facts = buildSelectionDetailPipeline(entity, context);
+  const byKey = Object.fromEntries(facts.map((fact) => [fact.key, fact.value]));
+  assert.equal(byKey['released-peer-instance'], '1 / 3');
+  assert.equal(byKey['released-peer-instances'], '3');
+});
+
+test('pipeline passes through source text guide rows', () => {
+  const entity = makeEntity({
+    type: 'text',
+    sourceType: 'DIMENSION',
+    proxyKind: 'text',
+    groupId: 100,
+    editMode: 'proxy',
+    position: { x: 5, y: 10 },
+    sourceTextPos: { x: 5, y: 10 },
+    sourceTextRotation: 0,
+  });
+  const anchor = makeEntity({ id: 2, type: 'line', groupId: 100, start: { x: 0, y: 0 }, end: { x: 20, y: 0 } });
+  const allEntities = [entity, anchor];
+  const context = makeContext({
+    getLayer: () => makeLayer(),
+    listEntities: () => allEntities,
+    sourceGroupSummary: {
+      groupId: 100,
+      sourceType: 'DIMENSION',
+      memberIds: [1, 2],
+      editableIds: [1, 2],
+      readOnlyIds: [],
+    },
+    sourceTextGuide: {
+      anchor: { x: 0, y: 0 },
+      anchorDriver: { entityId: 2, entityType: 'line', kind: 'midpoint' },
+      sourceOffset: { x: 0, y: 14 },
+      currentOffset: { x: 5, y: 10 },
+    },
+  });
+
+  const facts = buildSelectionDetailPipeline(entity, context);
+  const keys = facts.map((f) => f.key);
+  assert.ok(keys.includes('source-text-pos'), 'missing source-text-pos');
+  assert.ok(keys.includes('source-text-rotation'), 'missing source-text-rotation');
+  assert.ok(keys.includes('source-anchor'), 'missing source-anchor');
+});
+
+test('pipeline appends rows in correct order: base, archive, group, released-peer, line-style, guide', () => {
+  const entity = makeEntity({
+    id: 1,
+    type: 'text',
+    space: 1,
+    layout: 'Layout-A',
+    releasedInsertArchive: {
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      groupId: 700,
+      blockName: 'AttdefBlock',
+      textKind: 'attdef',
+      attributeTag: 'ATTDEF_TAG',
+    },
+    sourceTextPos: { x: 5, y: 10 },
+    sourceTextRotation: 0,
+    position: { x: 5, y: 10 },
+  });
+  const context = makeContext({
+    getLayer: () => makeLayer(),
+    releasedInsertArchive: {
+      sourceType: 'INSERT',
+      proxyKind: 'text',
+      editMode: 'proxy',
+      groupId: 700,
+      blockName: 'AttdefBlock',
+      textKind: 'attdef',
+      attributeTag: 'ATTDEF_TAG',
+    },
+    releasedInsertPeerSummary: {
+      peerCount: 2,
+      currentIndex: 0,
+      peers: [
+        { space: 1, layout: 'Layout-A' },
+        { space: 1, layout: 'Layout-B' },
+      ],
+    },
+    sourceTextGuide: {
+      anchor: { x: 0, y: 0 },
+      anchorDriver: { entityId: 2, entityType: 'line', kind: 'midpoint' },
+      sourceOffset: { x: 0, y: 14 },
+      currentOffset: { x: 5, y: 10 },
+    },
+  });
+
+  const facts = buildSelectionDetailPipeline(entity, context);
+  const keys = facts.map((f) => f.key);
+
+  // Base facts come first
+  const layerIdx = keys.indexOf('layer');
+  // Released archive identity/attribute rows
+  const releasedFromIdx = keys.indexOf('released-from');
+  // Released peer rows
+  const releasedPeerIdx = keys.indexOf('released-peer-instance');
+  // Line-style rows
+  const lineTypeIdx = keys.indexOf('line-type');
+  // Source text guide rows
+  const sourceTextIdx = keys.indexOf('source-text-pos');
+
+  assert.ok(layerIdx >= 0, 'missing layer');
+  assert.ok(releasedFromIdx >= 0, 'missing released-from');
+  assert.ok(releasedPeerIdx >= 0, 'missing released-peer-instance');
+  assert.ok(lineTypeIdx >= 0, 'missing line-type');
+  assert.ok(sourceTextIdx >= 0, 'missing source-text-pos');
+
+  assert.ok(layerIdx < releasedFromIdx, 'base facts should precede released archive rows');
+  assert.ok(releasedFromIdx < releasedPeerIdx, 'released archive rows should precede released peer rows');
+  assert.ok(releasedPeerIdx < lineTypeIdx, 'released peer rows should precede line-style rows');
+  assert.ok(lineTypeIdx < sourceTextIdx, 'line-style rows should precede source text guide rows');
+});

--- a/tools/web_viewer/ui/selection_detail_facts.js
+++ b/tools/web_viewer/ui/selection_detail_facts.js
@@ -2,19 +2,8 @@ import {
   summarizeReleasedInsertArchiveSelection,
 } from './selection_released_archive_helpers.js';
 import { buildReleasedInsertArchiveSelectionRows } from './released_insert_selection_rows.js';
-import { buildPeerSummaryRows } from './peer_summary_rows.js';
-import { appendSelectionLineStyleRows } from './selection_line_style_rows.js';
-import { appendSelectionBaseFacts } from './selection_base_facts.js';
 import { buildSelectionDetailContext } from './selection_detail_context.js';
-import {
-  appendReleasedArchiveIdentityRows,
-  appendReleasedArchiveAttributeRows,
-} from './released_archive_metadata_rows.js';
-import {
-  buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
-  buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
-} from './group_info_rows.js';
-import { appendSourceTextGuideRows } from './source_text_guide_rows.js';
+import { buildSelectionDetailPipeline } from './selection_detail_pipeline.js';
 
 export function buildMultiSelectionDetailFacts(entities, options = {}) {
   const releasedInsertArchiveSelection = summarizeReleasedInsertArchiveSelection(entities, options);
@@ -24,25 +13,5 @@ export function buildMultiSelectionDetailFacts(entities, options = {}) {
 export function buildSelectionDetailFacts(entity, options = {}) {
   if (!entity) return [];
   const context = buildSelectionDetailContext(entity, options);
-  const facts = [];
-  appendSelectionBaseFacts(facts, entity, { getLayer: context.getLayer, effectiveColor: context.effectiveColor });
-  appendReleasedArchiveIdentityRows(facts, context.releasedInsertArchive);
-  appendReleasedArchiveAttributeRows(facts, context.releasedInsertArchive);
-  const groupRows = context.insertGroupSummary
-    ? buildSharedInsertGroupInfoRows(entity, context.insertGroupSummary, {
-      listEntities: context.listEntities,
-      peerSummary: context.insertPeerSummary,
-      includeIdentityRows: false,
-      includeBlockName: false,
-      includeBounds: true,
-    })
-    : buildSharedSourceGroupInfoRows(entity, context.sourceGroupSummary, {
-      listEntities: context.listEntities,
-      includeIdentityRows: false,
-    });
-  facts.push(...groupRows);
-  buildPeerSummaryRows(facts, context.releasedInsertPeerSummary, { released: true });
-  appendSelectionLineStyleRows(facts, context.effectiveStyle, context.styleSources);
-  appendSourceTextGuideRows(facts, entity, context.sourceTextGuide);
-  return facts;
+  return buildSelectionDetailPipeline(entity, context);
 }

--- a/tools/web_viewer/ui/selection_detail_pipeline.js
+++ b/tools/web_viewer/ui/selection_detail_pipeline.js
@@ -1,0 +1,36 @@
+import {
+  appendReleasedArchiveIdentityRows,
+  appendReleasedArchiveAttributeRows,
+} from './released_archive_metadata_rows.js';
+import { buildPeerSummaryRows } from './peer_summary_rows.js';
+import { appendSelectionLineStyleRows } from './selection_line_style_rows.js';
+import { appendSelectionBaseFacts } from './selection_base_facts.js';
+import {
+  buildSourceGroupInfoRows as buildSharedSourceGroupInfoRows,
+  buildInsertGroupInfoRows as buildSharedInsertGroupInfoRows,
+} from './group_info_rows.js';
+import { appendSourceTextGuideRows } from './source_text_guide_rows.js';
+
+export function buildSelectionDetailPipeline(entity, context) {
+  const facts = [];
+  appendSelectionBaseFacts(facts, entity, { getLayer: context.getLayer, effectiveColor: context.effectiveColor });
+  appendReleasedArchiveIdentityRows(facts, context.releasedInsertArchive);
+  appendReleasedArchiveAttributeRows(facts, context.releasedInsertArchive);
+  const groupRows = context.insertGroupSummary
+    ? buildSharedInsertGroupInfoRows(entity, context.insertGroupSummary, {
+      listEntities: context.listEntities,
+      peerSummary: context.insertPeerSummary,
+      includeIdentityRows: false,
+      includeBlockName: false,
+      includeBounds: true,
+    })
+    : buildSharedSourceGroupInfoRows(entity, context.sourceGroupSummary, {
+      listEntities: context.listEntities,
+      includeIdentityRows: false,
+    });
+  facts.push(...groupRows);
+  buildPeerSummaryRows(facts, context.releasedInsertPeerSummary, { released: true });
+  appendSelectionLineStyleRows(facts, context.effectiveStyle, context.styleSources);
+  appendSourceTextGuideRows(facts, entity, context.sourceTextGuide);
+  return facts;
+}


### PR DESCRIPTION
## Summary
- extract the single-selection detail append sequence into `selection_detail_pipeline.js`
- keep `selection_detail_facts.js` focused on null guard, context resolution, and pipeline execution
- add focused tests for append order, insert/source branching, released peer passthrough, and source guide passthrough

## Verification
- node --check tools/web_viewer/ui/selection_detail_pipeline.js
- node --check tools/web_viewer/ui/selection_detail_facts.js
- node --test tools/web_viewer/tests/selection_detail_pipeline.test.js tools/web_viewer/tests/selection_detail_facts.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check