### PR TITLE
refactor: extract insert proxy field appender

### DIFF
--- a/docs/STEP380_INSERT_PROXY_FIELD_APPENDER_DESIGN.md
+++ b/docs/STEP380_INSERT_PROXY_FIELD_APPENDER_DESIGN.md
@@ -1,0 +1,58 @@
+# Step380: Insert Proxy Field Appender Extraction
+
+## Goal
+
+Extract the insert-proxy field appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_field_appenders.js`
+
+The purpose is to isolate:
+
+- `appendInsertProxyTextFields(...)`
+
+without changing descriptor ordering, dependency threading, or `allowPositionEditing` behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendInsertProxyTextFields(...)`
+- Keep `appendFieldDescriptors(...)` threading unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` threading unchanged
+- Keep `allowPositionEditing` passthrough unchanged
+
+Out of scope:
+
+- `appendCommonPropertyFields(...)`
+- `appendSourceTextFields(...)`
+- `appendSingleEntityFields(...)`
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFieldAppenders(...)` public contract unchanged.
+- Preserve exact descriptor ordering and update behavior.
+- Preserve `allowPositionEditing` passthrough semantics.
+- Only extract the insert-proxy field appender into a dedicated helper module.
+- Keep `property_panel_glue_field_appenders.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_insert_proxy_field_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendInsertProxyTextFields(...)`
+- `property_panel_glue_field_appenders.js`: factory, remaining appenders, returned object
+
+## Acceptance
+
+Accept Step380 only if:
+
+- `property_panel_glue_field_appenders.js` no longer defines `appendInsertProxyTextFields(...)` inline
+- focused tests cover extracted insert-proxy appender behavior directly
+- existing glue field appender tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP380_INSERT_PROXY_FIELD_APPENDER_VERIFICATION.md
+++ b/docs/STEP380_INSERT_PROXY_FIELD_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step380: Insert Proxy Field Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step380-insert-proxy-field-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_insert_proxy_field_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_insert_proxy_field_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_insert_proxy_field_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_insert_proxy_field_appender.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendInsertProxyTextFields } from '../ui/property_panel_insert_proxy_field_appender.js';
+
+test('appendInsertProxyTextFields preserves allowPositionEditing passthrough and update behavior', () => {
+  const fieldBatches = [];
+  const patchCalls = [];
+  const buildPatchCalls = [];
+  const primary = {
+    id: 8,
+    type: 'text',
+    textKind: 'attdef',
+    position: { x: 10, y: 20 },
+    value: 'TEXT',
+  };
+
+  appendInsertProxyTextFields(
+    (descriptors) => fieldBatches.push(descriptors),
+    primary,
+    { allowPositionEditing: true },
+    {
+      patchSelection: (patch, message) => patchCalls.push([patch, message]),
+      buildPatch: (entity, key, value) => {
+        buildPatchCalls.push([entity.id ?? null, key, value]);
+        return { entityId: entity.id ?? null, key, value };
+      },
+    },
+  );
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['value', 'position.x', 'position.y'],
+  );
+
+  fieldBatches[0][1].onChange('42');
+
+  assert.deepEqual(buildPatchCalls, [[8, 'position.x', '42']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 8, key: 'position.x', value: '42' }, 'Text position updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_glue_field_appenders.js
+++ b/tools/web_viewer/ui/property_panel_glue_field_appenders.js
@@ -1,9 +1,9 @@
 import {
-  buildInsertProxyTextFieldDescriptors,
   buildSingleEntityEditFieldDescriptors,
 } from './property_panel_entity_fields.js';
 import { appendCommonPropertyFields } from './property_panel_common_field_appender.js';
 import { appendSourceTextFields } from './property_panel_source_text_field_appender.js';
+import { appendInsertProxyTextFields as appendInsertProxyTextFieldsHelper } from './property_panel_insert_proxy_field_appender.js';
 
 export function createPropertyPanelGlueFieldAppenders({
   appendFieldDescriptors,
@@ -31,12 +31,16 @@ export function createPropertyPanelGlueFieldAppenders({
     appendSourceTextFields(appendFieldDescriptors, primary, { patchSelection, buildPatch });
   }
 
-  function appendInsertProxyTextFields(primary, { allowPositionEditing = false } = {}) {
-    appendFieldDescriptors(buildInsertProxyTextFieldDescriptors(
+  function appendInsertProxyTextFieldsForPrimary(primary, { allowPositionEditing = false } = {}) {
+    appendInsertProxyTextFieldsHelper(
+      appendFieldDescriptors,
       primary,
       { allowPositionEditing },
-      { patchSelection, buildPatch },
-    ));
+      {
+        patchSelection,
+        buildPatch,
+      },
+    );
   }
 
   function appendSingleEntityFields(primary) {
@@ -46,7 +50,7 @@ export function createPropertyPanelGlueFieldAppenders({
   return {
     appendCommonPropertyFields: appendCommonPropertyFieldsForPrimary,
     appendSourceTextFields: appendSourceTextFieldsForPrimary,
-    appendInsertProxyTextFields,
+    appendInsertProxyTextFields: appendInsertProxyTextFieldsForPrimary,
     appendSingleEntityFields,
   };
 }

--- a/tools/web_viewer/ui/property_panel_insert_proxy_field_appender.js
+++ b/tools/web_viewer/ui/property_panel_insert_proxy_field_appender.js
@@ -1,0 +1,16 @@
+import { buildInsertProxyTextFieldDescriptors } from './property_panel_entity_fields.js';
+
+export function appendInsertProxyTextFields(
+  appendFieldDescriptors,
+  primary,
+  options = {},
+  deps = {},
+) {
+  const { allowPositionEditing = false } = options;
+  const { patchSelection, buildPatch } = deps;
+  appendFieldDescriptors(buildInsertProxyTextFieldDescriptors(
+    primary,
+    { allowPositionEditing },
+    { patchSelection, buildPatch },
+  ));
+}


### PR DESCRIPTION
## Summary\n- extract appendInsertProxyTextFields(...) into a dedicated helper\n- keep property_panel_glue_field_appenders.js focused on the factory and remaining appenders\n- add focused insert-proxy appender coverage while preserving existing glue-appender behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_insert_proxy_field_appender.js\n- node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js\n- node --test tools/web_viewer/tests/property_panel_insert_proxy_field_appender.test.js tools/web_viewer/tests/property_panel_glue_field_appenders.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check