### PR TITLE
refactor: share selection shell hero

### DIFF
--- a/docs/STEP364_SELECTION_SHELL_HERO_DESIGN.md
+++ b/docs/STEP364_SELECTION_SHELL_HERO_DESIGN.md
@@ -1,0 +1,59 @@
+# Step364: Selection Shell Hero Extraction
+
+## Goal
+
+Extract the single-selection hero DOM builder from:
+
+- `tools/web_viewer/ui/property_panel_selection_shell_renderers.js`
+
+The purpose is to isolate the single-selection hero fragment without changing shell wording, DOM shape, datasets, swatch fallback behavior, or hero append order.
+
+## Scope
+
+In scope:
+
+- Extract the single-selection hero renderer:
+  - swatch block
+  - title block
+  - origin caption block
+
+Out of scope:
+
+- badge row rendering
+- fact list rendering
+- empty shell wording
+- multiple-selection wording
+- single vs multiple shell dispatch behavior
+- selection presentation behavior
+
+## Constraints
+
+- Keep `appendSingleSelectionShell(...)` behavior unchanged.
+- Keep `appendEmptySelectionShell(...)` behavior unchanged.
+- Keep `appendMultipleSelectionShell(...)` behavior unchanged.
+- Preserve exact class names, dataset keys, swatch fallback behavior, and DOM append order.
+- Do not change `describeSelectionOrigin(...)` behavior.
+- Only extract the single-selection hero renderer into a dedicated helper module.
+- Do not import `selection_presenter.js` from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_selection_hero_renderer.js`
+
+Expected responsibility split:
+
+- helper: build/append the single-selection hero fragment
+- `property_panel_selection_shell_renderers.js`: empty shell, multiple shell, and high-level single-shell composition
+
+## Acceptance
+
+Accept Step364 only if:
+
+- `property_panel_selection_shell_renderers.js` no longer hand-builds the single-selection hero
+- output remains DOM-for-DOM compatible
+- focused tests cover swatch fallback, title rendering, origin caption rendering, and no-caption behavior
+- existing property panel selection shell tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP364_SELECTION_SHELL_HERO_VERIFICATION.md
+++ b/docs/STEP364_SELECTION_SHELL_HERO_VERIFICATION.md
@@ -1,0 +1,45 @@
+# Step364: Selection Shell Hero Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step364-selection-shell-hero`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_selection_hero_renderer.js
+node --check tools/web_viewer/ui/property_panel_selection_shell_renderers.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_selection_hero_renderer.test.js \
+  tools/web_viewer/tests/property_panel_selection_shell_renderers.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/property_panel_selection_shells.test.js
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `property_panel_selection_shells.test.js` total
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_selection_hero_renderer.test.js
+++ b/tools/web_viewer/tests/property_panel_selection_hero_renderer.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSingleSelectionHero } from '../ui/property_panel_selection_hero_renderer.js';
+
+class FakeElement {
+  constructor(ownerDocument, tagName = 'div') {
+    this.ownerDocument = ownerDocument;
+    this.tagName = tagName;
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.className = '';
+    this.textContent = '';
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(this, tagName);
+  }
+}
+
+test('swatch uses effective-color swatch when available', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { color: '#00ff00' }, [
+    { key: 'effective-color', swatch: '#ff0000' },
+  ]);
+
+  const hero = element.children[0];
+  const swatch = hero.children[0];
+  assert.equal(swatch.className, 'cad-selection-hero__swatch');
+  assert.equal(swatch.dataset.selectionColor, '#ff0000');
+  assert.equal(swatch.style.background, '#ff0000');
+});
+
+test('swatch falls back to primary.color when effective-color swatch is missing', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { color: '#00ff00' }, [
+    { key: 'effective-color', value: '#ff0000' },
+  ]);
+
+  const swatch = element.children[0].children[0];
+  assert.equal(swatch.dataset.selectionColor, '#00ff00');
+  assert.equal(swatch.style.background, '#00ff00');
+});
+
+test('swatch falls back to #ffffff when both swatch and primary.color are absent', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, {}, []);
+
+  const swatch = element.children[0].children[0];
+  assert.equal(swatch.dataset.selectionColor, '#ffffff');
+  assert.equal(swatch.style.background, '#ffffff');
+});
+
+test('swatch falls back to #ffffff when primary.color is empty string', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { color: '  ' }, []);
+
+  const swatch = element.children[0].children[0];
+  assert.equal(swatch.dataset.selectionColor, '#ffffff');
+});
+
+test('title renders primary.type', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { type: 'circle' }, []);
+
+  const heroText = element.children[0].children[1];
+  const title = heroText.children[0];
+  assert.equal(title.className, 'cad-selection-hero__title');
+  assert.equal(title.dataset.selectionField, 'type');
+  assert.equal(title.textContent, 'circle');
+});
+
+test('title falls back to entity when type is missing', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, {}, []);
+
+  const title = element.children[0].children[1].children[0];
+  assert.equal(title.textContent, 'entity');
+});
+
+test('origin caption renders when sourceType and proxyKind are present', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { sourceType: 'INSERT', proxyKind: 'fragment' }, []);
+
+  const heroText = element.children[0].children[1];
+  assert.equal(heroText.children.length, 2);
+  const subtitle = heroText.children[1];
+  assert.equal(subtitle.className, 'cad-selection-hero__subtitle');
+  assert.equal(subtitle.dataset.selectionField, 'origin-caption');
+  assert.equal(subtitle.textContent, 'INSERT / fragment');
+});
+
+test('no caption element when origin is empty', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { type: 'line' }, []);
+
+  const heroText = element.children[0].children[1];
+  assert.equal(heroText.children.length, 1);
+});
+
+test('hero DOM structure and append order', () => {
+  const doc = new FakeDocument();
+  const element = new FakeElement(doc);
+
+  appendSingleSelectionHero(doc, element, { type: 'arc', sourceType: 'XREF' }, [
+    { key: 'effective-color', swatch: '#abc123' },
+  ]);
+
+  assert.equal(element.children.length, 1);
+  const hero = element.children[0];
+  assert.equal(hero.className, 'cad-selection-hero');
+  assert.equal(hero.children.length, 2);
+  assert.equal(hero.children[0].className, 'cad-selection-hero__swatch');
+  assert.equal(hero.children[0].dataset.selectionField, 'effective-color-swatch');
+  assert.equal(hero.children[1].className, 'cad-selection-hero__text');
+});

--- a/tools/web_viewer/ui/property_panel_selection_hero_renderer.js
+++ b/tools/web_viewer/ui/property_panel_selection_hero_renderer.js
@@ -1,0 +1,37 @@
+import { describeSelectionOrigin } from './selection_meta_helpers.js';
+
+export function appendSingleSelectionHero(doc, element, primary, detailFacts) {
+  const hero = doc.createElement('div');
+  hero.className = 'cad-selection-hero';
+
+  const swatch = doc.createElement('div');
+  swatch.className = 'cad-selection-hero__swatch';
+  swatch.dataset.selectionField = 'effective-color-swatch';
+  const effectiveColorFact = detailFacts.find((fact) => fact && fact.key === 'effective-color');
+  const swatchColor = typeof effectiveColorFact?.swatch === 'string' && effectiveColorFact.swatch.trim()
+    ? effectiveColorFact.swatch.trim()
+    : (typeof primary.color === 'string' && primary.color.trim() ? primary.color.trim() : '#ffffff');
+  swatch.dataset.selectionColor = swatchColor;
+  swatch.style.background = swatchColor;
+  hero.appendChild(swatch);
+
+  const heroText = doc.createElement('div');
+  heroText.className = 'cad-selection-hero__text';
+
+  const title = doc.createElement('strong');
+  title.className = 'cad-selection-hero__title';
+  title.dataset.selectionField = 'type';
+  title.textContent = primary.type || 'entity';
+  heroText.appendChild(title);
+
+  const caption = describeSelectionOrigin(primary, { separator: ' / ', includeReadOnly: true });
+  if (caption) {
+    const subtitle = doc.createElement('div');
+    subtitle.className = 'cad-selection-hero__subtitle';
+    subtitle.dataset.selectionField = 'origin-caption';
+    subtitle.textContent = caption;
+    heroText.appendChild(subtitle);
+  }
+  hero.appendChild(heroText);
+  element.appendChild(hero);
+}

--- a/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
+++ b/tools/web_viewer/ui/property_panel_selection_shell_renderers.js
@@ -1,41 +1,5 @@
-import { describeSelectionOrigin } from './selection_meta_helpers.js';
+import { appendSingleSelectionHero } from './property_panel_selection_hero_renderer.js';
 import { renderSelectionBadgeRow, renderSelectionFactList } from './property_panel_selection_row_renderers.js';
-
-function appendSingleSelectionHero(doc, element, primary, detailFacts) {
-  const hero = doc.createElement('div');
-  hero.className = 'cad-selection-hero';
-
-  const swatch = doc.createElement('div');
-  swatch.className = 'cad-selection-hero__swatch';
-  swatch.dataset.selectionField = 'effective-color-swatch';
-  const effectiveColorFact = detailFacts.find((fact) => fact && fact.key === 'effective-color');
-  const swatchColor = typeof effectiveColorFact?.swatch === 'string' && effectiveColorFact.swatch.trim()
-    ? effectiveColorFact.swatch.trim()
-    : (typeof primary.color === 'string' && primary.color.trim() ? primary.color.trim() : '#ffffff');
-  swatch.dataset.selectionColor = swatchColor;
-  swatch.style.background = swatchColor;
-  hero.appendChild(swatch);
-
-  const heroText = doc.createElement('div');
-  heroText.className = 'cad-selection-hero__text';
-
-  const title = doc.createElement('strong');
-  title.className = 'cad-selection-hero__title';
-  title.dataset.selectionField = 'type';
-  title.textContent = primary.type || 'entity';
-  heroText.appendChild(title);
-
-  const caption = describeSelectionOrigin(primary, { separator: ' / ', includeReadOnly: true });
-  if (caption) {
-    const subtitle = doc.createElement('div');
-    subtitle.className = 'cad-selection-hero__subtitle';
-    subtitle.dataset.selectionField = 'origin-caption';
-    subtitle.textContent = caption;
-    heroText.appendChild(subtitle);
-  }
-  hero.appendChild(heroText);
-  element.appendChild(hero);
-}
 
 export function appendEmptySelectionShell(doc, element) {
   const empty = doc.createElement('div');


### PR DESCRIPTION
## Summary
- extract the single-selection hero fragment into `property_panel_selection_hero_renderer.js`
- keep `property_panel_selection_shell_renderers.js` focused on empty/multiple/single shell composition
- add focused tests for swatch fallback, title fallback, origin caption rendering, and DOM order

## Verification
- node --check tools/web_viewer/ui/property_panel_selection_hero_renderer.js
- node --check tools/web_viewer/ui/property_panel_selection_shell_renderers.js
- node --test tools/web_viewer/tests/property_panel_selection_hero_renderer.test.js tools/web_viewer/tests/property_panel_selection_shell_renderers.test.js
- node --test tools/web_viewer/tests/property_panel_selection_shells.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check