### PR TITLE
refactor: extract single entity field appender

### DIFF
--- a/docs/STEP381_SINGLE_ENTITY_FIELD_APPENDER_DESIGN.md
+++ b/docs/STEP381_SINGLE_ENTITY_FIELD_APPENDER_DESIGN.md
@@ -1,0 +1,57 @@
+# Step381: Single Entity Field Appender Extraction
+
+## Goal
+
+Extract the single-entity field appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_field_appenders.js`
+
+The purpose is to isolate:
+
+- `appendSingleEntityFields(...)`
+
+without changing descriptor ordering, dependency threading, or single-entity edit behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendSingleEntityFields(...)`
+- Keep `appendFieldDescriptors(...)` threading unchanged
+- Keep `patchSelection(...)` / `buildPatch(...)` threading unchanged
+
+Out of scope:
+
+- `appendCommonPropertyFields(...)`
+- `appendSourceTextFields(...)`
+- `appendInsertProxyTextFields(...)`
+
+## Constraints
+
+- Keep `createPropertyPanelGlueFieldAppenders(...)` public contract unchanged.
+- Preserve exact descriptor ordering and update behavior.
+- Preserve line / polyline / circle / arc / text delegation behavior.
+- Only extract the single-entity field appender into a dedicated helper module.
+- Keep `property_panel_glue_field_appenders.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_single_entity_field_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendSingleEntityFields(...)`
+- `property_panel_glue_field_appenders.js`: factory, remaining appenders, returned object
+
+## Acceptance
+
+Accept Step381 only if:
+
+- `property_panel_glue_field_appenders.js` no longer defines `appendSingleEntityFields(...)` inline
+- focused tests cover extracted single-entity appender behavior directly
+- existing glue field appender tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP381_SINGLE_ENTITY_FIELD_APPENDER_VERIFICATION.md
+++ b/docs/STEP381_SINGLE_ENTITY_FIELD_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step381: Single Entity Field Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step381-single-entity-field-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_single_entity_field_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_single_entity_field_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_field_appenders.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_single_entity_field_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_single_entity_field_appender.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendSingleEntityFields } from '../ui/property_panel_single_entity_field_appender.js';
+
+test('appendSingleEntityFields preserves single-entity descriptor threading and update behavior', () => {
+  const fieldBatches = [];
+  const patchCalls = [];
+  const buildPatchCalls = [];
+  const primary = {
+    id: 9,
+    type: 'line',
+    start: { x: 1, y: 2 },
+    end: { x: 3, y: 4 },
+  };
+
+  appendSingleEntityFields(
+    (descriptors) => fieldBatches.push(descriptors),
+    primary,
+    {
+      patchSelection: (patch, message) => patchCalls.push([patch, message]),
+      buildPatch: (entity, key, value) => {
+        buildPatchCalls.push([entity.id ?? null, key, value]);
+        return { entityId: entity.id ?? null, key, value };
+      },
+    },
+  );
+
+  assert.deepEqual(
+    fieldBatches[0].map((descriptor) => descriptor.config.name),
+    ['start.x', 'start.y', 'end.x', 'end.y'],
+  );
+
+  fieldBatches[0][3].onChange('7');
+
+  assert.deepEqual(buildPatchCalls, [[9, 'end.y', '7']]);
+  assert.deepEqual(patchCalls, [
+    [{ entityId: 9, key: 'end.y', value: '7' }, 'Line end updated'],
+  ]);
+});

--- a/tools/web_viewer/ui/property_panel_glue_field_appenders.js
+++ b/tools/web_viewer/ui/property_panel_glue_field_appenders.js
@@ -1,9 +1,7 @@
-import {
-  buildSingleEntityEditFieldDescriptors,
-} from './property_panel_entity_fields.js';
 import { appendCommonPropertyFields } from './property_panel_common_field_appender.js';
 import { appendSourceTextFields } from './property_panel_source_text_field_appender.js';
 import { appendInsertProxyTextFields as appendInsertProxyTextFieldsHelper } from './property_panel_insert_proxy_field_appender.js';
+import { appendSingleEntityFields as appendSingleEntityFieldsHelper } from './property_panel_single_entity_field_appender.js';
 
 export function createPropertyPanelGlueFieldAppenders({
   appendFieldDescriptors,
@@ -43,14 +41,14 @@ export function createPropertyPanelGlueFieldAppenders({
     );
   }
 
-  function appendSingleEntityFields(primary) {
-    appendFieldDescriptors(buildSingleEntityEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+  function appendSingleEntityFieldsForPrimary(primary) {
+    appendSingleEntityFieldsHelper(appendFieldDescriptors, primary, { patchSelection, buildPatch });
   }
 
   return {
     appendCommonPropertyFields: appendCommonPropertyFieldsForPrimary,
     appendSourceTextFields: appendSourceTextFieldsForPrimary,
     appendInsertProxyTextFields: appendInsertProxyTextFieldsForPrimary,
-    appendSingleEntityFields,
+    appendSingleEntityFields: appendSingleEntityFieldsForPrimary,
   };
 }

--- a/tools/web_viewer/ui/property_panel_single_entity_field_appender.js
+++ b/tools/web_viewer/ui/property_panel_single_entity_field_appender.js
@@ -1,0 +1,6 @@
+import { buildSingleEntityEditFieldDescriptors } from './property_panel_entity_fields.js';
+
+export function appendSingleEntityFields(appendFieldDescriptors, primary, deps = {}) {
+  const { patchSelection, buildPatch } = deps;
+  appendFieldDescriptors(buildSingleEntityEditFieldDescriptors(primary, { patchSelection, buildPatch }));
+}


### PR DESCRIPTION
## Summary\n- extract appendSingleEntityFields(...) into a dedicated helper\n- keep property_panel_glue_field_appenders.js focused on the factory and remaining appenders\n- add focused single-entity appender coverage while preserving existing glue-appender behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_single_entity_field_appender.js\n- node --check tools/web_viewer/ui/property_panel_glue_field_appenders.js\n- node --test tools/web_viewer/tests/property_panel_single_entity_field_appender.test.js tools/web_viewer/tests/property_panel_glue_field_appenders.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check