### PR TITLE
refactor: extract glue group action appenders

### DIFF
--- a/docs/STEP368_GLUE_GROUP_ACTION_APPENDERS_DESIGN.md
+++ b/docs/STEP368_GLUE_GROUP_ACTION_APPENDERS_DESIGN.md
@@ -1,0 +1,74 @@
+# Step368: Glue Group Action Appenders Extraction
+
+## Goal
+
+Extract the grouped action appenders from:
+
+- `tools/web_viewer/ui/property_panel_glue_facade.js`
+
+The purpose is to isolate the glue-layer wrappers around:
+
+- `buildSourceGroupActions(...)`
+- `buildInsertGroupActions(...)`
+- `buildReleasedInsertArchiveActions(...)`
+- `appendCommonSelectionActions(...)`
+
+without changing add-action-row behavior, row ordering, or facade contract.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendSourceGroupActions(...)`
+  - `appendInsertGroupActions(...)`
+  - `appendReleasedInsertArchiveActions(...)`
+  - `appendCommonSelectionActions(...)`
+- Keep grouped action row ordering unchanged
+- Keep `setStatus` and action handler threading unchanged
+
+Out of scope:
+
+- `appendStyleActions(...)`
+- `appendLayerActions(...)`
+- field descriptor routing helpers
+- collaborator wiring
+- branch context wiring
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFacade(...)` public contract unchanged.
+- Preserve exact row ordering for grouped action rows.
+- Preserve exact deps threading into:
+  - `buildSourceGroupActions(...)`
+  - `buildInsertGroupActions(...)`
+  - `buildReleasedInsertArchiveActions(...)`
+- Preserve `addActionRow(...)` call count and sequencing.
+- Only extract grouped action appenders into a dedicated helper module.
+- Keep `property_panel_glue_facade.js` owning the public facade return shape.
+- Do not import `selection_presenter.js` or unrelated entrypoints from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_glue_group_actions.js`
+
+Expected responsibility split:
+
+- helper: grouped action appenders + shared grouped-action deps bag
+- `property_panel_glue_facade.js`: style actions, layer actions, field routing, facade assembly
+
+## Acceptance
+
+Accept Step368 only if:
+
+- `property_panel_glue_facade.js` no longer hand-builds grouped action appenders
+- grouped action row order remains unchanged
+- focused tests cover:
+  - source / insert / released deps threading
+  - common selection action sequencing
+  - action row ordering
+- existing glue facade tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP368_GLUE_GROUP_ACTION_APPENDERS_VERIFICATION.md
+++ b/docs/STEP368_GLUE_GROUP_ACTION_APPENDERS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step368: Glue Group Action Appenders Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step368-glue-group-action-appenders-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_glue_group_actions.js
+node --check tools/web_viewer/ui/property_panel_glue_facade.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_glue_group_actions.test.js \
+  tools/web_viewer/tests/property_panel_glue_facade.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_glue_group_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_glue_group_actions.test.js
@@ -1,0 +1,170 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGroupActionAppenders } from '../ui/property_panel_glue_group_actions.js';
+
+function createHarness(overrides = {}) {
+  const actionRows = [];
+  const statusMessages = [];
+
+  const appenders = createGroupActionAppenders({
+    addActionRow: (actions) => actionRows.push(actions),
+    setStatus: (message) => statusMessages.push(message),
+    ...overrides,
+  });
+
+  return { appenders, actionRows, statusMessages };
+}
+
+const baseActionContext = {
+  sourceGroup: {
+    summary: { memberIds: [21, 22], editableIds: [], readOnlyIds: [21, 22] },
+    textMemberCount: 1,
+    resettableTextMemberCount: 0,
+    selectionMatchesGroup: false,
+    selectionMatchesText: false,
+    sourceTextGuide: null,
+  },
+  insertGroup: {
+    summary: { memberIds: [21, 22, 23], editableIds: [21], readOnlyIds: [22, 23] },
+    peerTargets: [
+      { index: 0, target: '1: Model / Model', isCurrent: true },
+      { index: 1, target: '2: Paper / A1', isCurrent: false },
+    ],
+    textMemberCount: 1,
+    editableTextMemberCount: 0,
+    selectionMatchesGroup: false,
+    selectionMatchesText: false,
+    selectionMatchesEditableText: true,
+    selectionMatchesEditableMembers: true,
+    peerNavigableSelection: true,
+  },
+  releasedInsert: {
+    archive: { sourceType: 'INSERT', groupId: 7, blockName: 'TAG' },
+    groupSummary: { memberIds: [31, 32] },
+    peerTargets: [
+      { index: 0, target: '1: Model / Model', isCurrent: true },
+      { index: 1, target: '2: Paper / A1', isCurrent: false },
+    ],
+    selectionMatchesGroup: false,
+  },
+};
+
+const baseEntity = { id: 21, type: 'text', sourceType: 'INSERT', proxyKind: 'text', editMode: 'proxy' };
+
+test('createGroupActionAppenders threads source group deps', () => {
+  const invokedWith = [];
+  const { appenders, actionRows } = createHarness({
+    selectSourceGroup: (id) => { invokedWith.push(['selectSourceGroup', id]); return true; },
+    selectSourceText: (id) => { invokedWith.push(['selectSourceText', id]); return true; },
+    fitSourceGroup: (id) => { invokedWith.push(['fitSourceGroup', id]); return true; },
+    releaseSourceGroup: (id) => { invokedWith.push(['releaseSourceGroup', id]); return true; },
+    editSourceGroupText: (id) => { invokedWith.push(['editSourceGroupText', id]); return true; },
+  });
+
+  appenders.appendSourceGroupActions(baseEntity, baseActionContext);
+
+  assert.equal(actionRows.length, 1);
+  const ids = actionRows[0].map((a) => a.id);
+  assert.ok(ids.includes('select-source-group'), 'select-source-group present');
+  assert.ok(ids.includes('select-source-text'), 'select-source-text present');
+  assert.ok(ids.includes('fit-source-group'), 'fit-source-group present');
+  assert.ok(ids.includes('release-source-group'), 'release-source-group present');
+
+  actionRows[0].find((a) => a.id === 'select-source-group').onClick();
+  assert.deepEqual(invokedWith, [['selectSourceGroup', 21]]);
+});
+
+test('createGroupActionAppenders threads insert group deps', () => {
+  const invokedWith = [];
+  const { appenders, actionRows } = createHarness({
+    openInsertPeer: (id, idx) => { invokedWith.push(['openInsertPeer', id, idx]); return true; },
+    selectInsertGroup: (id) => { invokedWith.push(['selectInsertGroup', id]); return true; },
+    selectInsertText: (id) => { invokedWith.push(['selectInsertText', id]); return true; },
+    fitInsertGroup: (id) => { invokedWith.push(['fitInsertGroup', id]); return true; },
+    releaseInsertGroup: (id) => { invokedWith.push(['releaseInsertGroup', id]); return true; },
+  });
+
+  appenders.appendInsertGroupActions(baseEntity, baseActionContext);
+
+  assert.equal(actionRows.length, 1);
+  const ids = actionRows[0].map((a) => a.id);
+  assert.ok(ids.includes('select-insert-group'), 'select-insert-group present');
+  assert.ok(ids.includes('fit-insert-group'), 'fit-insert-group present');
+  assert.ok(ids.includes('release-insert-group'), 'release-insert-group present');
+
+  actionRows[0].find((a) => a.id === 'select-insert-group').onClick();
+  assert.deepEqual(invokedWith, [['selectInsertGroup', 21]]);
+});
+
+test('createGroupActionAppenders threads released insert deps', () => {
+  const invokedWith = [];
+  const { appenders, actionRows } = createHarness({
+    openReleasedInsertPeer: (id, idx) => { invokedWith.push(['openReleasedInsertPeer', id, idx]); return true; },
+    selectReleasedInsertGroup: (id) => { invokedWith.push(['selectReleasedInsertGroup', id]); return true; },
+    fitReleasedInsertGroup: (id) => { invokedWith.push(['fitReleasedInsertGroup', id]); return true; },
+  });
+
+  appenders.appendReleasedInsertArchiveActions(baseEntity, baseActionContext);
+
+  assert.equal(actionRows.length, 1);
+  const ids = actionRows[0].map((a) => a.id);
+  assert.ok(ids.includes('select-released-insert-group'), 'select-released-insert-group present');
+  assert.ok(ids.includes('fit-released-insert-group'), 'fit-released-insert-group present');
+
+  actionRows[0].find((a) => a.id === 'select-released-insert-group').onClick();
+  assert.deepEqual(invokedWith, [['selectReleasedInsertGroup', 21]]);
+});
+
+test('createGroupActionAppenders appendCommonSelectionActions produces three rows in order', () => {
+  const { appenders, actionRows } = createHarness({
+    selectSourceGroup: () => true,
+    selectSourceText: () => true,
+    fitSourceGroup: () => true,
+    releaseSourceGroup: () => true,
+    openInsertPeer: () => true,
+    selectInsertGroup: () => true,
+    fitInsertGroup: () => true,
+    releaseInsertGroup: () => true,
+    openReleasedInsertPeer: () => true,
+    selectReleasedInsertGroup: () => true,
+    fitReleasedInsertGroup: () => true,
+  });
+
+  appenders.appendCommonSelectionActions(baseEntity, baseActionContext);
+
+  assert.equal(actionRows.length, 3);
+  assert.deepEqual(
+    actionRows.map((row) => row.map((a) => a.id)),
+    [
+      ['select-source-group', 'select-source-text', 'fit-source-group', 'edit-source-text', 'release-source-group'],
+      ['open-insert-peer-2', 'previous-insert-peer', 'next-insert-peer', 'select-insert-group', 'select-insert-text', 'fit-insert-group', 'edit-insert-text', 'release-insert-group'],
+      ['open-released-insert-peer-2', 'previous-released-insert-peer', 'next-released-insert-peer', 'select-released-insert-group', 'fit-released-insert-group'],
+    ],
+  );
+});
+
+test('createGroupActionAppenders appendCommonSelectionActions row ordering: source then insert then released', () => {
+  const { appenders, actionRows } = createHarness({
+    selectSourceGroup: () => true,
+    fitSourceGroup: () => true,
+    releaseSourceGroup: () => true,
+    openInsertPeer: () => true,
+    selectInsertGroup: () => true,
+    fitInsertGroup: () => true,
+    releaseInsertGroup: () => true,
+    openReleasedInsertPeer: () => true,
+    selectReleasedInsertGroup: () => true,
+    fitReleasedInsertGroup: () => true,
+  });
+
+  appenders.appendSourceGroupActions(baseEntity, baseActionContext);
+  appenders.appendInsertGroupActions(baseEntity, baseActionContext);
+  appenders.appendReleasedInsertArchiveActions(baseEntity, baseActionContext);
+
+  assert.equal(actionRows.length, 3);
+  // Row 0 is source, row 1 is insert, row 2 is released
+  assert.ok(actionRows[0].some((a) => a.id === 'select-source-group'), 'row 0: source group');
+  assert.ok(actionRows[1].some((a) => a.id === 'select-insert-group'), 'row 1: insert group');
+  assert.ok(actionRows[2].some((a) => a.id === 'select-released-insert-group'), 'row 2: released insert group');
+});

--- a/tools/web_viewer/ui/property_panel_glue_facade.js
+++ b/tools/web_viewer/ui/property_panel_glue_facade.js
@@ -1,9 +1,5 @@
 import { buildLayerActions } from './property_panel_layer_actions.js';
-import {
-  buildInsertGroupActions,
-  buildReleasedInsertArchiveActions,
-  buildSourceGroupActions,
-} from './property_panel_group_actions.js';
+import { createGroupActionAppenders } from './property_panel_glue_group_actions.js';
 import {
   buildFullTextEditFieldDescriptors,
   buildInsertProxyTextFieldDescriptors,
@@ -83,51 +79,37 @@ export function createPropertyPanelGlueFacade({
     }));
   }
 
-  function appendSourceGroupActions(entity, actionContext = null) {
-    addActionRow(buildSourceGroupActions(entity, actionContext, {
-      setStatus,
-      selectSourceGroup,
-      selectSourceText,
-      selectSourceAnchorDriver,
-      flipDimensionTextSide,
-      flipLeaderLandingSide,
-      resetSourceTextPlacement,
-      fitSourceAnchor,
-      fitLeaderLanding,
-      fitSourceGroup,
-      editSourceGroupText,
-      releaseSourceGroup,
-    }));
-  }
-
-  function appendInsertGroupActions(entity, actionContext = null) {
-    addActionRow(buildInsertGroupActions(entity, actionContext, {
-      setStatus,
-      openInsertPeer,
-      selectInsertGroup,
-      selectInsertText,
-      selectEditableInsertText,
-      selectEditableInsertGroup,
-      fitInsertGroup,
-      editInsertText,
-      releaseInsertGroup,
-    }));
-  }
-
-  function appendReleasedInsertArchiveActions(entity, actionContext = null) {
-    addActionRow(buildReleasedInsertArchiveActions(entity, actionContext, {
-      setStatus,
-      openReleasedInsertPeer,
-      selectReleasedInsertGroup,
-      fitReleasedInsertGroup,
-    }));
-  }
-
-  function appendCommonSelectionActions(primary, actionContext) {
-    appendSourceGroupActions(primary, actionContext);
-    appendInsertGroupActions(primary, actionContext);
-    appendReleasedInsertArchiveActions(primary, actionContext);
-  }
+  const {
+    appendSourceGroupActions,
+    appendInsertGroupActions,
+    appendReleasedInsertArchiveActions,
+    appendCommonSelectionActions,
+  } = createGroupActionAppenders({
+    addActionRow,
+    setStatus,
+    selectSourceGroup,
+    selectSourceText,
+    selectSourceAnchorDriver,
+    flipDimensionTextSide,
+    flipLeaderLandingSide,
+    resetSourceTextPlacement,
+    fitSourceAnchor,
+    fitLeaderLanding,
+    fitSourceGroup,
+    editSourceGroupText,
+    releaseSourceGroup,
+    openInsertPeer,
+    selectInsertGroup,
+    selectInsertText,
+    selectEditableInsertText,
+    selectEditableInsertGroup,
+    fitInsertGroup,
+    editInsertText,
+    releaseInsertGroup,
+    openReleasedInsertPeer,
+    selectReleasedInsertGroup,
+    fitReleasedInsertGroup,
+  });
 
   function appendCommonPropertyFields(primary, displayedColor, promoteImportedColorSource) {
     appendFieldDescriptors(buildCommonPropertyFieldDescriptors(

--- a/tools/web_viewer/ui/property_panel_glue_group_actions.js
+++ b/tools/web_viewer/ui/property_panel_glue_group_actions.js
@@ -1,0 +1,85 @@
+import {
+  buildInsertGroupActions,
+  buildReleasedInsertArchiveActions,
+  buildSourceGroupActions,
+} from './property_panel_group_actions.js';
+
+export function createGroupActionAppenders({
+  addActionRow,
+  setStatus,
+  selectSourceGroup = null,
+  selectSourceText = null,
+  selectSourceAnchorDriver = null,
+  flipDimensionTextSide = null,
+  flipLeaderLandingSide = null,
+  resetSourceTextPlacement = null,
+  fitSourceAnchor = null,
+  fitLeaderLanding = null,
+  fitSourceGroup = null,
+  editSourceGroupText = null,
+  releaseSourceGroup = null,
+  openInsertPeer = null,
+  selectInsertGroup = null,
+  selectInsertText = null,
+  selectEditableInsertText = null,
+  selectEditableInsertGroup = null,
+  fitInsertGroup = null,
+  editInsertText = null,
+  releaseInsertGroup = null,
+  openReleasedInsertPeer = null,
+  selectReleasedInsertGroup = null,
+  fitReleasedInsertGroup = null,
+}) {
+  function appendSourceGroupActions(entity, actionContext = null) {
+    addActionRow(buildSourceGroupActions(entity, actionContext, {
+      setStatus,
+      selectSourceGroup,
+      selectSourceText,
+      selectSourceAnchorDriver,
+      flipDimensionTextSide,
+      flipLeaderLandingSide,
+      resetSourceTextPlacement,
+      fitSourceAnchor,
+      fitLeaderLanding,
+      fitSourceGroup,
+      editSourceGroupText,
+      releaseSourceGroup,
+    }));
+  }
+
+  function appendInsertGroupActions(entity, actionContext = null) {
+    addActionRow(buildInsertGroupActions(entity, actionContext, {
+      setStatus,
+      openInsertPeer,
+      selectInsertGroup,
+      selectInsertText,
+      selectEditableInsertText,
+      selectEditableInsertGroup,
+      fitInsertGroup,
+      editInsertText,
+      releaseInsertGroup,
+    }));
+  }
+
+  function appendReleasedInsertArchiveActions(entity, actionContext = null) {
+    addActionRow(buildReleasedInsertArchiveActions(entity, actionContext, {
+      setStatus,
+      openReleasedInsertPeer,
+      selectReleasedInsertGroup,
+      fitReleasedInsertGroup,
+    }));
+  }
+
+  function appendCommonSelectionActions(primary, actionContext) {
+    appendSourceGroupActions(primary, actionContext);
+    appendInsertGroupActions(primary, actionContext);
+    appendReleasedInsertArchiveActions(primary, actionContext);
+  }
+
+  return {
+    appendSourceGroupActions,
+    appendInsertGroupActions,
+    appendReleasedInsertArchiveActions,
+    appendCommonSelectionActions,
+  };
+}


### PR DESCRIPTION
## Summary
- extract grouped action appenders from `property_panel_glue_facade.js` into a dedicated helper
- keep `createPropertyPanelGlueFacade(...)` public return shape unchanged
- add focused helper coverage for grouped action deps threading and row sequencing

## Verification
- `node --check tools/web_viewer/ui/property_panel_glue_group_actions.js`
- `node --check tools/web_viewer/ui/property_panel_glue_facade.js`
- `node --test tools/web_viewer/tests/property_panel_glue_group_actions.test.js tools/web_viewer/tests/property_panel_glue_facade.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
