### PR TITLE
refactor: extract insert group actions

### DIFF
--- a/docs/STEP366_INSERT_GROUP_ACTIONS_DESIGN.md
+++ b/docs/STEP366_INSERT_GROUP_ACTIONS_DESIGN.md
@@ -1,0 +1,63 @@
+# Step366: Insert Group Actions Extraction
+
+## Goal
+
+Extract the insert-group action builder from:
+
+- `tools/web_viewer/ui/property_panel_group_actions.js`
+
+The purpose is to isolate insert peer navigation, insert-group selection, editable-member selection, fit, edit, and release actions without changing labels, ids, invoke wiring, failure messages, or action ordering.
+
+## Scope
+
+In scope:
+
+- Extract `buildInsertGroupActions(...)`
+- Keep insert peer navigation action assembly unchanged
+- Keep insert text / editable text / editable member selection action assembly unchanged
+- Keep fit / release-and-edit / release actions unchanged
+
+Out of scope:
+
+- `buildSourceGroupActions(...)`
+- `buildReleasedInsertArchiveActions(...)`
+- `pushAction(...)`
+- property panel branch wiring
+- property panel glue wiring
+
+## Constraints
+
+- Keep `buildInsertGroupActions(...)` public contract unchanged.
+- Preserve exact action ids, labels, invoke arguments, failure messages, and action ordering.
+- Preserve current gating for:
+  - missing entity
+  - missing insert summary
+  - peer target count
+  - `peerNavigableSelection`
+  - selectionMatches* flags
+  - editable vs read-only member counts
+- Only extract insert-group action assembly into a dedicated helper module.
+- Keep `property_panel_group_actions.js` forwarding or re-exporting `buildInsertGroupActions(...)`.
+- Do not import `selection_presenter.js` or unrelated property-panel entrypoints from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_insert_group_actions.js`
+
+Expected responsibility split:
+
+- helper: insert peer navigation + insert group actions
+- `property_panel_group_actions.js`: source-group actions, shared `pushAction(...)`, and re-exports/forwarding
+
+## Acceptance
+
+Accept Step366 only if:
+
+- `property_panel_group_actions.js` no longer hand-builds insert-group actions
+- insert-group action output remains behaviorally identical
+- focused tests cover peer navigation, editable-member gating, missing-summary behavior, and failure status behavior
+- existing property panel group action tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP366_INSERT_GROUP_ACTIONS_VERIFICATION.md
+++ b/docs/STEP366_INSERT_GROUP_ACTIONS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step366: Insert Group Actions Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step366-insert-group-actions-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_insert_group_actions.js
+node --check tools/web_viewer/ui/property_panel_group_actions.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_insert_group_actions.test.js \
+  tools/web_viewer/tests/property_panel_group_actions.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_insert_group_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_insert_group_actions.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildInsertGroupActions } from '../ui/property_panel_insert_group_actions.js';
+
+test('buildInsertGroupActions returns empty for missing entity or summary', () => {
+  assert.deepEqual(buildInsertGroupActions(null, null, {}), []);
+  assert.deepEqual(buildInsertGroupActions({ id: 1 }, null, {}), []);
+  assert.deepEqual(
+    buildInsertGroupActions({ id: 1 }, { insertGroup: { summary: null } }, {}),
+    [],
+  );
+});
+
+test('buildInsertGroupActions preserves peer and editable action labels', () => {
+  const actions = buildInsertGroupActions(
+    { id: 21, type: 'text', sourceType: 'INSERT', proxyKind: 'text', editMode: 'proxy' },
+    {
+      insertGroup: {
+        summary: { memberIds: [21, 22, 23], editableIds: [21], readOnlyIds: [22, 23] },
+        peerTargets: [
+          { index: 0, target: '1: Model / Model', isCurrent: true },
+          { index: 1, target: '2: Paper / A1', isCurrent: false },
+        ],
+        textMemberCount: 2,
+        editableTextMemberCount: 1,
+        selectionMatchesGroup: false,
+        selectionMatchesText: false,
+        selectionMatchesEditableText: false,
+        selectionMatchesEditableMembers: false,
+        peerNavigableSelection: true,
+      },
+    },
+    {
+      openInsertPeer: () => true,
+      selectInsertGroup: () => true,
+      selectInsertText: () => true,
+      selectEditableInsertText: () => true,
+      selectEditableInsertGroup: () => true,
+      fitInsertGroup: () => true,
+      editInsertText: () => true,
+      releaseInsertGroup: () => true,
+    },
+  );
+
+  assert.deepEqual(
+    actions.map((action) => action.label),
+    [
+      'Open 2: Paper / A1',
+      'Previous Peer Instance',
+      'Next Peer Instance',
+      'Select Insert Group (3)',
+      'Select Insert Text (2)',
+      'Select Editable Insert Text (1)',
+      'Select Editable Members (1)',
+      'Fit Insert Group',
+      'Release & Edit Insert Text (2)',
+      'Release Insert Group (3)',
+    ],
+  );
+});
+
+test('buildInsertGroupActions omits editable-member action when selection already matches editable members', () => {
+  const actions = buildInsertGroupActions(
+    { id: 21, type: 'text' },
+    {
+      insertGroup: {
+        summary: { memberIds: [21, 22, 23], editableIds: [21], readOnlyIds: [22, 23] },
+        peerTargets: [],
+        textMemberCount: 0,
+        editableTextMemberCount: 0,
+        selectionMatchesGroup: false,
+        selectionMatchesText: false,
+        selectionMatchesEditableText: false,
+        selectionMatchesEditableMembers: true,
+        peerNavigableSelection: false,
+      },
+    },
+    {
+      selectEditableInsertGroup: () => true,
+      fitInsertGroup: () => true,
+      releaseInsertGroup: () => true,
+    },
+  );
+
+  assert.ok(!actions.some((action) => action.id === 'select-insert-editable'));
+});
+
+test('buildInsertGroupActions reports selection failure via setStatus', () => {
+  const failures = [];
+  const actions = buildInsertGroupActions(
+    { id: 21, type: 'text' },
+    {
+      insertGroup: {
+        summary: { memberIds: [21, 22], editableIds: [], readOnlyIds: [21, 22] },
+        peerTargets: [],
+        textMemberCount: 0,
+        editableTextMemberCount: 0,
+        selectionMatchesGroup: false,
+        selectionMatchesText: false,
+        selectionMatchesEditableText: false,
+        selectionMatchesEditableMembers: false,
+        peerNavigableSelection: false,
+      },
+    },
+    {
+      setStatus: (message) => failures.push(message),
+      selectInsertGroup: () => false,
+    },
+  );
+
+  const selectAction = actions.find((action) => action.id === 'select-insert-group');
+  assert.ok(selectAction);
+  selectAction.onClick();
+  assert.deepEqual(failures, ['Select Insert Group failed']);
+});

--- a/tools/web_viewer/ui/property_panel_group_actions.js
+++ b/tools/web_viewer/ui/property_panel_group_actions.js
@@ -1,4 +1,5 @@
 import { isInsertGroupEntity } from '../insert_group.js';
+export { buildInsertGroupActions } from './property_panel_insert_group_actions.js';
 export { buildReleasedInsertArchiveActions } from './property_panel_released_insert_actions.js';
 
 function pushAction(actions, {
@@ -138,120 +139,6 @@ export function buildSourceGroupActions(entity, actionContext = null, deps = {})
       label: `Release Source Group (${sourceGroupSummary.memberIds.length})`,
       invoke: () => (typeof releaseSourceGroup === 'function' ? releaseSourceGroup(entity.id) : false),
       failureMessage: 'Release Source Group failed',
-      setStatus,
-    });
-  }
-  return actions;
-}
-
-export function buildInsertGroupActions(entity, actionContext = null, deps = {}) {
-  const insertGroup = actionContext?.insertGroup || null;
-  if (!entity || !insertGroup?.summary) return [];
-  const {
-    setStatus = null,
-    openInsertPeer = null,
-    selectInsertGroup = null,
-    selectInsertText = null,
-    selectEditableInsertText = null,
-    selectEditableInsertGroup = null,
-    fitInsertGroup = null,
-    editInsertText = null,
-    releaseInsertGroup = null,
-  } = deps;
-  const insertGroupSummary = insertGroup.summary;
-  const insertPeerTargets = Array.isArray(insertGroup.peerTargets) ? insertGroup.peerTargets : [];
-  const actions = [];
-
-  if (insertPeerTargets.length > 1 && insertGroup.peerNavigableSelection) {
-    for (const peerTarget of insertPeerTargets) {
-      if (peerTarget.isCurrent) continue;
-      pushAction(actions, {
-        id: `open-insert-peer-${peerTarget.index + 1}`,
-        label: `Open ${peerTarget.target}`,
-        invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { peerIndex: peerTarget.index }) : false),
-        failureMessage: `Open ${peerTarget.target} failed`,
-        setStatus,
-      });
-    }
-    pushAction(actions, {
-      id: 'previous-insert-peer',
-      label: 'Previous Peer Instance',
-      invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { direction: -1 }) : false),
-      failureMessage: 'Previous Peer Instance failed',
-      setStatus,
-    });
-    pushAction(actions, {
-      id: 'next-insert-peer',
-      label: 'Next Peer Instance',
-      invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { direction: 1 }) : false),
-      failureMessage: 'Next Peer Instance failed',
-      setStatus,
-    });
-  }
-  if (insertGroupSummary.memberIds.length > 1 && !insertGroup.selectionMatchesGroup) {
-    pushAction(actions, {
-      id: 'select-insert-group',
-      label: `Select Insert Group (${insertGroupSummary.memberIds.length})`,
-      invoke: () => (typeof selectInsertGroup === 'function' ? selectInsertGroup(entity.id) : false),
-      failureMessage: 'Select Insert Group failed',
-      setStatus,
-    });
-  }
-  if (insertGroup.textMemberCount > 0 && !insertGroup.selectionMatchesText) {
-    pushAction(actions, {
-      id: 'select-insert-text',
-      label: `Select Insert Text (${insertGroup.textMemberCount})`,
-      invoke: () => (typeof selectInsertText === 'function' ? selectInsertText(entity.id) : false),
-      failureMessage: 'Select Insert Text failed',
-      setStatus,
-    });
-  }
-  if (insertGroup.editableTextMemberCount > 0 && !insertGroup.selectionMatchesEditableText) {
-    pushAction(actions, {
-      id: 'select-editable-insert-text',
-      label: `Select Editable Insert Text (${insertGroup.editableTextMemberCount})`,
-      invoke: () => (typeof selectEditableInsertText === 'function' ? selectEditableInsertText(entity.id) : false),
-      failureMessage: 'Select Editable Insert Text failed',
-      setStatus,
-    });
-  }
-  if (
-    insertGroupSummary.readOnlyIds.length > 0
-    && insertGroupSummary.editableIds.length > 0
-    && !insertGroup.selectionMatchesEditableMembers
-  ) {
-    pushAction(actions, {
-      id: 'select-insert-editable',
-      label: `Select Editable Members (${insertGroupSummary.editableIds.length})`,
-      invoke: () => (typeof selectEditableInsertGroup === 'function' ? selectEditableInsertGroup(entity.id) : false),
-      failureMessage: 'Select Editable Members failed',
-      setStatus,
-    });
-  }
-  if (insertGroupSummary.memberIds.length > 0) {
-    pushAction(actions, {
-      id: 'fit-insert-group',
-      label: 'Fit Insert Group',
-      invoke: () => (typeof fitInsertGroup === 'function' ? fitInsertGroup(entity.id) : false),
-      failureMessage: 'Fit Insert Group failed',
-      setStatus,
-    });
-  }
-  if (insertGroup.textMemberCount > 0) {
-    pushAction(actions, {
-      id: 'edit-insert-text',
-      label: `Release & Edit Insert Text (${insertGroup.textMemberCount})`,
-      invoke: () => (typeof editInsertText === 'function' ? editInsertText(entity.id) : false),
-      failureMessage: 'Release & Edit Insert Text failed',
-      setStatus,
-    });
-  }
-  if (insertGroupSummary.memberIds.length > 0) {
-    pushAction(actions, {
-      id: 'release-insert-group',
-      label: `Release Insert Group (${insertGroupSummary.memberIds.length})`,
-      invoke: () => (typeof releaseInsertGroup === 'function' ? releaseInsertGroup(entity.id) : false),
-      failureMessage: 'Release Insert Group failed',
       setStatus,
     });
   }

--- a/tools/web_viewer/ui/property_panel_insert_group_actions.js
+++ b/tools/web_viewer/ui/property_panel_insert_group_actions.js
@@ -1,0 +1,133 @@
+function pushAction(actions, {
+  id,
+  label,
+  invoke,
+  failureMessage,
+  setStatus = null,
+}) {
+  if (typeof invoke !== 'function') return;
+  actions.push({
+    id,
+    label,
+    onClick: () => {
+      const result = invoke();
+      if (result === false && typeof setStatus === 'function') {
+        setStatus(failureMessage);
+      }
+    },
+  });
+}
+
+export function buildInsertGroupActions(entity, actionContext = null, deps = {}) {
+  const insertGroup = actionContext?.insertGroup || null;
+  if (!entity || !insertGroup?.summary) return [];
+  const {
+    setStatus = null,
+    openInsertPeer = null,
+    selectInsertGroup = null,
+    selectInsertText = null,
+    selectEditableInsertText = null,
+    selectEditableInsertGroup = null,
+    fitInsertGroup = null,
+    editInsertText = null,
+    releaseInsertGroup = null,
+  } = deps;
+  const insertGroupSummary = insertGroup.summary;
+  const insertPeerTargets = Array.isArray(insertGroup.peerTargets) ? insertGroup.peerTargets : [];
+  const actions = [];
+
+  if (insertPeerTargets.length > 1 && insertGroup.peerNavigableSelection) {
+    for (const peerTarget of insertPeerTargets) {
+      if (peerTarget.isCurrent) continue;
+      pushAction(actions, {
+        id: `open-insert-peer-${peerTarget.index + 1}`,
+        label: `Open ${peerTarget.target}`,
+        invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { peerIndex: peerTarget.index }) : false),
+        failureMessage: `Open ${peerTarget.target} failed`,
+        setStatus,
+      });
+    }
+    pushAction(actions, {
+      id: 'previous-insert-peer',
+      label: 'Previous Peer Instance',
+      invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { direction: -1 }) : false),
+      failureMessage: 'Previous Peer Instance failed',
+      setStatus,
+    });
+    pushAction(actions, {
+      id: 'next-insert-peer',
+      label: 'Next Peer Instance',
+      invoke: () => (typeof openInsertPeer === 'function' ? openInsertPeer(entity.id, { direction: 1 }) : false),
+      failureMessage: 'Next Peer Instance failed',
+      setStatus,
+    });
+  }
+  if (insertGroupSummary.memberIds.length > 1 && !insertGroup.selectionMatchesGroup) {
+    pushAction(actions, {
+      id: 'select-insert-group',
+      label: `Select Insert Group (${insertGroupSummary.memberIds.length})`,
+      invoke: () => (typeof selectInsertGroup === 'function' ? selectInsertGroup(entity.id) : false),
+      failureMessage: 'Select Insert Group failed',
+      setStatus,
+    });
+  }
+  if (insertGroup.textMemberCount > 0 && !insertGroup.selectionMatchesText) {
+    pushAction(actions, {
+      id: 'select-insert-text',
+      label: `Select Insert Text (${insertGroup.textMemberCount})`,
+      invoke: () => (typeof selectInsertText === 'function' ? selectInsertText(entity.id) : false),
+      failureMessage: 'Select Insert Text failed',
+      setStatus,
+    });
+  }
+  if (insertGroup.editableTextMemberCount > 0 && !insertGroup.selectionMatchesEditableText) {
+    pushAction(actions, {
+      id: 'select-editable-insert-text',
+      label: `Select Editable Insert Text (${insertGroup.editableTextMemberCount})`,
+      invoke: () => (typeof selectEditableInsertText === 'function' ? selectEditableInsertText(entity.id) : false),
+      failureMessage: 'Select Editable Insert Text failed',
+      setStatus,
+    });
+  }
+  if (
+    insertGroupSummary.readOnlyIds.length > 0
+    && insertGroupSummary.editableIds.length > 0
+    && !insertGroup.selectionMatchesEditableMembers
+  ) {
+    pushAction(actions, {
+      id: 'select-insert-editable',
+      label: `Select Editable Members (${insertGroupSummary.editableIds.length})`,
+      invoke: () => (typeof selectEditableInsertGroup === 'function' ? selectEditableInsertGroup(entity.id) : false),
+      failureMessage: 'Select Editable Members failed',
+      setStatus,
+    });
+  }
+  if (insertGroupSummary.memberIds.length > 0) {
+    pushAction(actions, {
+      id: 'fit-insert-group',
+      label: 'Fit Insert Group',
+      invoke: () => (typeof fitInsertGroup === 'function' ? fitInsertGroup(entity.id) : false),
+      failureMessage: 'Fit Insert Group failed',
+      setStatus,
+    });
+  }
+  if (insertGroup.textMemberCount > 0) {
+    pushAction(actions, {
+      id: 'edit-insert-text',
+      label: `Release & Edit Insert Text (${insertGroup.textMemberCount})`,
+      invoke: () => (typeof editInsertText === 'function' ? editInsertText(entity.id) : false),
+      failureMessage: 'Release & Edit Insert Text failed',
+      setStatus,
+    });
+  }
+  if (insertGroupSummary.memberIds.length > 0) {
+    pushAction(actions, {
+      id: 'release-insert-group',
+      label: `Release Insert Group (${insertGroupSummary.memberIds.length})`,
+      invoke: () => (typeof releaseInsertGroup === 'function' ? releaseInsertGroup(entity.id) : false),
+      failureMessage: 'Release Insert Group failed',
+      setStatus,
+    });
+  }
+  return actions;
+}


### PR DESCRIPTION
## Summary
- extract insert-group action assembly into a dedicated helper
- keep `property_panel_group_actions.js` forwarding `buildInsertGroupActions(...)`
- add focused helper coverage for missing-summary, editable-member gating, and failure status behavior

## Verification
- `node --check tools/web_viewer/ui/property_panel_insert_group_actions.js`
- `node --check tools/web_viewer/ui/property_panel_group_actions.js`
- `node --test tools/web_viewer/tests/property_panel_insert_group_actions.test.js tools/web_viewer/tests/property_panel_group_actions.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
