### PR TITLE
refactor: extract layer action appender

### DIFF
--- a/docs/STEP383_LAYER_ACTION_APPENDER_DESIGN.md
+++ b/docs/STEP383_LAYER_ACTION_APPENDER_DESIGN.md
@@ -1,0 +1,54 @@
+# Step383: Layer Action Appender Extraction
+
+## Goal
+
+Extract the layer action appender from:
+
+- `tools/web_viewer/ui/property_panel_glue_style_layer_actions.js`
+
+The purpose is to isolate:
+
+- `appendLayerActions(...)`
+
+without changing action ordering, dependency threading, or layer action behavior.
+
+## Scope
+
+In scope:
+
+- Extract:
+  - `appendLayerActions(...)`
+- Keep `addActionRow(...)` threading unchanged
+- Keep layer action dependency threading unchanged
+
+Out of scope:
+
+- `appendStyleActions(...)`
+
+## Constraints
+
+- Keep `createStyleLayerActionAppenders(...)` public contract unchanged.
+- Preserve exact action ordering and click behavior.
+- Only extract the layer action appender into a dedicated helper module.
+- Keep `property_panel_glue_style_layer_actions.js` responsible for the returned object shape.
+- Do not introduce a new dependency cycle.
+
+## Expected Shape
+
+Introduce a new helper, expected name:
+
+- `tools/web_viewer/ui/property_panel_layer_action_appender.js`
+
+Expected responsibility split:
+
+- helper: `appendLayerActions(...)`
+- `property_panel_glue_style_layer_actions.js`: factory, style appender, returned object
+
+## Acceptance
+
+Accept Step383 only if:
+
+- `property_panel_glue_style_layer_actions.js` no longer defines `appendLayerActions(...)` inline
+- focused tests cover extracted layer action appender behavior directly
+- existing glue style/layer tests stay green
+- `git diff --check` stays clean

--- a/docs/STEP383_LAYER_ACTION_APPENDER_VERIFICATION.md
+++ b/docs/STEP383_LAYER_ACTION_APPENDER_VERIFICATION.md
@@ -1,0 +1,43 @@
+# Step383: Layer Action Appender Extraction Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/step383-layer-action-appender-cadgf`
+
+## Static Checks
+
+```bash
+node --check tools/web_viewer/ui/property_panel_layer_action_appender.js
+node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+```
+
+## Focused Tests
+
+```bash
+node --test \
+  tools/web_viewer/tests/property_panel_layer_action_appender.test.js \
+  tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js
+```
+
+## Integration
+
+```bash
+node --test tools/web_viewer/tests/editor_commands.test.js
+```
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Expected Report
+
+Report:
+
+- syntax status
+- focused test totals
+- `editor_commands.test.js` total
+- `git diff --check` result
+
+Do not claim browser smoke coverage unless it was actually rerun.

--- a/tools/web_viewer/tests/property_panel_layer_action_appender.test.js
+++ b/tools/web_viewer/tests/property_panel_layer_action_appender.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendLayerActions } from '../ui/property_panel_layer_action_appender.js';
+
+test('appendLayerActions preserves layer action ordering', () => {
+  const actionRows = [];
+
+  appendLayerActions(
+    (actions) => actionRows.push(actions),
+    { id: 3, name: 'ANNOT', visible: true, frozen: false, locked: false },
+    {
+      setStatus: () => {},
+      focusLayer: () => true,
+      getCurrentLayerId: () => 1,
+      useLayer: () => true,
+      lockLayer: () => true,
+      isolateLayer: () => true,
+      turnOffLayer: () => true,
+      freezeLayer: () => true,
+      hasLayerIsolation: () => true,
+      restoreLayerIsolation: () => true,
+      hasLayerFreeze: () => true,
+      restoreLayerFreeze: () => true,
+    },
+  );
+
+  assert.deepEqual(
+    actionRows[0].map((action) => action.id),
+    ['locate-layer', 'use-layer', 'lock-layer', 'isolate-layer', 'turn-off-layer', 'freeze-layer', 'restore-layers', 'thaw-layers'],
+  );
+});
+
+test('appendLayerActions preserves layer callback threading and status messaging', () => {
+  const actionRows = [];
+  const invokedWith = [];
+  const statusMessages = [];
+
+  appendLayerActions(
+    (actions) => actionRows.push(actions),
+    { id: 3, name: 'ANNOT', visible: true, frozen: false, locked: false },
+    {
+      setStatus: (message) => statusMessages.push(message),
+      focusLayer: (id) => { invokedWith.push(['focusLayer', id]); return true; },
+      getCurrentLayerId: () => 1,
+      useLayer: (id) => { invokedWith.push(['useLayer', id]); return true; },
+      lockLayer: (id) => { invokedWith.push(['lockLayer', id]); return true; },
+      isolateLayer: (id) => { invokedWith.push(['isolateLayer', id]); return true; },
+      turnOffLayer: (id) => { invokedWith.push(['turnOffLayer', id]); return true; },
+      freezeLayer: (id) => { invokedWith.push(['freezeLayer', id]); return true; },
+      hasLayerIsolation: () => true,
+      restoreLayerIsolation: () => { invokedWith.push(['restoreLayerIsolation']); return true; },
+      hasLayerFreeze: () => true,
+      restoreLayerFreeze: () => { invokedWith.push(['restoreLayerFreeze']); return true; },
+    },
+  );
+
+  actionRows[0][0].onClick();
+  actionRows[0][1].onClick();
+
+  assert.deepEqual(invokedWith.slice(0, 2), [
+    ['focusLayer', 3],
+    ['useLayer', 3],
+  ]);
+  assert.deepEqual(statusMessages, ['Layer focused: ANNOT']);
+});

--- a/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
+++ b/tools/web_viewer/ui/property_panel_glue_style_layer_actions.js
@@ -1,4 +1,4 @@
-import { buildLayerActions } from './property_panel_layer_actions.js';
+import { appendLayerActions as appendLayerActionsHelper } from './property_panel_layer_action_appender.js';
 import { appendStyleActions as appendStyleActionsHelper } from './property_panel_style_action_appender.js';
 
 export function createStyleLayerActionAppenders({
@@ -25,7 +25,7 @@ export function createStyleLayerActionAppenders({
   }
 
   function appendLayerActions(layer) {
-    addActionRow(buildLayerActions(layer, {
+    appendLayerActionsHelper(addActionRow, layer, {
       setStatus,
       focusLayer,
       getCurrentLayerId,
@@ -41,7 +41,7 @@ export function createStyleLayerActionAppenders({
       thawLayer,
       hasLayerFreeze,
       restoreLayerFreeze,
-    }));
+    });
   }
 
   return { appendStyleActions: appendStyleActionsForEntity, appendLayerActions };

--- a/tools/web_viewer/ui/property_panel_layer_action_appender.js
+++ b/tools/web_viewer/ui/property_panel_layer_action_appender.js
@@ -1,0 +1,5 @@
+import { buildLayerActions } from './property_panel_layer_actions.js';
+
+export function appendLayerActions(addActionRow, layer, deps = {}) {
+  addActionRow(buildLayerActions(layer, deps));
+}


### PR DESCRIPTION
## Summary
- extract `appendLayerActions(...)` from `property_panel_glue_style_layer_actions.js`
- add a dedicated `property_panel_layer_action_appender.js` leaf helper
- add focused tests for layer action ordering and dependency threading

## Verification
- `node --check tools/web_viewer/ui/property_panel_layer_action_appender.js`
- `node --check tools/web_viewer/ui/property_panel_glue_style_layer_actions.js`
- `node --test tools/web_viewer/tests/property_panel_layer_action_appender.test.js tools/web_viewer/tests/property_panel_glue_style_layer_actions.test.js`
- `node --test tools/web_viewer/tests/editor_commands.test.js`
- `git diff --check`
