### PR TITLE
refactor: extract common property field appender

### DIFF
--- a/docs/STEP378_COMMON_PROPERTY_FIELD_APPENDER_DESIGN.md
+++ b/docs/STEP378_COMMON_PROPERTY_FIELD_APPENDER_DESIGN.md
@@ -1,0 +1,57 @@
+# Step378: Common Property Field Appender Extraction
+
+## Goal
+
+Extract the common-property field appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_field_appenders.js`
+
+The purpose is to isolate:
+
+- `appendCommonPropertyFields(...)`
+
+without changing descriptor ordering, dependency threading, or imported-layer promotion behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendCommonPropertyFields(...)`
+- Keep `appendFieldDescriptors(...)` threading unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` / `getLayer(...)` / `ensureLayer(...)` threading unchanged
+
+Out of scope:
+
+- `appendSourceTextFields(...)`
+- `appendInsertProxyTextFields(...)`
+- `appendSingleEntityFields(...)`
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFieldAppenders(...)` public contract unchanged.
+- Preserve exact descriptor ordering and update behavior.
+- Preserve `displayedColor` and `promoteImportedColorSource` threading.
+- Only extract the common-property field appender into a dedicated helper module.
+- Keep `property_panel_glue_field_appenders.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_common_field_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendCommonPropertyFields(...)`
+- `property_panel_glue_field_appenders.js`: factory, remaining appenders, returned object
+
+## Acceptance
+
+Accept Step378 only if:
+
+- `property_panel_glue_field_appenders.js` no longer defines `appendCommonPropertyFields(...)` inline
+- focused tests cover extracted common-property appender behavior directly
+- existing glue field appender tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP378_COMMON_PROPERTY_FIELD_APPENDER_VERIFICATION.md
+++ b/docs/STEP378_COMMON_PROPERTY_FIELD_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step378: Common Property Field Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step378-common-property-field-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_common_field_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_common_field_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_common_field_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_common_field_appender.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendCommonPropertyFields } from '../ui/property_panel_common_field_appender.js';
+
+test('appendCommonPropertyFields preserves descriptor threading and imported-layer promotion behavior', () => {
+  const fieldBatches = [];
+  const patchCalls = [];
+  const ensuredLayers = [];
+  const primary = {
+    id: 8,
+    type: 'text',
+    layerId: 2,
+    color: '#778899',
+    visible: true,
+    lineType: 'BYLAYER',
+    lineWeight: 0,
+    lineTypeScale: 1,
+  };
+
+  appendCommonPropertyFields(
+    (descriptors) => fieldBatches.push(descriptors),
+    primary,
+    '#112233',
+    true,
+    {
+      patchSelection: (patch, message) => patchCalls.push([patch, message]),
+      buildPatch: (entity, key, value) => ({ entityId: entity.id ?? null, key, value }),
+      getLayer: () => null,
+      ensureLayer: (layerId) => ensuredLayers.push(layerId),
+    },
+  );
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.kind === 'toggle' ? descriptor.label : descriptor.config.name),
+    ['layerId', 'color', 'Visible', 'lineType', 'lineWeight', 'lineTypeScale'],
+  );
+
+  fieldBatches[0][0].onChange('7');
+
+  assert.deepEqual(ensuredLayers, [7]);
+  assert.deepEqual(patchCalls, [
+    [{ layerId: 7, colorSource: 'TRUECOLOR', colorAci: null }, 'Layer updated; imported color promoted to explicit'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_common_field_appender.js
+++ b/tools/web_viewer/ui/property_panel_common_field_appender.js
@@ -1,0 +1,26 @@
+import { buildCommonPropertyFieldDescriptors } from './property_panel_common_fields.js';
+
+export function appendCommonPropertyFields(
+  appendFieldDescriptors,
+  primary,
+  displayedColor,
+  promoteImportedColorSource,
+  deps = {},
+) {
+  const {
+    patchSelection,
+    buildPatch,
+    getLayer,
+    ensureLayer,
+  } = deps;
+  appendFieldDescriptors(buildCommonPropertyFieldDescriptors(
+    primary,
+    { displayedColor, promoteImportedColorSource },
+    {
+      patchSelection,
+      buildPatch,
+      getLayer,
+      ensureLayer,
+    },
+  ));
+}

--- a/tools/web_viewer/ui/property_panel_glue_field_appenders.js
+++ b/tools/web_viewer/ui/property_panel_glue_field_appenders.js
@@ -3,7 +3,7 @@ import {
   buildInsertProxyTextFieldDescriptors,
   buildSingleEntityEditFieldDescriptors,
 } from './property_panel_entity_fields.js';
-import { buildCommonPropertyFieldDescriptors } from './property_panel_common_fields.js';
+import { appendCommonPropertyFields } from './property_panel_common_field_appender.js';
 
 export function createPropertyPanelGlueFieldAppenders({
   appendFieldDescriptors,
@@ -12,17 +12,19 @@ export function createPropertyPanelGlueFieldAppenders({
   getLayer,
   ensureLayer,
 }) {
-  function appendCommonPropertyFields(primary, displayedColor, promoteImportedColorSource) {
-    appendFieldDescriptors(buildCommonPropertyFieldDescriptors(
+  function appendCommonPropertyFieldsForPrimary(primary, displayedColor, promoteImportedColorSource) {
+    appendCommonPropertyFields(
+      appendFieldDescriptors,
       primary,
-      { displayedColor, promoteImportedColorSource },
+      displayedColor,
+      promoteImportedColorSource,
       {
         patchSelection,
         buildPatch,
         getLayer,
         ensureLayer,
       },
-    ));
+    );
   }
 
   function appendSourceTextFields(primary) {
@@ -42,7 +44,7 @@ export function createPropertyPanelGlueFieldAppenders({
   }
 
   return {
-    appendCommonPropertyFields,
+    appendCommonPropertyFields: appendCommonPropertyFieldsForPrimary,
     appendSourceTextFields,
     appendInsertProxyTextFields,
     appendSingleEntityFields,


### PR DESCRIPTION
## Summary\n- extract appendCommonPropertyFields(...) into a dedicated helper\n- keep property_panel_glue_field_appenders.js focused on the factory and remaining appenders\n- add focused common-property appender coverage while preserving existing glue-appender behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_common_field_appender.js\n- node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js\n- node --test tools/web_viewer/tests/property_panel_common_field_appender.test.js tools/web_viewer/tests/property_panel_glue_field_appenders.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check