### PR TITLE
refactor: extract full text fields

### DIFF
--- a/docs/STEP374_FULL_TEXT_FIELDS_DESIGN.md
+++ b/docs/STEP374_FULL_TEXT_FIELDS_DESIGN.md
@@ -1,0 +1,57 @@
+# Step374: Full Text Fields Extraction
+
+## Goal
+
+Extract the full-text field builder from:
+
+- `tools/web_viewer/ui/property_panel_entity_fields.js`
+
+The purpose is to isolate:
+
+- `buildFullTextEditFieldDescriptors(...)`
+
+without changing field labels, names, patch payloads, or update messages.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `buildFullTextEditFieldDescriptors(...)`
+- Keep field ordering unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` threading unchanged
+
+Out of scope:
+
+- `buildInsertProxyTextFieldDescriptors(...)`
+- `buildSingleEntityEditFieldDescriptors(...)`
+- render callback behavior
+
+## Constraints
+
+- Keep `buildFullTextEditFieldDescriptors(...)` public contract unchanged.
+- Preserve exact field labels, names, ordering, and update messages.
+- Preserve `primary.type === 'text'` guard behavior.
+- Only extract full-text field assembly into a dedicated helper module.
+- Keep `property_panel_entity_fields.js` re-exporting `buildFullTextEditFieldDescriptors(...)`.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_full_text_fields.js`
+
+Expected responsibility split:
+
+- helper: `buildFullTextEditFieldDescriptors(...)`
+- `property_panel_entity_fields.js`: insert-proxy fields, single-entity fields, re-export
+
+## Acceptance
+
+Accept Step374 only if:
+
+- `property_panel_entity_fields.js` no longer defines `buildFullTextEditFieldDescriptors(...)` inline
+- focused tests cover extracted full-text field behavior directly
+- existing entity field tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP374_FULL_TEXT_FIELDS_VERIFICATION.md
+++ b/docs/STEP374_FULL_TEXT_FIELDS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step374: Full Text Fields Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step374-full-text-fields-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_full_text_fields.js
+node --check tools/web_viewer/ui/property_panel_entity_fields.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_full_text_fields.test.js \
+  tools/web_viewer/tests/property_panel_entity_fields.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_full_text_fields.test.js
+++ b/tools/web_viewer/tests/property_panel_full_text_fields.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildFullTextEditFieldDescriptors } from '../ui/property_panel_full_text_fields.js';
+
+test('buildFullTextEditFieldDescriptors preserves text field labels and names', () => {
+  const fields = buildFullTextEditFieldDescriptors(
+    { type: 'text', value: 'TEXT', position: { x: 10, y: 20 }, height: 2.5, rotation: 0 },
+    { patchSelection: () => {}, buildPatch: () => ({}) },
+  );
+
+  assert.deepEqual(
+    fields.map((field) => [field.config.name, field.config.label]),
+    [
+      ['value', 'Text'],
+      ['position.x', 'Position X'],
+      ['position.y', 'Position Y'],
+      ['height', 'Height'],
+      ['rotation', 'Rotation (rad)'],
+    ],
+  );
+});
+
+test('buildFullTextEditFieldDescriptors preserves update messages', () => {
+  const calls = [];
+  const fields = buildFullTextEditFieldDescriptors(
+    { id: 8, type: 'text', value: 'TEXT', position: { x: 10, y: 20 }, height: 2.5, rotation: 0 },
+    {
+      patchSelection: (patch, message) => calls.push([patch, message]),
+      buildPatch: (entity, key, value) => ({ entityId: entity.id, key, value }),
+    },
+  );
+
+  fields[0].onChange('UPDATED');
+  fields[3].onChange('3.0');
+
+  assert.deepEqual(calls, [
+    [{ entityId: 8, key: 'value', value: 'UPDATED' }, 'Text updated'],
+    [{ entityId: 8, key: 'height', value: '3.0' }, 'Text height updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_entity_fields.js
+++ b/tools/web_viewer/ui/property_panel_entity_fields.js
@@ -1,35 +1,4 @@
-export function buildFullTextEditFieldDescriptors(primary, deps = {}) {
-  if (!primary || primary.type !== 'text') return [];
-  const { patchSelection = null, buildPatch = null } = deps;
-  if (typeof patchSelection !== 'function' || typeof buildPatch !== 'function') return [];
-  return [
-    {
-      kind: 'field',
-      config: { label: 'Text', name: 'value', value: primary.value || 'TEXT' },
-      onChange: (value) => patchSelection(buildPatch(primary, 'value', value), 'Text updated'),
-    },
-    {
-      kind: 'field',
-      config: { label: 'Position X', name: 'position.x', type: 'number', value: String(primary.position.x) },
-      onChange: (value) => patchSelection(buildPatch(primary, 'position.x', value), 'Text position updated'),
-    },
-    {
-      kind: 'field',
-      config: { label: 'Position Y', name: 'position.y', type: 'number', value: String(primary.position.y) },
-      onChange: (value) => patchSelection(buildPatch(primary, 'position.y', value), 'Text position updated'),
-    },
-    {
-      kind: 'field',
-      config: { label: 'Height', name: 'height', type: 'number', value: String(primary.height || 2.5) },
-      onChange: (value) => patchSelection(buildPatch(primary, 'height', value), 'Text height updated'),
-    },
-    {
-      kind: 'field',
-      config: { label: 'Rotation (rad)', name: 'rotation', type: 'number', value: String(primary.rotation || 0) },
-      onChange: (value) => patchSelection(buildPatch(primary, 'rotation', value), 'Text rotation updated'),
-    },
-  ];
-}
+export { buildFullTextEditFieldDescriptors } from './property_panel_full_text_fields.js';
 
 export function buildInsertProxyTextFieldDescriptors(primary, options = {}, deps = {}) {
   if (!primary || primary.type !== 'text') return [];

--- a/tools/web_viewer/ui/property_panel_full_text_fields.js
+++ b/tools/web_viewer/ui/property_panel_full_text_fields.js
@@ -1,0 +1,32 @@
+export function buildFullTextEditFieldDescriptors(primary, deps = {}) {
+  if (!primary || primary.type !== 'text') return [];
+  const { patchSelection = null, buildPatch = null } = deps;
+  if (typeof patchSelection !== 'function' || typeof buildPatch !== 'function') return [];
+  return [
+    {
+      kind: 'field',
+      config: { label: 'Text', name: 'value', value: primary.value || 'TEXT' },
+      onChange: (value) => patchSelection(buildPatch(primary, 'value', value), 'Text updated'),
+    },
+    {
+      kind: 'field',
+      config: { label: 'Position X', name: 'position.x', type: 'number', value: String(primary.position.x) },
+      onChange: (value) => patchSelection(buildPatch(primary, 'position.x', value), 'Text position updated'),
+    },
+    {
+      kind: 'field',
+      config: { label: 'Position Y', name: 'position.y', type: 'number', value: String(primary.position.y) },
+      onChange: (value) => patchSelection(buildPatch(primary, 'position.y', value), 'Text position updated'),
+    },
+    {
+      kind: 'field',
+      config: { label: 'Height', name: 'height', type: 'number', value: String(primary.height || 2.5) },
+      onChange: (value) => patchSelection(buildPatch(primary, 'height', value), 'Text height updated'),
+    },
+    {
+      kind: 'field',
+      config: { label: 'Rotation (rad)', name: 'rotation', type: 'number', value: String(primary.rotation || 0) },
+      onChange: (value) => patchSelection(buildPatch(primary, 'rotation', value), 'Text rotation updated'),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- extract buildFullTextEditFieldDescriptors into a dedicated helper module
- keep property_panel_entity_fields re-exporting the public API
- add focused helper coverage without changing insert-proxy or single-entity behavior

## Verification
- node --check tools/web_viewer/ui/property_panel_full_text_fields.js
- node --check tools/web_viewer/ui/property_panel_entity_fields.js
- node --test tools/web_viewer/tests/property_panel_full_text_fields.test.js tools/web_viewer/tests/property_panel_entity_fields.test.js
- node --test tools/web_viewer/tests/editor_commands.test.js
- git diff --check