### PR TITLE
refactor: extract glue style/layer actions

### DIFF
--- a/docs/STEP370_GLUE_STYLE_LAYER_ACTIONS_DESIGN.md
+++ b/docs/STEP370_GLUE_STYLE_LAYER_ACTIONS_DESIGN.md
@@ -1,0 +1,68 @@
+# Step370: Glue Style/Layer Action Appenders Extraction
+
+## Goal
+
+Extract the remaining action appender wrappers from:
+
+- `tools/web_viewer/ui/property_panel_glue_facade.js`
+
+The purpose is to isolate the glue-layer routing around:
+
+- `buildStyleActionDescriptors(...)`
+- `buildLayerActions(...)`
+
+without changing action row ordering, descriptor contents, or facade contract.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendStyleActions(...)`
+  - `appendLayerActions(...)`
+- Keep `addActionRow(...)` call sequencing unchanged
+- Keep style/layer collaborator threading unchanged
+
+Out of scope:
+
+- grouped action appenders
+- field appenders
+- facade return shape changes
+- render callback behavior
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFacade(...)` public contract unchanged.
+- Preserve exact row ordering and action ids for style/layer rows.
+- Preserve exact deps threading into:
+  - `buildStyleActionDescriptors(...)`
+  - `buildLayerActions(...)`
+- Preserve `addActionRow(...)` call count and sequencing.
+- Only extract style/layer action appenders into a dedicated helper module.
+- Keep `property_panel_glue_facade.js` owning the public facade return shape.
+- Do not import `selection_presenter.js` or unrelated entrypoints from the new helper.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_glue_style_layer_actions.js`
+
+Expected responsibility split:
+
+- helper: style/layer action appenders + shared action deps bag
+- `property_panel_glue_facade.js`: grouped action appenders, field appenders, facade assembly
+
+## Acceptance
+
+Accept Step370 only if:
+
+- `property_panel_glue_facade.js` no longer hand-builds style/layer action appenders
+- style/layer action row ordering remains unchanged
+- focused tests cover:
+  - style action deps threading
+  - layer action deps threading
+  - style/layer row ordering
+- existing glue facade tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP370_GLUE_STYLE_LAYER_ACTIONS_VERIFICATION.md
+++ b/docs/STEP370_GLUE_STYLE_LAYER_ACTIONS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step370: Glue Style/Layer Action Appenders Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step370-glue-style-layer-actions-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+node --check tools/web_viewer/ui/property_panel_glue_facade.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js \
+  tools/web_viewer/tests/property_panel_glue_facade.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStyleLayerActionAppenders } from '../ui/property_panel_glue_style_layer_actions.js';
+
+function createHarness(overrides = {}) {
+  const actionRows = [];
+  const patchCalls = [];
+  const statusMessages = [];
+  const invokedWith = [];
+
+  const appenders = createStyleLayerActionAppenders({
+    addActionRow: (actions) => actionRows.push(actions),
+    patchSelection: (patch, message) => patchCalls.push([patch, message]),
+    setStatus: (message) => statusMessages.push(message),
+    focusLayer: (id) => { invokedWith.push(['focusLayer', id]); return true; },
+    getCurrentLayerId: () => 1,
+    useLayer: (id) => { invokedWith.push(['useLayer', id]); return true; },
+    lockLayer: (id) => { invokedWith.push(['lockLayer', id]); return true; },
+    isolateLayer: (id) => { invokedWith.push(['isolateLayer', id]); return true; },
+    turnOffLayer: (id) => { invokedWith.push(['turnOffLayer', id]); return true; },
+    freezeLayer: (id) => { invokedWith.push(['freezeLayer', id]); return true; },
+    hasLayerIsolation: () => true,
+    restoreLayerIsolation: () => { invokedWith.push(['restoreLayerIsolation']); return true; },
+    hasLayerFreeze: () => true,
+    restoreLayerFreeze: () => { invokedWith.push(['restoreLayerFreeze']); return true; },
+    ...overrides,
+  });
+
+  return {
+    appenders,
+    actionRows,
+    patchCalls,
+    statusMessages,
+    invokedWith,
+  };
+}
+
+test('createStyleLayerActionAppenders threads style action deps', () => {
+  const { appenders, actionRows, patchCalls } = createHarness();
+
+  appenders.appendStyleActions(
+    {
+      id: 10,
+      colorSource: 'TRUECOLOR',
+      lineType: 'CENTER',
+      lineWeight: 0.25,
+      lineWeightSource: 'EXPLICIT',
+      lineTypeScale: 2,
+      lineTypeScaleSource: 'EXPLICIT',
+    },
+    { id: 3, name: 'ANNOT', color: '#55aaee', visible: true, frozen: false, locked: false },
+  );
+
+  assert.deepEqual(
+    actionRows[0].map((action) => action.id),
+    ['use-layer-color', 'use-layer-line-type', 'use-layer-line-weight', 'use-default-line-type-scale'],
+  );
+
+  actionRows[0][0].onClick();
+
+  assert.deepEqual(patchCalls, [[
+    { color: '#55aaee', colorSource: 'BYLAYER', colorAci: null },
+    'Color source: BYLAYER',
+  ]]);
+});
+
+test('createStyleLayerActionAppenders threads layer action deps', () => {
+  const { appenders, actionRows, invokedWith, statusMessages } = createHarness();
+  const layer = { id: 3, name: 'ANNOT', visible: true, frozen: false, locked: false };
+
+  appenders.appendLayerActions(layer);
+
+  assert.deepEqual(
+    actionRows[0].map((action) => action.id),
+    ['locate-layer', 'use-layer', 'lock-layer', 'isolate-layer', 'turn-off-layer', 'freeze-layer', 'restore-layers', 'thaw-layers'],
+  );
+
+  actionRows[0][0].onClick();
+  actionRows[0][1].onClick();
+
+  assert.deepEqual(invokedWith.slice(0, 2), [
+    ['focusLayer', 3],
+    ['useLayer', 3],
+  ]);
+  assert.deepEqual(statusMessages, ['Layer focused: ANNOT']);
+});
+
+test('createStyleLayerActionAppenders preserves row ordering when style then layer appenders run', () => {
+  const { appenders, actionRows } = createHarness();
+  const layer = { id: 3, name: 'ANNOT', color: '#55aaee', visible: true, frozen: false, locked: false };
+
+  appenders.appendStyleActions(
+    {
+      id: 10,
+      colorSource: 'TRUECOLOR',
+      lineType: 'CENTER',
+      lineWeight: 0.25,
+      lineWeightSource: 'EXPLICIT',
+      lineTypeScale: 2,
+      lineTypeScaleSource: 'EXPLICIT',
+    },
+    layer,
+  );
+  appenders.appendLayerActions(layer);
+
+  assert.deepEqual(
+    actionRows.map((row) => row.map((action) => action.id)),
+    [
+      ['use-layer-color', 'use-layer-line-type', 'use-layer-line-weight', 'use-default-line-type-scale'],
+      ['locate-layer', 'use-layer', 'lock-layer', 'isolate-layer', 'turn-off-layer', 'freeze-layer', 'restore-layers', 'thaw-layers'],
+    ],
+  );
+});

--- a/tools/web_viewer/ui/property_panel_glue_facade.js
+++ b/tools/web_viewer/ui/property_panel_glue_facade.js
@@ -1,7 +1,6 @@
-import { buildLayerActions } from './property_panel_layer_actions.js';
+import { createStyleLayerActionAppenders } from './property_panel_glue_style_layer_actions.js';
 import { createGroupActionAppenders } from './property_panel_glue_group_actions.js';
 import { createPropertyPanelGlueFieldAppenders } from './property_panel_glue_field_appenders.js';
-import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
 
 export function createPropertyPanelGlueFacade({
   addActionRow,
@@ -48,29 +47,25 @@ export function createPropertyPanelGlueFacade({
   selectReleasedInsertGroup = null,
   fitReleasedInsertGroup = null,
 }) {
-  function appendStyleActions(entity, layer) {
-    addActionRow(buildStyleActionDescriptors(entity, layer, { patchSelection }));
-  }
-
-  function appendLayerActions(layer) {
-    addActionRow(buildLayerActions(layer, {
-      setStatus,
-      focusLayer,
-      getCurrentLayerId,
-      useLayer,
-      lockLayer,
-      unlockLayer,
-      isolateLayer,
-      hasLayerIsolation,
-      restoreLayerIsolation,
-      turnOffLayer,
-      turnOnLayer,
-      freezeLayer,
-      thawLayer,
-      hasLayerFreeze,
-      restoreLayerFreeze,
-    }));
-  }
+  const { appendStyleActions, appendLayerActions } = createStyleLayerActionAppenders({
+    addActionRow,
+    patchSelection,
+    setStatus,
+    focusLayer,
+    getCurrentLayerId,
+    useLayer,
+    lockLayer,
+    unlockLayer,
+    isolateLayer,
+    hasLayerIsolation,
+    restoreLayerIsolation,
+    turnOffLayer,
+    turnOnLayer,
+    freezeLayer,
+    thawLayer,
+    hasLayerFreeze,
+    restoreLayerFreeze,
+  });
 
   const {
     appendSourceGroupActions,

--- a/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+++ b/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
@@ -1,0 +1,48 @@
+import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
+import { buildLayerActions } from './property_panel_layer_actions.js';
+
+export function createStyleLayerActionAppenders({
+  addActionRow,
+  patchSelection,
+  setStatus,
+  focusLayer = null,
+  getCurrentLayerId = null,
+  useLayer = null,
+  lockLayer = null,
+  unlockLayer = null,
+  isolateLayer = null,
+  hasLayerIsolation = null,
+  restoreLayerIsolation = null,
+  turnOffLayer = null,
+  turnOnLayer = null,
+  freezeLayer = null,
+  thawLayer = null,
+  hasLayerFreeze = null,
+  restoreLayerFreeze = null,
+}) {
+  function appendStyleActions(entity, layer) {
+    addActionRow(buildStyleActionDescriptors(entity, layer, { patchSelection }));
+  }
+
+  function appendLayerActions(layer) {
+    addActionRow(buildLayerActions(layer, {
+      setStatus,
+      focusLayer,
+      getCurrentLayerId,
+      useLayer,
+      lockLayer,
+      unlockLayer,
+      isolateLayer,
+      hasLayerIsolation,
+      restoreLayerIsolation,
+      turnOffLayer,
+      turnOnLayer,
+      freezeLayer,
+      thawLayer,
+      hasLayerFreeze,
+      restoreLayerFreeze,
+    }));
+  }
+
+  return { appendStyleActions, appendLayerActions };
+}


### PR DESCRIPTION
## Summary
- extract the remaining style/layer glue action appenders into a dedicated helper
- keep property_panel_glue_facade owning the public facade return shape
- add focused tests for style/layer action routing and row ordering

## Verification
- node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
- node --check tools/web_viewer/ui/property_panel_glue_facade.js
- node --test tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js tools/web_viewer/tests/property_panel_glue_facade.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check