### PR TITLE
refactor: extract source text field appender

### DIFF
--- a/docs/STEP379_SOURCE_TEXT_FIELD_APPENDER_DESIGN.md
+++ b/docs/STEP379_SOURCE_TEXT_FIELD_APPENDER_DESIGN.md
@@ -1,0 +1,56 @@
+# Step379: Source Text Field Appender Extraction
+
+## Goal
+
+Extract the source-text field appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_field_appenders.js`
+
+The purpose is to isolate:
+
+- `appendSourceTextFields(...)`
+
+without changing descriptor ordering, dependency threading, or text update behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendSourceTextFields(...)`
+- Keep `appendFieldDescriptors(...)` threading unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` threading unchanged
+
+Out of scope:
+
+- `appendCommonPropertyFields(...)`
+- `appendInsertProxyTextFields(...)`
+- `appendSingleEntityFields(...)`
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFieldAppenders(...)` public contract unchanged.
+- Preserve exact descriptor ordering and update behavior.
+- Only extract the source-text field appender into a dedicated helper module.
+- Keep `property_panel_glue_field_appenders.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_source_text_field_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendSourceTextFields(...)`
+- `property_panel_glue_field_appenders.js`: factory, remaining appenders, returned object
+
+## Acceptance
+
+Accept Step379 only if:
+
+- `property_panel_glue_field_appenders.js` no longer defines `appendSourceTextFields(...)` inline
+- focused tests cover extracted source-text appender behavior directly
+- existing glue field appender tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP379_SOURCE_TEXT_FIELD_APPENDER_VERIFICATION.md
+++ b/docs/STEP379_SOURCE_TEXT_FIELD_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step379: Source Text Field Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step379-source-text-field-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_source_text_field_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_source_text_field_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_source_text_field_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_source_text_field_appender.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSourceTextFields } from '../ui/property_panel_source_text_field_appender.js';
+
+test('appendSourceTextFields preserves descriptor threading and text update behavior', () => {
+  const fieldBatches = [];
+  const patchCalls = [];
+  const buildPatchCalls = [];
+  const primary = {
+    id: 8,
+    type: 'text',
+    position: { x: 10, y: 20 },
+    value: 'TEXT',
+    height: 2.5,
+    rotation: 0,
+  };
+
+  appendSourceTextFields(
+    (descriptors) => fieldBatches.push(descriptors),
+    primary,
+    {
+      patchSelection: (patch, message) => patchCalls.push([patch, message]),
+      buildPatch: (entity, key, value) => {
+        buildPatchCalls.push([entity.id ?? null, key, value]);
+        return { entityId: entity.id ?? null, key, value };
+      },
+    },
+  );
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['value', 'position.x', 'position.y', 'height', 'rotation'],
+  );
+
+  fieldBatches[0][0].onChange('UPDATED');
+
+  assert.deepEqual(buildPatchCalls, [[8, 'value', 'UPDATED']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 8, key: 'value', value: 'UPDATED' }, 'Text updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_glue_field_appenders.js
+++ b/tools/web_viewer/ui/property_panel_glue_field_appenders.js
@@ -1,9 +1,9 @@
 import {
-  buildFullTextEditFieldDescriptors,
   buildInsertProxyTextFieldDescriptors,
   buildSingleEntityEditFieldDescriptors,
 } from './property_panel_entity_fields.js';
 import { appendCommonPropertyFields } from './property_panel_common_field_appender.js';
+import { appendSourceTextFields } from './property_panel_source_text_field_appender.js';
 
 export function createPropertyPanelGlueFieldAppenders({
   appendFieldDescriptors,
@@ -27,8 +27,8 @@ export function createPropertyPanelGlueFieldAppenders({
     );
   }
 
-  function appendSourceTextFields(primary) {
-    appendFieldDescriptors(buildFullTextEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+  function appendSourceTextFieldsForPrimary(primary) {
+    appendSourceTextFields(appendFieldDescriptors, primary, { patchSelection, buildPatch });
   }
 
   function appendInsertProxyTextFields(primary, { allowPositionEditing = false } = {}) {
@@ -45,7 +45,7 @@ export function createPropertyPanelGlueFieldAppenders({
 
   return {
     appendCommonPropertyFields: appendCommonPropertyFieldsForPrimary,
-    appendSourceTextFields,
+    appendSourceTextFields: appendSourceTextFieldsForPrimary,
     appendInsertProxyTextFields,
     appendSingleEntityFields,
   };

--- a/tools/web_viewer/ui/property_panel_source_text_field_appender.js
+++ b/tools/web_viewer/ui/property_panel_source_text_field_appender.js
@@ -1,0 +1,6 @@
+import { buildFullTextEditFieldDescriptors } from './property_panel_entity_fields.js';
+
+export function appendSourceTextFields(appendFieldDescriptors, primary, deps = {}) {
+  const { patchSelection, buildPatch } = deps;
+  appendFieldDescriptors(buildFullTextEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+}


### PR DESCRIPTION
## Summary\n- extract appendSourceTextFields(...) into a dedicated helper\n- keep property_panel_glue_field_appenders.js focused on the factory and remaining appenders\n- add focused source-text appender coverage while preserving existing glue-appender behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_source_text_field_appender.js\n- node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js\n- node --test tools/web_viewer/tests/property_panel_source_text_field_appender.test.js tools/web_viewer/tests/property_panel_glue_field_appenders.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check