### PR TITLE
refactor: extract glue field appenders

### DIFF
--- a/docs/STEP369_GLUE_FIELD_APPENDERS_DESIGN.md
+++ b/docs/STEP369_GLUE_FIELD_APPENDERS_DESIGN.md
@@ -1,0 +1,75 @@
+# Step369: Glue Field Appenders Extraction
+
+## Goal
+
+Extract the field appender wrappers from:
+
+- `tools/web_viewer/ui/property_panel_glue_facade.js`
+
+The purpose is to isolate the glue-layer routing around:
+
+- `buildCommonPropertyFieldDescriptors(...)`
+- `buildFullTextEditFieldDescriptors(...)`
+- `buildInsertProxyTextFieldDescriptors(...)`
+- `buildSingleEntityEditFieldDescriptors(...)`
+
+without changing field batch ordering, descriptor contents, or facade contract.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendCommonPropertyFields(...)`
+  - `appendSourceTextFields(...)`
+  - `appendInsertProxyTextFields(...)`
+  - `appendSingleEntityFields(...)`
+- Keep `appendFieldDescriptors(...)` call sequencing unchanged
+- Keep patch/buildPatch/layer collaborator threading unchanged
+
+Out of scope:
+
+- `appendStyleActions(...)`
+- `appendLayerActions(...)`
+- grouped action appenders
+- branch context wiring
+- render callback behavior
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFacade(...)` public contract unchanged.
+- Preserve exact field descriptor batch ordering for all four appenders.
+- Preserve exact deps threading into:
+  - `buildCommonPropertyFieldDescriptors(...)`
+  - `buildFullTextEditFieldDescriptors(...)`
+  - `buildInsertProxyTextFieldDescriptors(...)`
+  - `buildSingleEntityEditFieldDescriptors(...)`
+- Preserve `appendFieldDescriptors(...)` call count and sequencing.
+- Only extract field appenders into a dedicated helper module.
+- Keep `property_panel_glue_facade.js` owning the public facade return shape.
+- Do not import `selection_presenter.js` or unrelated entrypoints from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_glue_field_appenders.js`
+
+Expected responsibility split:
+
+- helper: field appender wrappers + shared field deps bag
+- `property_panel_glue_facade.js`: style actions, layer actions, grouped action appenders, facade assembly
+
+## Acceptance
+
+Accept Step369 only if:
+
+- `property_panel_glue_facade.js` no longer hand-builds the four field appenders
+- field descriptor routing remains unchanged
+- focused tests cover:
+  - common/source/insert/single field deps threading
+  - field batch ordering
+  - allow-position-editing passthrough
+- existing glue facade tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP369_GLUE_FIELD_APPENDERS_VERIFICATION.md
+++ b/docs/STEP369_GLUE_FIELD_APPENDERS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step369: Glue Field Appenders Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step369-glue-field-appenders-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
+node --check tools/web_viewer/ui/property_panel_glue_facade.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_glue_field_appenders.test.js \
+  tools/web_viewer/tests/property_panel_glue_facade.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+++ b/tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createFieldAppenders } from '../ui/property_panel_glue_field_appenders.js';
+import { createPropertyPanelGlueFieldAppenders } from '../ui/property_panel_glue_field_appenders.js';
 
 function createHarness(overrides = {}) {
   const fieldBatches = [];
@@ -9,7 +9,7 @@ function createHarness(overrides = {}) {
   const buildPatchCalls = [];
   const ensuredLayers = [];
 
-  const appenders = createFieldAppenders({
+  const appenders = createPropertyPanelGlueFieldAppenders({
     appendFieldDescriptors: (descriptors) => fieldBatches.push(descriptors),
     patchSelection: (patch, message) => patchCalls.push([patch, message]),
     buildPatch: (entity, key, value) => {
@@ -30,7 +30,7 @@ function createHarness(overrides = {}) {
   };
 }
 
-test('createFieldAppenders threads common property field deps', () => {
+test('createPropertyPanelGlueFieldAppenders threads common property field deps', () => {
   const primary = {
     id: 8,
     type: 'text',
@@ -58,7 +58,7 @@ test('createFieldAppenders threads common property field deps', () => {
   ]);
 });
 
-test('createFieldAppenders threads source text field deps', () => {
+test('createPropertyPanelGlueFieldAppenders threads source text field deps', () => {
   const primary = {
     id: 8,
     type: 'text',
@@ -84,7 +84,7 @@ test('createFieldAppenders threads source text field deps', () => {
   ]);
 });
 
-test('createFieldAppenders preserves insert proxy allowPositionEditing passthrough', () => {
+test('createPropertyPanelGlueFieldAppenders preserves insert proxy allowPositionEditing passthrough', () => {
   const primary = {
     id: 8,
     type: 'text',
@@ -109,7 +109,7 @@ test('createFieldAppenders preserves insert proxy allowPositionEditing passthrou
   ]);
 });
 
-test('createFieldAppenders threads single entity field deps', () => {
+test('createPropertyPanelGlueFieldAppenders threads single entity field deps', () => {
   const primary = {
     id: 9,
     type: 'line',

--- a/tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+++ b/tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createFieldAppenders } from '../ui/property_panel_glue_field_appenders.js';
+
+function createHarness(overrides = {}) {
+  const fieldBatches = [];
+  const patchCalls = [];
+  const buildPatchCalls = [];
+  const ensuredLayers = [];
+
+  const appenders = createFieldAppenders({
+    appendFieldDescriptors: (descriptors) => fieldBatches.push(descriptors),
+    patchSelection: (patch, message) => patchCalls.push([patch, message]),
+    buildPatch: (entity, key, value) => {
+      buildPatchCalls.push([entity.id ?? null, key, value]);
+      return { entityId: entity.id ?? null, key, value };
+    },
+    getLayer: () => null,
+    ensureLayer: (layerId) => ensuredLayers.push(layerId),
+    ...overrides,
+  });
+
+  return {
+    appenders,
+    fieldBatches,
+    patchCalls,
+    buildPatchCalls,
+    ensuredLayers,
+  };
+}
+
+test('createFieldAppenders threads common property field deps', () => {
+  const primary = {
+    id: 8,
+    type: 'text',
+    layerId: 2,
+    color: '#778899',
+    visible: true,
+    lineType: 'BYLAYER',
+    lineWeight: 0,
+    lineTypeScale: 1,
+  };
+  const { appenders, fieldBatches, patchCalls, ensuredLayers } = createHarness();
+
+  appenders.appendCommonPropertyFields(primary, '#112233', true);
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.kind === 'toggle' ? descriptor.label : descriptor.config.name),
+    ['layerId', 'color', 'Visible', 'lineType', 'lineWeight', 'lineTypeScale'],
+  );
+
+  fieldBatches[0][0].onChange('7');
+
+  assert.deepEqual(ensuredLayers, [7]);
+  assert.deepEqual(patchCalls, [
+    [{ layerId: 7, colorSource: 'TRUECOLOR', colorAci: null }, 'Layer updated; imported color promoted to explicit'],
+  ]);
+});
+
+test('createFieldAppenders threads source text field deps', () => {
+  const primary = {
+    id: 8,
+    type: 'text',
+    position: { x: 10, y: 20 },
+    value: 'TEXT',
+    height: 2.5,
+    rotation: 0,
+  };
+  const { appenders, fieldBatches, patchCalls, buildPatchCalls } = createHarness();
+
+  appenders.appendSourceTextFields(primary);
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['value', 'position.x', 'position.y', 'height', 'rotation'],
+  );
+
+  fieldBatches[0][0].onChange('UPDATED');
+
+  assert.deepEqual(buildPatchCalls, [[8, 'value', 'UPDATED']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 8, key: 'value', value: 'UPDATED' }, 'Text updated'],
+  ]);
+});
+
+test('createFieldAppenders preserves insert proxy allowPositionEditing passthrough', () => {
+  const primary = {
+    id: 8,
+    type: 'text',
+    textKind: 'attdef',
+    position: { x: 10, y: 20 },
+    value: 'TEXT',
+  };
+  const { appenders, fieldBatches, patchCalls, buildPatchCalls } = createHarness();
+
+  appenders.appendInsertProxyTextFields(primary, { allowPositionEditing: true });
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['value', 'position.x', 'position.y'],
+  );
+
+  fieldBatches[0][1].onChange('42');
+
+  assert.deepEqual(buildPatchCalls, [[8, 'position.x', '42']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 8, key: 'position.x', value: '42' }, 'Text position updated'],
+  ]);
+});
+
+test('createFieldAppenders threads single entity field deps', () => {
+  const primary = {
+    id: 9,
+    type: 'line',
+    start: { x: 1, y: 2 },
+    end: { x: 3, y: 4 },
+  };
+  const { appenders, fieldBatches, patchCalls, buildPatchCalls } = createHarness();
+
+  appenders.appendSingleEntityFields(primary);
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['start.x', 'start.y', 'end.x', 'end.y'],
+  );
+
+  fieldBatches[0][3].onChange('7');
+
+  assert.deepEqual(buildPatchCalls, [[9, 'end.y', '7']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 9, key: 'end.y', value: '7' }, 'Line end updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_glue_facade.js
+++ b/tools/web_viewer/ui/property_panel_glue_facade.js
@@ -1,14 +1,7 @@
 import { buildLayerActions } from './property_panel_layer_actions.js';
 import { createGroupActionAppenders } from './property_panel_glue_group_actions.js';
-import {
-  buildFullTextEditFieldDescriptors,
-  buildInsertProxyTextFieldDescriptors,
-  buildSingleEntityEditFieldDescriptors,
-} from './property_panel_entity_fields.js';
-import {
-  buildCommonPropertyFieldDescriptors,
-  buildStyleActionDescriptors,
-} from './property_panel_common_fields.js';
+import { createFieldAppenders } from './property_panel_glue_field_appenders.js';
+import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
 
 export function createPropertyPanelGlueFacade({
   addActionRow,
@@ -111,34 +104,18 @@ export function createPropertyPanelGlueFacade({
     fitReleasedInsertGroup,
   });
 
-  function appendCommonPropertyFields(primary, displayedColor, promoteImportedColorSource) {
-    appendFieldDescriptors(buildCommonPropertyFieldDescriptors(
-      primary,
-      { displayedColor, promoteImportedColorSource },
-      {
-        patchSelection,
-        buildPatch,
-        getLayer,
-        ensureLayer,
-      },
-    ));
-  }
-
-  function appendSourceTextFields(primary) {
-    appendFieldDescriptors(buildFullTextEditFieldDescriptors(primary, { patchSelection, buildPatch }));
-  }
-
-  function appendInsertProxyTextFields(primary, { allowPositionEditing = false } = {}) {
-    appendFieldDescriptors(buildInsertProxyTextFieldDescriptors(
-      primary,
-      { allowPositionEditing },
-      { patchSelection, buildPatch },
-    ));
-  }
-
-  function appendSingleEntityFields(primary) {
-    appendFieldDescriptors(buildSingleEntityEditFieldDescriptors(primary, { patchSelection, buildPatch }));
-  }
+  const {
+    appendCommonPropertyFields,
+    appendSourceTextFields,
+    appendInsertProxyTextFields,
+    appendSingleEntityFields,
+  } = createFieldAppenders({
+    appendFieldDescriptors,
+    patchSelection,
+    buildPatch,
+    getLayer,
+    ensureLayer,
+  });
 
   return {
     appendStyleActions,

--- a/tools/web_viewer/ui/property_panel_glue_facade.js
+++ b/tools/web_viewer/ui/property_panel_glue_facade.js
@@ -1,6 +1,6 @@
 import { buildLayerActions } from './property_panel_layer_actions.js';
 import { createGroupActionAppenders } from './property_panel_glue_group_actions.js';
-import { createFieldAppenders } from './property_panel_glue_field_appenders.js';
+import { createPropertyPanelGlueFieldAppenders } from './property_panel_glue_field_appenders.js';
 import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
 
 export function createPropertyPanelGlueFacade({
@@ -109,7 +109,7 @@ export function createPropertyPanelGlueFacade({
     appendSourceTextFields,
     appendInsertProxyTextFields,
     appendSingleEntityFields,
-  } = createFieldAppenders({
+  } = createPropertyPanelGlueFieldAppenders({
     appendFieldDescriptors,
     patchSelection,
     buildPatch,

--- a/tools/web_viewer/ui/property_panel_glue_field_appenders.js
+++ b/tools/web_viewer/ui/property_panel_glue_field_appenders.js
@@ -1,0 +1,50 @@
+import {
+  buildFullTextEditFieldDescriptors,
+  buildInsertProxyTextFieldDescriptors,
+  buildSingleEntityEditFieldDescriptors,
+} from './property_panel_entity_fields.js';
+import { buildCommonPropertyFieldDescriptors } from './property_panel_common_fields.js';
+
+export function createPropertyPanelGlueFieldAppenders({
+  appendFieldDescriptors,
+  patchSelection,
+  buildPatch,
+  getLayer,
+  ensureLayer,
+}) {
+  function appendCommonPropertyFields(primary, displayedColor, promoteImportedColorSource) {
+    appendFieldDescriptors(buildCommonPropertyFieldDescriptors(
+      primary,
+      { displayedColor, promoteImportedColorSource },
+      {
+        patchSelection,
+        buildPatch,
+        getLayer,
+        ensureLayer,
+      },
+    ));
+  }
+
+  function appendSourceTextFields(primary) {
+    appendFieldDescriptors(buildFullTextEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+  }
+
+  function appendInsertProxyTextFields(primary, { allowPositionEditing = false } = {}) {
+    appendFieldDescriptors(buildInsertProxyTextFieldDescriptors(
+      primary,
+      { allowPositionEditing },
+      { patchSelection, buildPatch },
+    ));
+  }
+
+  function appendSingleEntityFields(primary) {
+    appendFieldDescriptors(buildSingleEntityEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+  }
+
+  return {
+    appendCommonPropertyFields,
+    appendSourceTextFields,
+    appendInsertProxyTextFields,
+    appendSingleEntityFields,
+  };
+}


### PR DESCRIPTION
## Summary
- extract glue field appenders into a dedicated helper
- keep property_panel_glue_facade owning the public facade return shape
- add focused tests for common/source/insert/single field routing

## Verification
- node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
- node --check tools/web_viewer/ui/property_panel_glue_facade.js
- node --test tools/web_viewer/tests/property_panel_glue_field_appenders.test.js tools/web_viewer/tests/property_panel_glue_facade.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check