### PR TITLE
refactor: extract property panel style actions

### DIFF
--- a/docs/STEP371_PROPERTY_PANEL_STYLE_ACTIONS_DESIGN.md
+++ b/docs/STEP371_PROPERTY_PANEL_STYLE_ACTIONS_DESIGN.md
@@ -1,0 +1,58 @@
+# Step371: Property Panel Style Actions Extraction
+
+## Goal
+
+Extract the style action builder from:
+
+- `tools/web_viewer/ui/property_panel_common_fields.js`
+
+The purpose is to isolate:
+
+- `buildStyleActionDescriptors(...)`
+
+without changing action ids, labels, patch payloads, or reset semantics.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `buildStyleActionDescriptors(...)`
+- Keep style reset action ordering unchanged
+- Keep `patchSelection(...)` threading unchanged
+
+Out of scope:
+
+- `buildCommonPropertyFieldDescriptors(...)`
+- glue facade wiring
+- layer action behavior
+- render callback behavior
+
+## Constraints
+
+- Keep `buildStyleActionDescriptors(...)` public contract unchanged.
+- Preserve exact action ids, labels, patch payloads, and messages.
+- Preserve action ordering.
+- Only extract style action descriptor assembly into a dedicated helper module.
+- Keep `property_panel_common_fields.js` re-exporting `buildStyleActionDescriptors(...)`.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_style_actions.js`
+
+Expected responsibility split:
+
+- helper: `buildStyleActionDescriptors(...)`
+- `property_panel_common_fields.js`: `buildCommonPropertyFieldDescriptors(...)` plus re-export
+
+## Acceptance
+
+Accept Step371 only if:
+
+- `property_panel_common_fields.js` no longer defines `buildStyleActionDescriptors(...)` inline
+- focused tests cover extracted style action behavior directly
+- existing common fields tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP371_PROPERTY_PANEL_STYLE_ACTIONS_VERIFICATION.md
+++ b/docs/STEP371_PROPERTY_PANEL_STYLE_ACTIONS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step371: Property Panel Style Actions Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step371-property-panel-style-actions-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_style_actions.js
+node --check tools/web_viewer/ui/property_panel_common_fields.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_style_actions.test.js \
+  tools/web_viewer/tests/property_panel_common_fields.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_style_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_style_actions.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildStyleActionDescriptors } from '../ui/property_panel_style_actions.js';
+
+test('buildStyleActionDescriptors preserves reset action labels and patch messages', () => {
+  const calls = [];
+  const actions = buildStyleActionDescriptors(
+    {
+      colorSource: 'TRUECOLOR',
+      lineType: 'CENTER',
+      lineWeight: 0.35,
+      lineWeightSource: 'EXPLICIT',
+      lineTypeScale: 2,
+      lineTypeScaleSource: 'EXPLICIT',
+    },
+    { color: '#00AAFF' },
+    { patchSelection: (patch, message) => calls.push([patch, message]) },
+  );
+
+  assert.deepEqual(
+    actions.map((action) => [action.id, action.label]),
+    [
+      ['use-layer-color', 'Use Layer Color'],
+      ['use-layer-line-type', 'Use Layer Line Type'],
+      ['use-layer-line-weight', 'Use Layer Line Weight'],
+      ['use-default-line-type-scale', 'Use Default Line Type Scale'],
+    ],
+  );
+
+  for (const action of actions) {
+    action.onClick();
+  }
+
+  assert.deepEqual(calls, [
+    [{ color: '#00AAFF', colorSource: 'BYLAYER', colorAci: null }, 'Color source: BYLAYER'],
+    [{ lineType: 'BYLAYER' }, 'Line type source: BYLAYER'],
+    [{ lineWeight: 0, lineWeightSource: 'BYLAYER' }, 'Line weight source: BYLAYER'],
+    [{ lineTypeScale: 1, lineTypeScaleSource: 'DEFAULT' }, 'Line type scale source: DEFAULT'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_common_fields.js
+++ b/tools/web_viewer/ui/property_panel_common_fields.js
@@ -1,4 +1,4 @@
-import { resolveEntityStyleSources } from '../line_style.js';
+export { buildStyleActionDescriptors } from './property_panel_style_actions.js';
 
 export function buildCommonPropertyFieldDescriptors(primary, options = {}, deps = {}) {
   if (!primary) return [];
@@ -67,45 +67,4 @@ export function buildCommonPropertyFieldDescriptors(primary, options = {}, deps 
       onChange: (value) => patchSelection(buildPatch(primary, 'lineTypeScale', value), 'Line type scale updated'),
     },
   ];
-}
-
-export function buildStyleActionDescriptors(entity, layer, deps = {}) {
-  if (!entity || !layer) return [];
-  const { patchSelection = null } = deps;
-  if (typeof patchSelection !== 'function') return [];
-  const styleSources = resolveEntityStyleSources(entity);
-  const actions = [];
-  if (styleSources.colorSource !== 'BYLAYER') {
-    actions.push({
-      id: 'use-layer-color',
-      label: 'Use Layer Color',
-      onClick: () => patchSelection({
-        color: layer.color || '#9ca3af',
-        colorSource: 'BYLAYER',
-        colorAci: null,
-      }, 'Color source: BYLAYER'),
-    });
-  }
-  if (styleSources.lineTypeSource !== 'BYLAYER') {
-    actions.push({
-      id: 'use-layer-line-type',
-      label: 'Use Layer Line Type',
-      onClick: () => patchSelection({ lineType: 'BYLAYER' }, 'Line type source: BYLAYER'),
-    });
-  }
-  if (styleSources.lineWeightSource !== 'BYLAYER') {
-    actions.push({
-      id: 'use-layer-line-weight',
-      label: 'Use Layer Line Weight',
-      onClick: () => patchSelection({ lineWeight: 0, lineWeightSource: 'BYLAYER' }, 'Line weight source: BYLAYER'),
-    });
-  }
-  if (styleSources.lineTypeScaleSource !== 'DEFAULT') {
-    actions.push({
-      id: 'use-default-line-type-scale',
-      label: 'Use Default Line Type Scale',
-      onClick: () => patchSelection({ lineTypeScale: 1, lineTypeScaleSource: 'DEFAULT' }, 'Line type scale source: DEFAULT'),
-    });
-  }
-  return actions;
 }

--- a/tools/web_viewer/ui/property_panel_style_actions.js
+++ b/tools/web_viewer/ui/property_panel_style_actions.js
@@ -1,0 +1,42 @@
+import { resolveEntityStyleSources } from '../line_style.js';
+
+export function buildStyleActionDescriptors(entity, layer, deps = {}) {
+  if (!entity || !layer) return [];
+  const { patchSelection = null } = deps;
+  if (typeof patchSelection !== 'function') return [];
+  const styleSources = resolveEntityStyleSources(entity);
+  const actions = [];
+  if (styleSources.colorSource !== 'BYLAYER') {
+    actions.push({
+      id: 'use-layer-color',
+      label: 'Use Layer Color',
+      onClick: () => patchSelection({
+        color: layer.color || '#9ca3af',
+        colorSource: 'BYLAYER',
+        colorAci: null,
+      }, 'Color source: BYLAYER'),
+    });
+  }
+  if (styleSources.lineTypeSource !== 'BYLAYER') {
+    actions.push({
+      id: 'use-layer-line-type',
+      label: 'Use Layer Line Type',
+      onClick: () => patchSelection({ lineType: 'BYLAYER' }, 'Line type source: BYLAYER'),
+    });
+  }
+  if (styleSources.lineWeightSource !== 'BYLAYER') {
+    actions.push({
+      id: 'use-layer-line-weight',
+      label: 'Use Layer Line Weight',
+      onClick: () => patchSelection({ lineWeight: 0, lineWeightSource: 'BYLAYER' }, 'Line weight source: BYLAYER'),
+    });
+  }
+  if (styleSources.lineTypeScaleSource !== 'DEFAULT') {
+    actions.push({
+      id: 'use-default-line-type-scale',
+      label: 'Use Default Line Type Scale',
+      onClick: () => patchSelection({ lineTypeScale: 1, lineTypeScaleSource: 'DEFAULT' }, 'Line type scale source: DEFAULT'),
+    });
+  }
+  return actions;
+}


### PR DESCRIPTION
## Summary
- extract buildStyleActionDescriptors into a dedicated helper module
- keep property_panel_common_fields re-exporting the public API
- add focused helper coverage without changing common property field behavior

## Verification
- node --check tools/web_viewer/ui/property_panel_style_actions.js
- node --check tools/web_viewer/ui/property_panel_common_fields.js
- node --test tools/web_viewer/tests/property_panel_style_actions.test.js tools/web_viewer/tests/property_panel_common_fields.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check