### PR TITLE
refactor: extract released insert actions

### DIFF
--- a/docs/STEP365_RELEASED_INSERT_ACTIONS_DESIGN.md
+++ b/docs/STEP365_RELEASED_INSERT_ACTIONS_DESIGN.md
@@ -1,0 +1,61 @@
+# Step365: Released Insert Actions Extraction
+
+## Goal
+
+Extract the released-insert action builder from:
+
+- `tools/web_viewer/ui/property_panel_group_actions.js`
+
+The purpose is to isolate released peer navigation and released-group actions without changing action labels, ids, invoke wiring, failure messages, or action ordering.
+
+## Scope
+
+In scope:
+
+- Extract `buildReleasedInsertArchiveActions(...)`
+- Keep released peer navigation action assembly unchanged
+- Keep released group selection / fit action assembly unchanged
+
+Out of scope:
+
+- `buildSourceGroupActions(...)`
+- `buildInsertGroupActions(...)`
+- `pushAction(...)`
+- property panel branch wiring
+- property panel glue wiring
+
+## Constraints
+
+- Keep `buildReleasedInsertArchiveActions(...)` public contract unchanged.
+- Preserve exact action ids, labels, invoke arguments, failure messages, and action ordering.
+- Preserve current gating for:
+  - missing entity
+  - missing released archive
+  - peer target count
+  - `selectionMatchesGroup`
+  - group member count
+- Only extract released insert archive action assembly into a dedicated helper module.
+- Keep `property_panel_group_actions.js` re-exporting or forwarding `buildReleasedInsertArchiveActions(...)`.
+- Do not import `selection_presenter.js` or unrelated property-panel entrypoints from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_released_insert_actions.js`
+
+Expected responsibility split:
+
+- helper: released peer navigation + released insert group actions
+- `property_panel_group_actions.js`: source-group actions, insert-group actions, shared `pushAction(...)`, and released-action re-export/forwarding
+
+## Acceptance
+
+Accept Step365 only if:
+
+- `property_panel_group_actions.js` no longer hand-builds released insert archive actions
+- released action output remains behaviorally identical
+- focused tests cover peer navigation, group gating, and missing-archive behavior
+- existing property panel group action tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP365_RELEASED_INSERT_ACTIONS_VERIFICATION.md
+++ b/docs/STEP365_RELEASED_INSERT_ACTIONS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step365: Released Insert Actions Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step365-released-insert-actions`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_released_insert_actions.js
+node --check tools/web_viewer/ui/property_panel_group_actions.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_released_insert_actions.test.js \
+  tools/web_viewer/tests/property_panel_group_actions.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_released_insert_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_released_insert_actions.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildReleasedInsertArchiveActions } from '../ui/property_panel_released_insert_actions.js';
+
+test('buildReleasedInsertArchiveActions returns empty for missing entity or archive', () => {
+  assert.deepEqual(buildReleasedInsertArchiveActions(null, null, {}), []);
+  assert.deepEqual(buildReleasedInsertArchiveActions({ id: 1 }, null, {}), []);
+  assert.deepEqual(
+    buildReleasedInsertArchiveActions({ id: 1 }, { releasedInsert: { archive: null } }, {}),
+    [],
+  );
+});
+
+test('buildReleasedInsertArchiveActions preserves peer navigation and group labels', () => {
+  const entity = { id: 31, type: 'text' };
+  const actionContext = {
+    releasedInsert: {
+      archive: { sourceType: 'INSERT', groupId: 5, blockName: 'TAG' },
+      groupSummary: { memberIds: [31, 32] },
+      peerTargets: [
+        { index: 0, target: '1: Model / Model', isCurrent: true },
+        { index: 1, target: '2: Paper / A1', isCurrent: false },
+      ],
+      selectionMatchesGroup: false,
+    },
+  };
+  const actions = buildReleasedInsertArchiveActions(entity, actionContext, {
+    openReleasedInsertPeer: () => true,
+    selectReleasedInsertGroup: () => true,
+    fitReleasedInsertGroup: () => true,
+  });
+
+  assert.deepEqual(
+    actions.map((action) => action.label),
+    [
+      'Open 2: Paper / A1',
+      'Previous Released Peer',
+      'Next Released Peer',
+      'Select Released Insert Group (2)',
+      'Fit Released Insert Group',
+    ],
+  );
+});
+
+test('buildReleasedInsertArchiveActions omits select action when selection already matches group', () => {
+  const actions = buildReleasedInsertArchiveActions(
+    { id: 31, type: 'text' },
+    {
+      releasedInsert: {
+        archive: { sourceType: 'INSERT', groupId: 5, blockName: 'TAG' },
+        groupSummary: { memberIds: [31, 32] },
+        peerTargets: [],
+        selectionMatchesGroup: true,
+      },
+    },
+    {
+      selectReleasedInsertGroup: () => true,
+      fitReleasedInsertGroup: () => true,
+    },
+  );
+
+  assert.deepEqual(
+    actions.map((action) => action.id),
+    ['fit-released-insert-group'],
+  );
+});
+
+test('buildReleasedInsertArchiveActions reports action failure via setStatus', () => {
+  const failures = [];
+  const actions = buildReleasedInsertArchiveActions(
+    { id: 31, type: 'text' },
+    {
+      releasedInsert: {
+        archive: { sourceType: 'INSERT', groupId: 5, blockName: 'TAG' },
+        groupSummary: { memberIds: [31, 32] },
+        peerTargets: [],
+        selectionMatchesGroup: false,
+      },
+    },
+    {
+      setStatus: (message) => failures.push(message),
+      selectReleasedInsertGroup: () => false,
+    },
+  );
+
+  const selectAction = actions.find((action) => action.id === 'select-released-insert-group');
+  assert.ok(selectAction);
+  selectAction.onClick();
+  assert.deepEqual(failures, ['Select Released Insert Group failed']);
+});

--- a/tools/web_viewer/ui/property_panel_group_actions.js
+++ b/tools/web_viewer/ui/property_panel_group_actions.js
@@ -1,4 +1,5 @@
 import { isInsertGroupEntity } from '../insert_group.js';
+export { buildReleasedInsertArchiveActions } from './property_panel_released_insert_actions.js';
 
 function pushAction(actions, {
   id,
@@ -251,66 +252,6 @@ export function buildInsertGroupActions(entity, actionContext = null, deps = {})
       label: `Release Insert Group (${insertGroupSummary.memberIds.length})`,
       invoke: () => (typeof releaseInsertGroup === 'function' ? releaseInsertGroup(entity.id) : false),
       failureMessage: 'Release Insert Group failed',
-      setStatus,
-    });
-  }
-  return actions;
-}
-
-export function buildReleasedInsertArchiveActions(entity, actionContext = null, deps = {}) {
-  const releasedInsert = actionContext?.releasedInsert || null;
-  if (!entity || !releasedInsert?.archive) return [];
-  const {
-    setStatus = null,
-    openReleasedInsertPeer = null,
-    selectReleasedInsertGroup = null,
-    fitReleasedInsertGroup = null,
-  } = deps;
-  const releasedInsertGroupSummary = releasedInsert.groupSummary;
-  const releasedInsertPeerTargets = Array.isArray(releasedInsert.peerTargets) ? releasedInsert.peerTargets : [];
-  const actions = [];
-
-  if (releasedInsertPeerTargets.length > 1) {
-    for (const peerTarget of releasedInsertPeerTargets) {
-      if (peerTarget.isCurrent) continue;
-      pushAction(actions, {
-        id: `open-released-insert-peer-${peerTarget.index + 1}`,
-        label: `Open ${peerTarget.target}`,
-        invoke: () => (typeof openReleasedInsertPeer === 'function' ? openReleasedInsertPeer(entity.id, { peerIndex: peerTarget.index }) : false),
-        failureMessage: `Open ${peerTarget.target} failed`,
-        setStatus,
-      });
-    }
-    pushAction(actions, {
-      id: 'previous-released-insert-peer',
-      label: 'Previous Released Peer',
-      invoke: () => (typeof openReleasedInsertPeer === 'function' ? openReleasedInsertPeer(entity.id, { direction: -1 }) : false),
-      failureMessage: 'Previous Released Peer failed',
-      setStatus,
-    });
-    pushAction(actions, {
-      id: 'next-released-insert-peer',
-      label: 'Next Released Peer',
-      invoke: () => (typeof openReleasedInsertPeer === 'function' ? openReleasedInsertPeer(entity.id, { direction: 1 }) : false),
-      failureMessage: 'Next Released Peer failed',
-      setStatus,
-    });
-  }
-  if (releasedInsertGroupSummary && releasedInsertGroupSummary.memberIds.length > 0 && !releasedInsert.selectionMatchesGroup) {
-    pushAction(actions, {
-      id: 'select-released-insert-group',
-      label: `Select Released Insert Group (${releasedInsertGroupSummary.memberIds.length})`,
-      invoke: () => (typeof selectReleasedInsertGroup === 'function' ? selectReleasedInsertGroup(entity.id) : false),
-      failureMessage: 'Select Released Insert Group failed',
-      setStatus,
-    });
-  }
-  if (releasedInsertGroupSummary && releasedInsertGroupSummary.memberIds.length > 0) {
-    pushAction(actions, {
-      id: 'fit-released-insert-group',
-      label: 'Fit Released Insert Group',
-      invoke: () => (typeof fitReleasedInsertGroup === 'function' ? fitReleasedInsertGroup(entity.id) : false),
-      failureMessage: 'Fit Released Insert Group failed',
       setStatus,
     });
   }

--- a/tools/web_viewer/ui/property_panel_released_insert_actions.js
+++ b/tools/web_viewer/ui/property_panel_released_insert_actions.js
@@ -1,0 +1,85 @@
+function pushAction(actions, {
+  id,
+  label,
+  invoke,
+  failureMessage,
+  setStatus = null,
+}) {
+  if (typeof invoke !== 'function') return;
+  actions.push({
+    id,
+    label,
+    onClick: () => {
+      const result = invoke();
+      if (result === false && typeof setStatus === 'function') {
+        setStatus(failureMessage);
+      }
+    },
+  });
+}
+
+export function buildReleasedInsertArchiveActions(entity, actionContext = null, deps = {}) {
+  const releasedInsert = actionContext?.releasedInsert || null;
+  if (!entity || !releasedInsert?.archive) return [];
+  const {
+    setStatus = null,
+    openReleasedInsertPeer = null,
+    selectReleasedInsertGroup = null,
+    fitReleasedInsertGroup = null,
+  } = deps;
+  const releasedInsertGroupSummary = releasedInsert.groupSummary;
+  const releasedInsertPeerTargets = Array.isArray(releasedInsert.peerTargets) ? releasedInsert.peerTargets : [];
+  const actions = [];
+
+  if (releasedInsertPeerTargets.length > 1) {
+    for (const peerTarget of releasedInsertPeerTargets) {
+      if (peerTarget.isCurrent) continue;
+      pushAction(actions, {
+        id: `open-released-insert-peer-${peerTarget.index + 1}`,
+        label: `Open ${peerTarget.target}`,
+        invoke: () => (typeof openReleasedInsertPeer === 'function'
+          ? openReleasedInsertPeer(entity.id, { peerIndex: peerTarget.index })
+          : false),
+        failureMessage: `Open ${peerTarget.target} failed`,
+        setStatus,
+      });
+    }
+    pushAction(actions, {
+      id: 'previous-released-insert-peer',
+      label: 'Previous Released Peer',
+      invoke: () => (typeof openReleasedInsertPeer === 'function'
+        ? openReleasedInsertPeer(entity.id, { direction: -1 })
+        : false),
+      failureMessage: 'Previous Released Peer failed',
+      setStatus,
+    });
+    pushAction(actions, {
+      id: 'next-released-insert-peer',
+      label: 'Next Released Peer',
+      invoke: () => (typeof openReleasedInsertPeer === 'function'
+        ? openReleasedInsertPeer(entity.id, { direction: 1 })
+        : false),
+      failureMessage: 'Next Released Peer failed',
+      setStatus,
+    });
+  }
+  if (releasedInsertGroupSummary && releasedInsertGroupSummary.memberIds.length > 0 && !releasedInsert.selectionMatchesGroup) {
+    pushAction(actions, {
+      id: 'select-released-insert-group',
+      label: `Select Released Insert Group (${releasedInsertGroupSummary.memberIds.length})`,
+      invoke: () => (typeof selectReleasedInsertGroup === 'function' ? selectReleasedInsertGroup(entity.id) : false),
+      failureMessage: 'Select Released Insert Group failed',
+      setStatus,
+    });
+  }
+  if (releasedInsertGroupSummary && releasedInsertGroupSummary.memberIds.length > 0) {
+    pushAction(actions, {
+      id: 'fit-released-insert-group',
+      label: 'Fit Released Insert Group',
+      invoke: () => (typeof fitReleasedInsertGroup === 'function' ? fitReleasedInsertGroup(entity.id) : false),
+      failureMessage: 'Fit Released Insert Group failed',
+      setStatus,
+    });
+  }
+  return actions;
+}


### PR DESCRIPTION
## Summary
- extract released insert archive action assembly into a dedicated helper
- keep `property_panel_group_actions.js` forwarding `buildReleasedInsertArchiveActions(...)`
- add focused helper coverage for missing-archive, group gating, and failure status behavior

## Verification
- `node --check tools/web_viewer/ui/property_panel_released_insert_actions.js`
- `node --check tools/web_viewer/ui/property_panel_group_actions.js`
- `node --test tools/web_viewer/tests/property_panel_released_insert_actions.test.js tools/web_viewer/tests/property_panel_group_actions.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
