### PR TITLE
refactor: extract style action appender

### DIFF
--- a/docs/STEP382_STYLE_ACTION_APPENDER_DESIGN.md
+++ b/docs/STEP382_STYLE_ACTION_APPENDER_DESIGN.md
@@ -1,0 +1,54 @@
+# Step382: Style Action Appender Extraction
+
+## Goal
+
+Extract the style action appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_style_layer_actions.js`
+
+The purpose is to isolate:
+
+- `appendStyleActions(...)`
+
+without changing action ordering, dependency threading, or style reset behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendStyleActions(...)`
+- Keep `addActionRow(...)` threading unchanged
+- Keep `patchSelection(...)` threading unchanged
+
+Out of scope:
+
+- `appendLayerActions(...)`
+
+## Constraints
+
+- Keep `createStyleLayerActionAppenders(...)` public contract unchanged.
+- Preserve exact action ordering and click behavior.
+- Only extract the style action appender into a dedicated helper module.
+- Keep `property_panel_glue_style_layer_actions.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_style_action_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendStyleActions(...)`
+- `property_panel_glue_style_layer_actions.js`: factory, remaining layer appender, returned object
+
+## Acceptance
+
+Accept Step382 only if:
+
+- `property_panel_glue_style_layer_actions.js` no longer defines `appendStyleActions(...)` inline
+- focused tests cover extracted style action appender behavior directly
+- existing glue style/layer tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP382_STYLE_ACTION_APPENDER_VERIFICATION.md
+++ b/docs/STEP382_STYLE_ACTION_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step382: Style Action Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step382-style-action-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_style_action_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_style_action_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_style_action_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_style_action_appender.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendStyleActions } from '../ui/property_panel_style_action_appender.js';
+
+test('appendStyleActions preserves style action ordering and patch threading', () => {
+  const actionRows = [];
+  const patchCalls = [];
+
+  appendStyleActions(
+    (actions) => actionRows.push(actions),
+    {
+      id: 10,
+      colorSource: 'TRUECOLOR',
+      lineType: 'CENTER',
+      lineWeight: 0.25,
+      lineWeightSource: 'EXPLICIT',
+      lineTypeScale: 2,
+      lineTypeScaleSource: 'EXPLICIT',
+    },
+    { id: 3, name: 'ANNOT', color: '#55aaee', visible: true, frozen: false, locked: false },
+    {
+      patchSelection: (patch, message) => patchCalls.push([patch, message]),
+    },
+  );
+
+  assert.deepEqual(
+    actionRows[0].map((action) => action.id),
+    ['use-layer-color', 'use-layer-line-type', 'use-layer-line-weight', 'use-default-line-type-scale'],
+  );
+
+  actionRows[0][0].onClick();
+
+  assert.deepEqual(patchCalls, [[
+    { color: '#55aaee', colorSource: 'BYLAYER', colorAci: null },
+    'Color source: BYLAYER',
+  ]]);
+});

--- a/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+++ b/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
@@ -1,5 +1,5 @@
-import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
 import { buildLayerActions } from './property_panel_layer_actions.js';
+import { appendStyleActions as appendStyleActionsHelper } from './property_panel_style_action_appender.js';
 
 export function createStyleLayerActionAppenders({
   addActionRow,
@@ -20,8 +20,8 @@ export function createStyleLayerActionAppenders({
   hasLayerFreeze = null,
   restoreLayerFreeze = null,
 }) {
-  function appendStyleActions(entity, layer) {
-    addActionRow(buildStyleActionDescriptors(entity, layer, { patchSelection }));
+  function appendStyleActionsForEntity(entity, layer) {
+    appendStyleActionsHelper(addActionRow, entity, layer, { patchSelection });
   }
 
   function appendLayerActions(layer) {
@@ -44,5 +44,5 @@ export function createStyleLayerActionAppenders({
     }));
   }
 
-  return { appendStyleActions, appendLayerActions };
+  return { appendStyleActions: appendStyleActionsForEntity, appendLayerActions };
 }

--- a/tools/web_viewer/ui/property_panel_style_action_appender.js
+++ b/tools/web_viewer/ui/property_panel_style_action_appender.js
@@ -1,0 +1,6 @@
+import { buildStyleActionDescriptors } from './property_panel_common_fields.js';
+
+export function appendStyleActions(addActionRow, entity, layer, deps = {}) {
+  const { patchSelection } = deps;
+  addActionRow(buildStyleActionDescriptors(entity, layer, { patchSelection }));
+}


### PR DESCRIPTION
## Summary\n- extract appendStyleActions(...) into a dedicated helper\n- keep property_panel_glue_style_layer_actions.js focused on the factory and remaining layer appender\n- add focused style-action appender coverage while preserving existing glue style/layer behavior\n\n## Verification\n- node --check tools/web_viewer/ui/property_panel_style_action_appender.js\n- node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js\n- node --test tools/web_viewer/tests/property_panel_style_action_appender.test.js tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js\n- node --test tools/web_viewer/tests/editor_commands.test.js\n- git diff --check