### PR TITLE
refactor: share selection shell row renderers

### DIFF
--- a/docs/STEP363_SELECTION_SHELL_ROW_RENDERERS_DESIGN.md
+++ b/docs/STEP363_SELECTION_SHELL_ROW_RENDERERS_DESIGN.md
@@ -1,0 +1,58 @@
+# Step363: Selection Shell Row Renderers Extraction
+
+## Goal
+
+Extract the shared badge-row and fact-list DOM renderers from:
+
+- `tools/web_viewer/ui/property_panel_selection_shell_renderers.js`
+
+The purpose is to isolate the reusable selection shell row rendering logic without changing shell wording, DOM shape, datasets, class names, or swatch behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - badge row rendering
+  - fact list rendering
+- Keep the extracted helper leaf-level and cycle-safe.
+
+Out of scope:
+
+- single-selection hero rendering
+- empty shell wording
+- multiple-selection wording
+- single vs multiple shell dispatch behavior
+- selection presentation behavior
+
+## Constraints
+
+- Keep `appendEmptySelectionShell(...)` behavior unchanged.
+- Keep `appendMultipleSelectionShell(...)` behavior unchanged.
+- Keep `appendSingleSelectionShell(...)` behavior unchanged.
+- Preserve exact class names, dataset keys, swatch behavior, and DOM append order.
+- Do not change `describeSelectionOrigin(...)` behavior.
+- Only extract the shared badge/fact row renderers into a dedicated helper module.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_selection_row_renderers.js`
+
+Expected responsibility split:
+
+- helper: render badge row and fact list fragments
+- `property_panel_selection_shell_renderers.js`: empty shell, multiple shell, hero shell, and orchestration
+
+## Acceptance
+
+Accept Step363 only if:
+
+- `property_panel_selection_shell_renderers.js` no longer hand-builds badge/fact row fragments
+- output remains DOM-for-DOM compatible
+- focused tests cover badge tone classes, fact swatches, empty/null guard behavior, and shell integration
+- existing property panel selection shell tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP363_SELECTION_SHELL_ROW_RENDERERS_VERIFICATION.md
+++ b/docs/STEP363_SELECTION_SHELL_ROW_RENDERERS_VERIFICATION.md
@@ -1,0 +1,45 @@
+# Step363: Selection Shell Row Renderers Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step363-selection-shell-row-renderers`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_selection_row_renderers.js
+node --check tools/web_viewer/ui/property_panel_selection_shell_renderers.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_selection_row_renderers.test.js \
+  tools/web_viewer/tests/property_panel_selection_shell_renderers.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/property_panel_selection_shells.test.js
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `property_panel_selection_shells.test.js` total
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_selection_row_renderers.test.js
+++ b/tools/web_viewer/tests/property_panel_selection_row_renderers.test.js
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  renderSelectionBadgeRow,
+  renderSelectionFactList,
+} from '../ui/property_panel_selection_row_renderers.js';
+
+class FakeElement {
+  constructor(ownerDocument, tagName = 'div') {
+    this.ownerDocument = ownerDocument;
+    this.tagName = tagName;
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.className = '';
+    this.textContent = '';
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(this, tagName);
+  }
+}
+
+// --- renderSelectionBadgeRow ---
+
+test('renderSelectionBadgeRow returns null for empty array', () => {
+  const doc = new FakeDocument();
+  assert.equal(renderSelectionBadgeRow(doc, []), null);
+});
+
+test('renderSelectionBadgeRow returns null for non-array', () => {
+  const doc = new FakeDocument();
+  assert.equal(renderSelectionBadgeRow(doc, null), null);
+  assert.equal(renderSelectionBadgeRow(doc, undefined), null);
+});
+
+test('renderSelectionBadgeRow renders badges with correct class and dataset', () => {
+  const doc = new FakeDocument();
+  const row = renderSelectionBadgeRow(doc, [
+    { key: 'layer', value: '1:L1' },
+    { key: 'space', value: 'Paper' },
+  ]);
+  assert.equal(row.className, 'cad-selection-badges');
+  assert.equal(row.children.length, 2);
+  assert.equal(row.children[0].className, 'cad-selection-badge');
+  assert.equal(row.children[0].dataset.selectionBadge, 'layer');
+  assert.equal(row.children[0].textContent, '1:L1');
+  assert.equal(row.children[1].dataset.selectionBadge, 'space');
+  assert.equal(row.children[1].textContent, 'Paper');
+});
+
+test('renderSelectionBadgeRow applies tone class', () => {
+  const doc = new FakeDocument();
+  const row = renderSelectionBadgeRow(doc, [
+    { key: 'status', value: 'Active', tone: 'muted' },
+  ]);
+  assert.equal(row.children[0].className, 'cad-selection-badge is-muted');
+});
+
+test('renderSelectionBadgeRow omits tone class when tone is absent', () => {
+  const doc = new FakeDocument();
+  const row = renderSelectionBadgeRow(doc, [
+    { key: 'status', value: 'Active' },
+  ]);
+  assert.equal(row.children[0].className, 'cad-selection-badge');
+});
+
+// --- renderSelectionFactList ---
+
+test('renderSelectionFactList returns null for empty array', () => {
+  const doc = new FakeDocument();
+  assert.equal(renderSelectionFactList(doc, []), null);
+});
+
+test('renderSelectionFactList returns null for non-array', () => {
+  const doc = new FakeDocument();
+  assert.equal(renderSelectionFactList(doc, null), null);
+  assert.equal(renderSelectionFactList(doc, undefined), null);
+});
+
+test('renderSelectionFactList renders facts with label and value', () => {
+  const doc = new FakeDocument();
+  const facts = renderSelectionFactList(doc, [
+    { key: 'space', label: 'Space', value: 'Paper' },
+  ]);
+  assert.equal(facts.className, 'cad-selection-facts');
+  assert.equal(facts.children.length, 1);
+  assert.equal(facts.children[0].className, 'cad-selection-fact');
+  assert.equal(facts.children[0].dataset.selectionField, 'space');
+  // label span, then strong value (no swatch)
+  assert.equal(facts.children[0].children.length, 2);
+  assert.equal(facts.children[0].children[0].textContent, 'Space');
+  assert.equal(facts.children[0].children[1].textContent, 'Paper');
+});
+
+test('renderSelectionFactList renders swatch when present', () => {
+  const doc = new FakeDocument();
+  const facts = renderSelectionFactList(doc, [
+    { key: 'effective-color', label: 'Effective Color', value: '#ff0000', swatch: '#ff0000' },
+  ]);
+  const row = facts.children[0];
+  // label span, swatch span, strong value
+  assert.equal(row.children.length, 3);
+  assert.equal(row.children[1].className, 'cad-selection-fact__swatch');
+  assert.equal(row.children[1].style.background, '#ff0000');
+});
+
+test('renderSelectionFactList omits swatch when absent', () => {
+  const doc = new FakeDocument();
+  const facts = renderSelectionFactList(doc, [
+    { key: 'space', label: 'Space', value: 'Model' },
+  ]);
+  const row = facts.children[0];
+  assert.equal(row.children.length, 2);
+});

--- a/tools/web_viewer/ui/property_panel_selection_row_renderers.js
+++ b/tools/web_viewer/ui/property_panel_selection_row_renderers.js
@@ -1,0 +1,45 @@
+export function renderSelectionBadgeRow(doc, badges) {
+  if (!Array.isArray(badges) || badges.length === 0) {
+    return null;
+  }
+  const badgeRow = doc.createElement('div');
+  badgeRow.className = 'cad-selection-badges';
+  for (const badge of badges) {
+    const chip = doc.createElement('span');
+    chip.className = `cad-selection-badge${badge.tone ? ` is-${badge.tone}` : ''}`;
+    chip.dataset.selectionBadge = badge.key;
+    chip.textContent = badge.value;
+    badgeRow.appendChild(chip);
+  }
+  return badgeRow;
+}
+
+export function renderSelectionFactList(doc, detailFacts) {
+  if (!Array.isArray(detailFacts) || detailFacts.length === 0) {
+    return null;
+  }
+  const facts = doc.createElement('div');
+  facts.className = 'cad-selection-facts';
+  for (const fact of detailFacts) {
+    const row = doc.createElement('div');
+    row.className = 'cad-selection-fact';
+    row.dataset.selectionField = fact.key;
+
+    const label = doc.createElement('span');
+    label.textContent = fact.label;
+    row.appendChild(label);
+
+    if (fact.swatch) {
+      const dot = doc.createElement('span');
+      dot.className = 'cad-selection-fact__swatch';
+      dot.style.background = fact.swatch;
+      row.appendChild(dot);
+    }
+
+    const value = doc.createElement('strong');
+    value.textContent = fact.value;
+    row.appendChild(value);
+    facts.appendChild(row);
+  }
+  return facts;
+}

--- a/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
+++ b/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
@@ -1,50 +1,5 @@
 import { describeSelectionOrigin } from './selection_meta_helpers.js';
-
-function renderSelectionBadgeRow(doc, badges) {
-  if (!Array.isArray(badges) || badges.length === 0) {
-    return null;
-  }
-  const badgeRow = doc.createElement('div');
-  badgeRow.className = 'cad-selection-badges';
-  for (const badge of badges) {
-    const chip = doc.createElement('span');
-    chip.className = `cad-selection-badge${badge.tone ? ` is-${badge.tone}` : ''}`;
-    chip.dataset.selectionBadge = badge.key;
-    chip.textContent = badge.value;
-    badgeRow.appendChild(chip);
-  }
-  return badgeRow;
-}
-
-function renderSelectionFactList(doc, detailFacts) {
-  if (!Array.isArray(detailFacts) || detailFacts.length === 0) {
-    return null;
-  }
-  const facts = doc.createElement('div');
-  facts.className = 'cad-selection-facts';
-  for (const fact of detailFacts) {
-    const row = doc.createElement('div');
-    row.className = 'cad-selection-fact';
-    row.dataset.selectionField = fact.key;
-
-    const label = doc.createElement('span');
-    label.textContent = fact.label;
-    row.appendChild(label);
-
-    if (fact.swatch) {
-      const dot = doc.createElement('span');
-      dot.className = 'cad-selection-fact__swatch';
-      dot.style.background = fact.swatch;
-      row.appendChild(dot);
-    }
-
-    const value = doc.createElement('strong');
-    value.textContent = fact.value;
-    row.appendChild(value);
-    facts.appendChild(row);
-  }
-  return facts;
-}
+import { renderSelectionBadgeRow, renderSelectionFactList } from './property_panel_selection_row_renderers.js';
 
 function appendSingleSelectionHero(doc, element, primary, detailFacts) {
   const hero = doc.createElement('div');


### PR DESCRIPTION
## Summary
- extract shared badge-row and fact-list DOM renderers into `property_panel_selection_row_renderers.js`
- keep `property_panel_selection_shell_renderers.js` focused on empty/single/multiple shell composition
- add focused tests for badge tone classes, swatches, and null/empty guards

## Verification
- node --check tools/web_viewer/ui/property_panel_selection_row_renderers.js
- node --check tools/web_viewer/ui/property_panel_selection_shell_renderers.js
- node --test tools/web_viewer/tests/property_panel_selection_row_renderers.test.js tools/web_viewer/tests/property_panel_selection_shell_renderers.test.js
- node --test tools/web_viewer/tests/property_panel_selection_shells.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check