### PR TITLE
refactor: extract insert proxy fields

### DIFF
--- a/docs/STEP375_INSERT_PROXY_FIELDS_DESIGN.md
+++ b/docs/STEP375_INSERT_PROXY_FIELDS_DESIGN.md
@@ -1,0 +1,60 @@
+# Step375: Insert Proxy Fields Extraction
+
+## Goal
+
+Extract the insert-proxy field builder from:
+
+- `tools/web_viewer/ui/property_panel_entity_fields.js`
+
+The purpose is to isolate:
+
+- `buildInsertProxyTextFieldDescriptors(...)`
+
+without changing field labels, names, patch payloads, update messages, or position-edit gating.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `buildInsertProxyTextFieldDescriptors(...)`
+- Keep field ordering unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` threading unchanged
+- Keep `allowPositionEditing` semantics unchanged
+
+Out of scope:
+
+- `buildFullTextEditFieldDescriptors(...)`
+- `buildSingleEntityEditFieldDescriptors(...)`
+- render callback behavior
+
+## Constraints
+
+- Keep `buildInsertProxyTextFieldDescriptors(...)` public contract unchanged.
+- Preserve exact field labels, names, ordering, and update messages.
+- Preserve `primary.type === 'text'` guard behavior.
+- Preserve `attdef` label switching behavior.
+- Preserve the dependency guard that returns `[]` unless both `patchSelection` and `buildPatch` are functions.
+- Only extract insert-proxy field assembly into a dedicated helper module.
+- Keep `property_panel_entity_fields.js` re-exporting `buildInsertProxyTextFieldDescriptors(...)`.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_insert_proxy_fields.js`
+
+Expected responsibility split:
+
+- helper: `buildInsertProxyTextFieldDescriptors(...)`
+- `property_panel_entity_fields.js`: re-export insert-proxy builder, keep single-entity builder
+
+## Acceptance
+
+Accept Step375 only if:
+
+- `property_panel_entity_fields.js` no longer defines `buildInsertProxyTextFieldDescriptors(...)` inline
+- focused tests cover extracted insert-proxy field behavior directly
+- existing entity field tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP375_INSERT_PROXY_FIELDS_VERIFICATION.md
+++ b/docs/STEP375_INSERT_PROXY_FIELDS_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step375: Insert Proxy Fields Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step375-insert-proxy-fields-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_insert_proxy_fields.js
+node --check tools/web_viewer/ui/property_panel_entity_fields.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_insert_proxy_fields.test.js \
+  tools/web_viewer/tests/property_panel_entity_fields.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_entity_fields.test.js
+++ b/tools/web_viewer/tests/property_panel_entity_fields.test.js
@@ -79,3 +79,15 @@ test('buildSingleEntityEditFieldDescriptors forwards update messages', () => {
     [{ closed: true }, 'Polyline closed updated'],
   ]);
 });
+
+test('buildSingleEntityEditFieldDescriptors preserves text delegation', () => {
+  const fields = buildSingleEntityEditFieldDescriptors(
+    { type: 'text', value: 'TEXT', position: { x: 10, y: 20 }, height: 2.5, rotation: 0 },
+    { patchSelection: () => {}, buildPatch: () => ({}) },
+  );
+
+  assert.deepEqual(
+    fields.map((field) => field.config.label),
+    ['Text', 'Position X', 'Position Y', 'Height', 'Rotation (rad)'],
+  );
+});

--- a/tools/web_viewer/tests/property_panel_insert_proxy_fields.test.js
+++ b/tools/web_viewer/tests/property_panel_insert_proxy_fields.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildInsertProxyTextFieldDescriptors } from '../ui/property_panel_insert_proxy_fields.js';
+
+test('buildInsertProxyTextFieldDescriptors preserves optional position fields', () => {
+  const fields = buildInsertProxyTextFieldDescriptors(
+    { type: 'text', textKind: 'attdef', value: 'DEF', position: { x: 26, y: 15 } },
+    { allowPositionEditing: true },
+    { patchSelection: () => {}, buildPatch: () => ({}) },
+  );
+
+  assert.deepEqual(
+    fields.map((field) => [field.config.name, field.config.label]),
+    [
+      ['value', 'Default Text'],
+      ['position.x', 'Position X'],
+      ['position.y', 'Position Y'],
+    ],
+  );
+});
+
+test('buildInsertProxyTextFieldDescriptors preserves direct text patch and update message', () => {
+  const calls = [];
+  const fields = buildInsertProxyTextFieldDescriptors(
+    { type: 'text', textKind: 'text', value: 'TEXT', position: { x: 10, y: 20 } },
+    { allowPositionEditing: false },
+    {
+      patchSelection: (patch, message) => calls.push([patch, message]),
+      buildPatch: () => ({ unexpected: true }),
+    },
+  );
+
+  assert.equal(fields.length, 1);
+  fields[0].onChange('UPDATED');
+  assert.deepEqual(calls, [
+    [{ value: 'UPDATED' }, 'Text updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_entity_fields.js
+++ b/tools/web_viewer/ui/property_panel_entity_fields.js
@@ -1,34 +1,7 @@
-export { buildFullTextEditFieldDescriptors } from './property_panel_full_text_fields.js';
+import { buildFullTextEditFieldDescriptors } from './property_panel_full_text_fields.js';
 
-export function buildInsertProxyTextFieldDescriptors(primary, options = {}, deps = {}) {
-  if (!primary || primary.type !== 'text') return [];
-  const { allowPositionEditing = false } = options;
-  const { patchSelection = null, buildPatch = null } = deps;
-  if (typeof patchSelection !== 'function' || typeof buildPatch !== 'function') return [];
-  const label = String(primary?.textKind || '').trim().toLowerCase() === 'attdef' ? 'Default Text' : 'Text';
-  const fields = [
-    {
-      kind: 'field',
-      config: { label, name: 'value', value: primary.value || 'TEXT' },
-      onChange: (value) => patchSelection({ value: String(value ?? primary.value ?? '') }, 'Text updated'),
-    },
-  ];
-  if (allowPositionEditing) {
-    fields.push(
-      {
-        kind: 'field',
-        config: { label: 'Position X', name: 'position.x', type: 'number', value: String(primary.position.x) },
-        onChange: (value) => patchSelection(buildPatch(primary, 'position.x', value), 'Text position updated'),
-      },
-      {
-        kind: 'field',
-        config: { label: 'Position Y', name: 'position.y', type: 'number', value: String(primary.position.y) },
-        onChange: (value) => patchSelection(buildPatch(primary, 'position.y', value), 'Text position updated'),
-      },
-    );
-  }
-  return fields;
-}
+export { buildFullTextEditFieldDescriptors } from './property_panel_full_text_fields.js';
+export { buildInsertProxyTextFieldDescriptors } from './property_panel_insert_proxy_fields.js';
 
 export function buildSingleEntityEditFieldDescriptors(primary, deps = {}) {
   if (!primary) return [];

--- a/tools/web_viewer/ui/property_panel_insert_proxy_fields.js
+++ b/tools/web_viewer/ui/property_panel_insert_proxy_fields.js
@@ -1,0 +1,29 @@
+export function buildInsertProxyTextFieldDescriptors(primary, options = {}, deps = {}) {
+  if (!primary || primary.type !== 'text') return [];
+  const { allowPositionEditing = false } = options;
+  const { patchSelection = null, buildPatch = null } = deps;
+  if (typeof patchSelection !== 'function' || typeof buildPatch !== 'function') return [];
+  const label = String(primary?.textKind || '').trim().toLowerCase() === 'attdef' ? 'Default Text' : 'Text';
+  const fields = [
+    {
+      kind: 'field',
+      config: { label, name: 'value', value: primary.value || 'TEXT' },
+      onChange: (value) => patchSelection({ value: String(value ?? primary.value ?? '') }, 'Text updated'),
+    },
+  ];
+  if (allowPositionEditing) {
+    fields.push(
+      {
+        kind: 'field',
+        config: { label: 'Position X', name: 'position.x', type: 'number', value: String(primary.position.x) },
+        onChange: (value) => patchSelection(buildPatch(primary, 'position.x', value), 'Text position updated'),
+      },
+      {
+        kind: 'field',
+        config: { label: 'Position Y', name: 'position.y', type: 'number', value: String(primary.position.y) },
+        onChange: (value) => patchSelection(buildPatch(primary, 'position.y', value), 'Text position updated'),
+      },
+    );
+  }
+  return fields;
+}


### PR DESCRIPTION
## Summary\n- extract buildInsertProxyTextFieldDescriptors(...) into a dedicated helper\n- keep property_panel_entity_fields.js as the thin entrypoint/re-export surface\n- add focused insert-proxy field tests and preserve current entity-field behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_insert_proxy_fields.js\n- node --check tools/web_viewer/ui/property_panel_entity_fields.js\n- node --test tools/web_viewer/tests/property_panel_insert_proxy_fields.test.js tools/web_viewer/tests/property_panel_entity_fields.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check