### PR TITLE
refactor: extract current space actions

### DIFF
--- a/docs/STEP372_CURRENT_SPACE_ACTIONS_DESIGN.md
+++ b/docs/STEP372_CURRENT_SPACE_ACTIONS_DESIGN.md
@@ -1,0 +1,58 @@
+# Step372: Current Space Actions Extraction
+
+## Goal
+
+Extract the current-space action builder from:
+
+- `tools/web_viewer/ui/property_panel_layer_actions.js`
+
+The purpose is to isolate:
+
+- `buildCurrentSpaceActions(...)`
+
+without changing action ids, labels, status semantics, or layout normalization behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `buildCurrentSpaceActions(...)`
+- Keep current-space action ordering unchanged
+- Keep `setCurrentSpaceContext(...)` / `setStatus(...)` threading unchanged
+
+Out of scope:
+
+- `buildLayerActions(...)`
+- layer action behavior
+- property panel glue facade wiring
+
+## Constraints
+
+- Keep `buildCurrentSpaceActions(...)` public contract unchanged.
+- Preserve exact action ids, labels, and status behavior.
+- Preserve action ordering.
+- Preserve `normalizeLayoutName(...)` behavior.
+- Only extract current-space action assembly into a dedicated helper module.
+- Keep `property_panel_layer_actions.js` re-exporting `buildCurrentSpaceActions(...)`.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_current_space_actions.js`
+
+Expected responsibility split:
+
+- helper: `buildCurrentSpaceActions(...)`
+- `property_panel_layer_actions.js`: `buildLayerActions(...)` plus re-export
+
+## Acceptance
+
+Accept Step372 only if:
+
+- `property_panel_layer_actions.js` no longer defines `buildCurrentSpaceActions(...)` inline
+- focused tests cover extracted current-space action behavior directly
+- existing layer action tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP372_CURRENT_SPACE_ACTIONS_VERIFICATION.md
+++ b/docs/STEP372_CURRENT_SPACE_ACTIONS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step372: Current Space Actions Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step372-current-space-actions-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_current_space_actions.js
+node --check tools/web_viewer/ui/property_panel_layer_actions.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_current_space_actions.test.js \
+  tools/web_viewer/tests/property_panel_layer_actions.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_current_space_actions.test.js
+++ b/tools/web_viewer/tests/property_panel_current_space_actions.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCurrentSpaceActions } from '../ui/property_panel_current_space_actions.js';
+
+test('buildCurrentSpaceActions preserves model and paper layout labels', () => {
+  const actions = buildCurrentSpaceActions(
+    { space: 1, layout: 'Layout-A' },
+    ['Layout-A', 'Layout-B', 'Layout C'],
+    { setCurrentSpaceContext: () => true },
+  );
+
+  assert.deepEqual(
+    actions.map((action) => [action.id, action.label]),
+    [
+      ['use-model-space', 'Use Model Space'],
+      ['use-layout-layout-b', 'Use Layout Layout-B'],
+      ['use-layout-layout-c', 'Use Layout Layout C'],
+    ],
+  );
+});
+
+test('buildCurrentSpaceActions preserves status messaging for false result', () => {
+  const status = [];
+  const actions = buildCurrentSpaceActions(
+    { space: 1, layout: 'Layout-A' },
+    ['Layout-B'],
+    {
+      setCurrentSpaceContext: () => false,
+      setStatus: (message) => status.push(message),
+    },
+  );
+
+  actions[0].onClick();
+  actions[1].onClick();
+
+  assert.deepEqual(status, [
+    'Current space unchanged: Model',
+    'Current layout unchanged: Layout-B',
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_current_space_actions.js
+++ b/tools/web_viewer/ui/property_panel_current_space_actions.js
@@ -1,0 +1,66 @@
+import { normalizeLayoutName } from '../space_layout.js';
+
+function toActionIdToken(value, fallback = 'layout') {
+  const normalized = String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function pushAction(actions, {
+  id,
+  label,
+  invoke,
+  onFalse = null,
+  onTrue = null,
+  setStatus = null,
+}) {
+  if (typeof invoke !== 'function') return;
+  actions.push({
+    id,
+    label,
+    onClick: () => {
+      const result = invoke();
+      if (result === false) {
+        if (typeof onFalse === 'string' && typeof setStatus === 'function') {
+          setStatus(onFalse);
+        }
+        return;
+      }
+      if (typeof onTrue === 'string' && typeof setStatus === 'function') {
+        setStatus(onTrue);
+      }
+    },
+  });
+}
+
+export function buildCurrentSpaceActions(currentSpaceContext = null, paperLayouts = [], deps = {}) {
+  const { setCurrentSpaceContext = null, setStatus = null } = deps;
+  if (typeof setCurrentSpaceContext !== 'function') return [];
+  const actions = [];
+
+  if (currentSpaceContext?.space !== 0) {
+    pushAction(actions, {
+      id: 'use-model-space',
+      label: 'Use Model Space',
+      invoke: () => setCurrentSpaceContext({ space: 0, layout: 'Model' }),
+      onFalse: 'Current space unchanged: Model',
+      setStatus,
+    });
+  }
+
+  for (const layoutName of Array.isArray(paperLayouts) ? paperLayouts : []) {
+    const normalizedLayout = normalizeLayoutName(layoutName);
+    if (!normalizedLayout) continue;
+    if (currentSpaceContext?.space === 1 && normalizeLayoutName(currentSpaceContext.layout) === normalizedLayout) {
+      continue;
+    }
+    pushAction(actions, {
+      id: `use-layout-${toActionIdToken(normalizedLayout)}`,
+      label: `Use Layout ${normalizedLayout}`,
+      invoke: () => setCurrentSpaceContext({ space: 1, layout: normalizedLayout }),
+      onFalse: `Current layout unchanged: ${normalizedLayout}`,
+      setStatus,
+    });
+  }
+
+  return actions;
+}

--- a/tools/web_viewer/ui/property_panel_layer_actions.js
+++ b/tools/web_viewer/ui/property_panel_layer_actions.js
@@ -1,9 +1,4 @@
-import { normalizeLayoutName } from '../space_layout.js';
-
-function toActionIdToken(value, fallback = 'layout') {
-  const normalized = String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-  return normalized || fallback;
-}
+export { buildCurrentSpaceActions } from './property_panel_current_space_actions.js';
 
 function pushAction(actions, {
   id,
@@ -30,39 +25,6 @@ function pushAction(actions, {
       }
     },
   });
-}
-
-export function buildCurrentSpaceActions(currentSpaceContext = null, paperLayouts = [], deps = {}) {
-  const { setCurrentSpaceContext = null, setStatus = null } = deps;
-  if (typeof setCurrentSpaceContext !== 'function') return [];
-  const actions = [];
-
-  if (currentSpaceContext?.space !== 0) {
-    pushAction(actions, {
-      id: 'use-model-space',
-      label: 'Use Model Space',
-      invoke: () => setCurrentSpaceContext({ space: 0, layout: 'Model' }),
-      onFalse: 'Current space unchanged: Model',
-      setStatus,
-    });
-  }
-
-  for (const layoutName of Array.isArray(paperLayouts) ? paperLayouts : []) {
-    const normalizedLayout = normalizeLayoutName(layoutName);
-    if (!normalizedLayout) continue;
-    if (currentSpaceContext?.space === 1 && normalizeLayoutName(currentSpaceContext.layout) === normalizedLayout) {
-      continue;
-    }
-    pushAction(actions, {
-      id: `use-layout-${toActionIdToken(normalizedLayout)}`,
-      label: `Use Layout ${normalizedLayout}`,
-      invoke: () => setCurrentSpaceContext({ space: 1, layout: normalizedLayout }),
-      onFalse: `Current layout unchanged: ${normalizedLayout}`,
-      setStatus,
-    });
-  }
-
-  return actions;
 }
 
 export function buildLayerActions(layer, deps = {}) {


### PR DESCRIPTION
## Summary
- extract buildCurrentSpaceActions into a dedicated helper module
- keep property_panel_layer_actions re-exporting the public API
- add focused helper coverage without changing layer action behavior

## Verification
- node --check tools/web_viewer/ui/property_panel_current_space_actions.js
- node --check tools/web_viewer/ui/property_panel_layer_actions.js
- node --test tools/web_viewer/tests/property_panel_current_space_actions.test.js tools/web_viewer/tests/property_panel_layer_actions.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check