### PR TITLE
refactor: extract dxf leaf utility modules

### DIFF
--- a/docs/DXF_BATCH1_LEAF_MODULES_DESIGN.md
+++ b/docs/DXF_BATCH1_LEAF_MODULES_DESIGN.md
@@ -1,0 +1,30 @@
+# DXF Batch 1 Leaf Modules
+
+## Scope
+
+Extract the first low-risk DXF importer leaf modules from `plugins/dxf_importer_plugin.cpp`:
+
+- `dxf_types.h`
+- `dxf_text_encoding.h/.cpp`
+- `dxf_color.h/.cpp`
+- `dxf_math_utils.h/.cpp`
+
+Update `plugins/CMakeLists.txt` to compile the new `.cpp` files.
+
+## Non-Goals
+
+- No parser extraction
+- No document committer extraction
+- No plugin ABI changes
+- No plugin-shell slimming beyond removing moved code from `dxf_importer_plugin.cpp`
+
+## Invariants
+
+- `cadgf_plugin_get_api_v1()` behavior stays unchanged
+- Existing DXF importer behavior stays unchanged
+- Private helpers remain private where practical; this step does not blindly remove `static`
+- No new dependency cycles among extracted leaf modules
+
+## Expected Result
+
+`dxf_importer_plugin.cpp` becomes smaller, while encoding/color/math code is moved into self-contained leaf modules that can be reused by later DXF phases.

--- a/docs/DXF_BATCH1_LEAF_MODULES_VERIFICATION.md
+++ b/docs/DXF_BATCH1_LEAF_MODULES_VERIFICATION.md
@@ -1,0 +1,36 @@
+# DXF Batch 1 Leaf Modules Verification
+
+## Clean Worktree Build
+
+Built successfully in:
+
+- `build-codex`
+
+Targets built:
+
+- `cadgf_dxf_importer_plugin`
+- `convert_cli`
+- DXF/DWG tool test executables needed for clean validation
+
+## Clean Worktree Validation
+
+Observed in the clean worktree:
+
+- `22/26` runnable `dxf|dwg` tests passed after excluding two known baseline blockers:
+  - `test_dxf_leader_metadata_run` is blocked by a pre-existing compile break in `test_dxf_leader_metadata.cpp` against `core_c_api.h`
+  - `convert_cli_dxf_style_smoke` is blocked by missing `cmake/RunConvertCliDxfLineStyle.cmake`
+
+The remaining 4 failing runtime tests are pre-existing on `origin/main` and reproduced unchanged there:
+
+- `test_dxf_multi_layout_metadata_run`
+- `test_dxf_paperspace_insert_styles_run`
+- `test_dxf_paperspace_insert_dimension_run`
+- `test_dxf_paperspace_combo_run`
+
+## Acceptance Statement
+
+This packet does not introduce a new clean-baseline failure surface relative to `origin/main`.
+
+## Hygiene
+
+- `git diff --check` passed

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,7 +10,12 @@ set_target_properties(cadgf_sample_plugin PROPERTIES
 )
 
 # DXF importer plugin (lite)
-add_library(cadgf_dxf_importer_plugin SHARED dxf_importer_plugin.cpp)
+add_library(cadgf_dxf_importer_plugin SHARED
+    dxf_importer_plugin.cpp
+    dxf_math_utils.cpp
+    dxf_text_encoding.cpp
+    dxf_color.cpp
+)
 target_link_libraries(cadgf_dxf_importer_plugin PRIVATE core_c)
 target_include_directories(cadgf_dxf_importer_plugin PRIVATE ${CMAKE_SOURCE_DIR}/core/include)
 if(APPLE)

--- a/plugins/dxf_color.cpp
+++ b/plugins/dxf_color.cpp
@@ -1,0 +1,73 @@
+#include "dxf_color.h"
+
+unsigned int aci_to_rgb(int index) {
+    switch (index) {
+        case 1: return 0xFF0000u;
+        case 2: return 0xFFFF00u;
+        case 3: return 0x00FF00u;
+        case 4: return 0x00FFFFu;
+        case 5: return 0x0000FFu;
+        case 6: return 0xFF00FFu;
+        case 7: return 0xFFFFFFu;
+        case 8: return 0x808080u;
+        case 9: return 0xC0C0C0u;
+        default: return 0xFFFFFFu;
+    }
+}
+
+const char* color_source_label(DxfColorSource source) {
+    switch (source) {
+        case DxfColorSource::ByLayer:
+            return "BYLAYER";
+        case DxfColorSource::ByBlock:
+            return "BYBLOCK";
+        case DxfColorSource::Index:
+            return "INDEX";
+        case DxfColorSource::TrueColor:
+            return "TRUECOLOR";
+        default:
+            return "";
+    }
+}
+
+DxfColorMeta resolve_color_metadata(const DxfStyle& style,
+                                    const DxfStyle* layer_style,
+                                    const DxfStyle* block_style,
+                                    unsigned int* out_color,
+                                    bool* out_has_color) {
+    if (out_color) *out_color = 0;
+    if (out_has_color) *out_has_color = false;
+
+    DxfColorMeta meta{};
+    const DxfStyle* resolved = nullptr;
+    DxfColorSource source_hint = DxfColorSource::ByLayer;
+
+    if (style.has_color) {
+        resolved = &style;
+        source_hint = DxfColorSource::Index;
+    } else if (style.byblock_color && block_style && block_style->has_color) {
+        resolved = block_style;
+        source_hint = DxfColorSource::ByBlock;
+    } else if (layer_style && layer_style->has_color) {
+        resolved = layer_style;
+        source_hint = DxfColorSource::ByLayer;
+    }
+
+    if (resolved) {
+        if (out_color) *out_color = resolved->color;
+        if (out_has_color) *out_has_color = true;
+        if (resolved->color_is_true) {
+            meta.source = DxfColorSource::TrueColor;
+        } else {
+            meta.source = source_hint;
+        }
+        if (resolved->has_color_aci && !resolved->color_is_true) {
+            meta.aci = resolved->color_aci;
+            meta.has_aci = true;
+        }
+        return meta;
+    }
+
+    meta.source = DxfColorSource::ByLayer;
+    return meta;
+}

--- a/plugins/dxf_color.h
+++ b/plugins/dxf_color.h
@@ -1,0 +1,21 @@
+#pragma once
+// DXF color resolution utilities extracted from dxf_importer_plugin.cpp.
+// Depends on DxfStyle, DxfColorMeta, DxfColorSource from dxf_types.h.
+
+#include "dxf_types.h"
+
+// Map an AutoCAD Color Index (ACI 1-9) to a 24-bit 0xRRGGBB value.
+// Returns white (0xFFFFFF) for unknown indices.
+unsigned int aci_to_rgb(int index);
+
+// Human-readable label for a DxfColorSource enum value.
+const char* color_source_label(DxfColorSource source);
+
+// Resolve the effective color for an entity by checking entity style,
+// then block style (BYBLOCK), then layer style (BYLAYER).
+// Writes the resolved 24-bit color into *out_color and sets *out_has_color.
+DxfColorMeta resolve_color_metadata(const DxfStyle& style,
+                                    const DxfStyle* layer_style,
+                                    const DxfStyle* block_style,
+                                    unsigned int* out_color,
+                                    bool* out_has_color);

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -1,5 +1,10 @@
 #include "core/plugin_abi_c_v1.h"
 
+#include "dxf_types.h"
+#include "dxf_math_utils.h"
+#include "dxf_text_encoding.h"
+#include "dxf_color.h"
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -12,45 +17,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#if defined(__APPLE__) || defined(__linux__)
-#include <iconv.h>
-#define CADGF_HAVE_ICONV 1
-#else
-#define CADGF_HAVE_ICONV 0
-#endif
-
-struct DxfStyle {
-    std::string line_type;
-    double line_weight = 0.0;
-    double line_type_scale = 0.0;
-    bool has_line_type = false;
-    bool has_line_weight = false;
-    bool has_line_scale = false;
-    bool byblock_line_type = false;
-    bool byblock_line_weight = false;
-    unsigned int color = 0;
-    bool has_color = false;
-    int color_aci = 0;
-    bool has_color_aci = false;
-    bool color_is_true = false;
-    bool byblock_color = false;
-    bool hidden = false;
-};
-
-enum class DxfColorSource {
-    None,
-    ByLayer,
-    ByBlock,
-    Index,
-    TrueColor
-};
-
-struct DxfColorMeta {
-    DxfColorSource source{DxfColorSource::None};
-    int aci{0};
-    bool has_aci{false};
-};
 
 struct DxfEntityOriginMeta {
     std::string source_type;
@@ -413,24 +379,8 @@ struct DxfBlock {
     std::vector<DxfInsert> inserts;
 };
 
-static constexpr double kPi = 3.14159265358979323846;
-static constexpr double kTwoPi = kPi * 2.0;
-static constexpr double kDegToRad = kPi / 180.0;
-
-static cadgf_string_view sv(const char* s) {
-    cadgf_string_view v;
-    v.data = s;
-    v.size = s ? static_cast<int32_t>(std::strlen(s)) : 0;
-    return v;
-}
-
-static bool nearly_equal(double a, double b, double eps = 1e-6) {
-    return std::fabs(a - b) <= eps;
-}
-
-static bool points_nearly_equal(const cadgf_vec2& a, const cadgf_vec2& b, double eps = 1e-6) {
-    return nearly_equal(a.x, b.x, eps) && nearly_equal(a.y, b.y, eps);
-}
+// kPi, kTwoPi, kDegToRad, sv(), nearly_equal(), points_nearly_equal()
+// are now provided by dxf_math_utils.h
 
 static double dot_vec(const cadgf_vec2& a, const cadgf_vec2& b) {
     return a.x * b.x + a.y * b.y;
@@ -510,66 +460,8 @@ static void append_ellipse_points(std::vector<cadgf_vec2>* boundary, const cadgf
     }
 }
 
-static void set_error(cadgf_error_v1* err, int32_t code, const char* msg) {
-    if (!err) return;
-    err->code = code;
-    if (!msg) {
-        err->message[0] = 0;
-        return;
-    }
-    std::snprintf(err->message, sizeof(err->message), "%s", msg);
-    err->message[sizeof(err->message) - 1] = 0;
-}
-
-static bool parse_int(const std::string& s, int* out) {
-    if (!out) return false;
-    char* end = nullptr;
-    long v = std::strtol(s.c_str(), &end, 10);
-    if (!end || *end != '\0') return false;
-    *out = static_cast<int>(v);
-    return true;
-}
-
-static bool parse_double(const std::string& s, double* out) {
-    if (!out) return false;
-    char* end = nullptr;
-    double v = std::strtod(s.c_str(), &end);
-    if (!end || *end != '\0') return false;
-    if (!std::isfinite(v)) return false;
-    *out = v;
-    return true;
-}
-
-static void trim_code_line(std::string* line) {
-    if (!line) return;
-    while (!line->empty()) {
-        char ch = line->back();
-        if (ch == '\r' || ch == ' ' || ch == '\t') {
-            line->pop_back();
-            continue;
-        }
-        break;
-    }
-    size_t start = 0;
-    while (start < line->size()) {
-        char ch = (*line)[start];
-        if (ch == ' ' || ch == '\t') {
-            ++start;
-            continue;
-        }
-        break;
-    }
-    if (start > 0) {
-        line->erase(0, start);
-    }
-}
-
-static void strip_cr(std::string* line) {
-    if (!line || line->empty()) return;
-    if (line->back() == '\r') {
-        line->pop_back();
-    }
-}
+// set_error(), parse_int(), parse_double(), trim_code_line(), strip_cr()
+// are now provided by dxf_math_utils.h
 
 static std::string uppercase_ascii(const std::string& value) {
     std::string out;
@@ -598,217 +490,12 @@ static bool is_root_space_block_name(const std::string& name) {
     return upper == "*MODEL_SPACE";
 }
 
-static bool is_valid_utf8(const std::string& value) {
-    const unsigned char* data = reinterpret_cast<const unsigned char*>(value.data());
-    size_t i = 0;
-    while (i < value.size()) {
-        unsigned char c = data[i];
-        if (c <= 0x7Fu) {
-            ++i;
-            continue;
-        }
-        if ((c >> 5) == 0x6) {
-            if (i + 1 >= value.size()) return false;
-            unsigned char c1 = data[i + 1];
-            if ((c1 & 0xC0u) != 0x80u) return false;
-            if (c < 0xC2u) return false;
-            i += 2;
-            continue;
-        }
-        if ((c >> 4) == 0xE) {
-            if (i + 2 >= value.size()) return false;
-            unsigned char c1 = data[i + 1];
-            unsigned char c2 = data[i + 2];
-            if ((c1 & 0xC0u) != 0x80u || (c2 & 0xC0u) != 0x80u) return false;
-            if (c == 0xE0u && c1 < 0xA0u) return false;
-            if (c == 0xEDu && c1 >= 0xA0u) return false;
-            i += 3;
-            continue;
-        }
-        if ((c >> 3) == 0x1E) {
-            if (i + 3 >= value.size()) return false;
-            unsigned char c1 = data[i + 1];
-            unsigned char c2 = data[i + 2];
-            unsigned char c3 = data[i + 3];
-            if ((c1 & 0xC0u) != 0x80u || (c2 & 0xC0u) != 0x80u || (c3 & 0xC0u) != 0x80u) return false;
-            if (c == 0xF0u && c1 < 0x90u) return false;
-            if (c == 0xF4u && c1 > 0x8Fu) return false;
-            if (c > 0xF4u) return false;
-            i += 4;
-            continue;
-        }
-        return false;
-    }
-    return true;
-}
+// is_valid_utf8(), latin1_to_utf8(), all_digits(), normalize_dxf_codepage(),
+// convert_to_utf8_iconv(), sanitize_utf8()
+// are now provided by dxf_text_encoding.h
 
-static std::string latin1_to_utf8(const std::string& value) {
-    std::string out;
-    out.reserve(value.size() * 2);
-    for (unsigned char c : value) {
-        if (c < 0x80u) {
-            out.push_back(static_cast<char>(c));
-        } else {
-            out.push_back(static_cast<char>(0xC0u | (c >> 6)));
-            out.push_back(static_cast<char>(0x80u | (c & 0x3Fu)));
-        }
-    }
-    return out;
-}
-
-static bool all_digits(const std::string& value) {
-    if (value.empty()) return false;
-    for (char c : value) {
-        if (!std::isdigit(static_cast<unsigned char>(c))) return false;
-    }
-    return true;
-}
-
-static std::string normalize_dxf_codepage(const std::string& raw) {
-    std::string cleaned;
-    cleaned.reserve(raw.size());
-    for (char c : raw) {
-        if (std::isalnum(static_cast<unsigned char>(c))) {
-            cleaned.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
-        }
-    }
-    if (cleaned.empty()) return {};
-    if (cleaned == "UTF8" || cleaned == "UTF") return "UTF-8";
-    if (cleaned == "GBK" || cleaned == "GB2312" || cleaned == "ANSI936") return "CP936";
-    if (cleaned == "BIG5" || cleaned == "BIG5HKSCS" || cleaned == "ANSI950") return "CP950";
-    if (cleaned == "ANSI949" || cleaned == "KSC5601") return "CP949";
-    if (cleaned == "ANSI932" || cleaned == "SJIS" || cleaned == "SHIFTJIS") return "CP932";
-    if (cleaned.rfind("ANSI", 0) == 0) {
-        const std::string digits = cleaned.substr(4);
-        if (all_digits(digits)) {
-            return "CP" + digits;
-        }
-    }
-    if (cleaned.rfind("DOS", 0) == 0) {
-        const std::string digits = cleaned.substr(3);
-        if (all_digits(digits)) {
-            return "CP" + digits;
-        }
-    }
-    if (cleaned.rfind("CP", 0) == 0) {
-        const std::string digits = cleaned.substr(2);
-        if (all_digits(digits)) {
-            return "CP" + digits;
-        }
-    }
-    return {};
-}
-
-static std::string convert_to_utf8_iconv(const std::string& value, const std::string& encoding) {
-#if CADGF_HAVE_ICONV
-    if (encoding.empty()) return {};
-    iconv_t cd = iconv_open("UTF-8", encoding.c_str());
-    if (cd == reinterpret_cast<iconv_t>(-1)) return {};
-    size_t in_left = value.size();
-    size_t out_left = value.size() * 4 + 8;
-    std::string out(out_left, '\0');
-    char* in_buf = const_cast<char*>(value.data());
-    char* out_buf = out.data();
-    size_t result = iconv(cd, &in_buf, &in_left, &out_buf, &out_left);
-    iconv_close(cd);
-    if (result == static_cast<size_t>(-1)) return {};
-    out.resize(out.size() - out_left);
-    return out;
-#else
-    (void)value;
-    (void)encoding;
-    return {};
-#endif
-}
-
-static std::string sanitize_utf8(const std::string& value, const std::string& codepage) {
-    if (value.empty()) {
-        return value;
-    }
-    if (is_valid_utf8(value)) {
-        return value;
-    }
-    const std::string encoding = normalize_dxf_codepage(codepage);
-    if (!encoding.empty() && encoding != "UTF-8") {
-        const std::string converted = convert_to_utf8_iconv(value, encoding);
-        if (!converted.empty() && is_valid_utf8(converted)) {
-            return converted;
-        }
-    }
-    return latin1_to_utf8(value);
-}
-
-static unsigned int aci_to_rgb(int index) {
-    switch (index) {
-        case 1: return 0xFF0000u;
-        case 2: return 0xFFFF00u;
-        case 3: return 0x00FF00u;
-        case 4: return 0x00FFFFu;
-        case 5: return 0x0000FFu;
-        case 6: return 0xFF00FFu;
-        case 7: return 0xFFFFFFu;
-        case 8: return 0x808080u;
-        case 9: return 0xC0C0C0u;
-        default: return 0xFFFFFFu;
-    }
-}
-
-static const char* color_source_label(DxfColorSource source) {
-    switch (source) {
-        case DxfColorSource::ByLayer:
-            return "BYLAYER";
-        case DxfColorSource::ByBlock:
-            return "BYBLOCK";
-        case DxfColorSource::Index:
-            return "INDEX";
-        case DxfColorSource::TrueColor:
-            return "TRUECOLOR";
-        default:
-            return "";
-    }
-}
-
-static DxfColorMeta resolve_color_metadata(const DxfStyle& style,
-                                           const DxfStyle* layer_style,
-                                           const DxfStyle* block_style,
-                                           unsigned int* out_color,
-                                           bool* out_has_color) {
-    if (out_color) *out_color = 0;
-    if (out_has_color) *out_has_color = false;
-
-    DxfColorMeta meta{};
-    const DxfStyle* resolved = nullptr;
-    DxfColorSource source_hint = DxfColorSource::ByLayer;
-
-    if (style.has_color) {
-        resolved = &style;
-        source_hint = DxfColorSource::Index;
-    } else if (style.byblock_color && block_style && block_style->has_color) {
-        resolved = block_style;
-        source_hint = DxfColorSource::ByBlock;
-    } else if (layer_style && layer_style->has_color) {
-        resolved = layer_style;
-        source_hint = DxfColorSource::ByLayer;
-    }
-
-    if (resolved) {
-        if (out_color) *out_color = resolved->color;
-        if (out_has_color) *out_has_color = true;
-        if (resolved->color_is_true) {
-            meta.source = DxfColorSource::TrueColor;
-        } else {
-            meta.source = source_hint;
-        }
-        if (resolved->has_color_aci && !resolved->color_is_true) {
-            meta.aci = resolved->color_aci;
-            meta.has_aci = true;
-        }
-        return meta;
-    }
-
-    meta.source = DxfColorSource::ByLayer;
-    return meta;
-}
+// aci_to_rgb(), color_source_label(), resolve_color_metadata()
+// are now provided by dxf_color.h
 
 static void write_color_metadata(cadgf_document* doc, cadgf_entity_id id, const DxfColorMeta& meta) {
     if (!doc || id == 0) return;

--- a/plugins/dxf_math_utils.cpp
+++ b/plugins/dxf_math_utils.cpp
@@ -1,0 +1,86 @@
+#include "dxf_math_utils.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+// ---------- cadgf_string_view helper ----------------------------------------
+cadgf_string_view sv(const char* s) {
+    cadgf_string_view v;
+    v.data = s;
+    v.size = s ? static_cast<int32_t>(std::strlen(s)) : 0;
+    return v;
+}
+
+// ---------- numeric comparison -----------------------------------------------
+bool nearly_equal(double a, double b, double eps) {
+    return std::fabs(a - b) <= eps;
+}
+
+bool points_nearly_equal(const cadgf_vec2& a, const cadgf_vec2& b, double eps) {
+    return nearly_equal(a.x, b.x, eps) && nearly_equal(a.y, b.y, eps);
+}
+
+// ---------- parsing ----------------------------------------------------------
+bool parse_int(const std::string& s, int* out) {
+    if (!out) return false;
+    char* end = nullptr;
+    long v = std::strtol(s.c_str(), &end, 10);
+    if (!end || *end != '\0') return false;
+    *out = static_cast<int>(v);
+    return true;
+}
+
+bool parse_double(const std::string& s, double* out) {
+    if (!out) return false;
+    char* end = nullptr;
+    double v = std::strtod(s.c_str(), &end);
+    if (!end || *end != '\0') return false;
+    if (!std::isfinite(v)) return false;
+    *out = v;
+    return true;
+}
+
+// ---------- line helpers -----------------------------------------------------
+void trim_code_line(std::string* line) {
+    if (!line) return;
+    while (!line->empty()) {
+        char ch = line->back();
+        if (ch == '\r' || ch == ' ' || ch == '\t') {
+            line->pop_back();
+            continue;
+        }
+        break;
+    }
+    size_t start = 0;
+    while (start < line->size()) {
+        char ch = (*line)[start];
+        if (ch == ' ' || ch == '\t') {
+            ++start;
+            continue;
+        }
+        break;
+    }
+    if (start > 0) {
+        line->erase(0, start);
+    }
+}
+
+void strip_cr(std::string* line) {
+    if (!line || line->empty()) return;
+    if (line->back() == '\r') {
+        line->pop_back();
+    }
+}
+
+// ---------- error helper -----------------------------------------------------
+void set_error(cadgf_error_v1* err, int32_t code, const char* msg) {
+    if (!err) return;
+    err->code = code;
+    if (!msg) {
+        err->message[0] = 0;
+        return;
+    }
+    std::snprintf(err->message, sizeof(err->message), "%s", msg);
+    err->message[sizeof(err->message) - 1] = 0;
+}

--- a/plugins/dxf_math_utils.h
+++ b/plugins/dxf_math_utils.h
@@ -1,0 +1,32 @@
+#pragma once
+// DXF math/parse utilities extracted from dxf_importer_plugin.cpp.
+// Pure leaf module -- no internal project dependencies beyond the C ABI header.
+
+#include "core/plugin_abi_c_v1.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+// ---------- constants --------------------------------------------------------
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kTwoPi = kPi * 2.0;
+constexpr double kDegToRad = kPi / 180.0;
+
+// ---------- cadgf_string_view helper ----------------------------------------
+cadgf_string_view sv(const char* s);
+
+// ---------- numeric comparison -----------------------------------------------
+bool nearly_equal(double a, double b, double eps = 1e-6);
+bool points_nearly_equal(const cadgf_vec2& a, const cadgf_vec2& b, double eps = 1e-6);
+
+// ---------- parsing ----------------------------------------------------------
+bool parse_int(const std::string& s, int* out);
+bool parse_double(const std::string& s, double* out);
+
+// ---------- line helpers -----------------------------------------------------
+void trim_code_line(std::string* line);
+void strip_cr(std::string* line);
+
+// ---------- error helper -----------------------------------------------------
+void set_error(cadgf_error_v1* err, int32_t code, const char* msg);

--- a/plugins/dxf_text_encoding.cpp
+++ b/plugins/dxf_text_encoding.cpp
@@ -1,0 +1,159 @@
+#include "dxf_text_encoding.h"
+
+#include <cctype>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <iconv.h>
+#define CADGF_HAVE_ICONV 1
+#else
+#define CADGF_HAVE_ICONV 0
+#endif
+
+// ---------- internal helpers (file-scope only) --------------------------------
+namespace {
+
+bool all_digits(const std::string& value) {
+    if (value.empty()) return false;
+    for (char c : value) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) return false;
+    }
+    return true;
+}
+
+} // anonymous namespace
+
+// ---------- public API -------------------------------------------------------
+
+bool is_valid_utf8(const std::string& value) {
+    const unsigned char* data = reinterpret_cast<const unsigned char*>(value.data());
+    size_t i = 0;
+    while (i < value.size()) {
+        unsigned char c = data[i];
+        if (c <= 0x7Fu) {
+            ++i;
+            continue;
+        }
+        if ((c >> 5) == 0x6) {
+            if (i + 1 >= value.size()) return false;
+            unsigned char c1 = data[i + 1];
+            if ((c1 & 0xC0u) != 0x80u) return false;
+            if (c < 0xC2u) return false;
+            i += 2;
+            continue;
+        }
+        if ((c >> 4) == 0xE) {
+            if (i + 2 >= value.size()) return false;
+            unsigned char c1 = data[i + 1];
+            unsigned char c2 = data[i + 2];
+            if ((c1 & 0xC0u) != 0x80u || (c2 & 0xC0u) != 0x80u) return false;
+            if (c == 0xE0u && c1 < 0xA0u) return false;
+            if (c == 0xEDu && c1 >= 0xA0u) return false;
+            i += 3;
+            continue;
+        }
+        if ((c >> 3) == 0x1E) {
+            if (i + 3 >= value.size()) return false;
+            unsigned char c1 = data[i + 1];
+            unsigned char c2 = data[i + 2];
+            unsigned char c3 = data[i + 3];
+            if ((c1 & 0xC0u) != 0x80u || (c2 & 0xC0u) != 0x80u || (c3 & 0xC0u) != 0x80u) return false;
+            if (c == 0xF0u && c1 < 0x90u) return false;
+            if (c == 0xF4u && c1 > 0x8Fu) return false;
+            if (c > 0xF4u) return false;
+            i += 4;
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+std::string latin1_to_utf8(const std::string& value) {
+    std::string out;
+    out.reserve(value.size() * 2);
+    for (unsigned char c : value) {
+        if (c < 0x80u) {
+            out.push_back(static_cast<char>(c));
+        } else {
+            out.push_back(static_cast<char>(0xC0u | (c >> 6)));
+            out.push_back(static_cast<char>(0x80u | (c & 0x3Fu)));
+        }
+    }
+    return out;
+}
+
+std::string normalize_dxf_codepage(const std::string& raw) {
+    std::string cleaned;
+    cleaned.reserve(raw.size());
+    for (char c : raw) {
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            cleaned.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+        }
+    }
+    if (cleaned.empty()) return {};
+    if (cleaned == "UTF8" || cleaned == "UTF") return "UTF-8";
+    if (cleaned == "GBK" || cleaned == "GB2312" || cleaned == "ANSI936") return "CP936";
+    if (cleaned == "BIG5" || cleaned == "BIG5HKSCS" || cleaned == "ANSI950") return "CP950";
+    if (cleaned == "ANSI949" || cleaned == "KSC5601") return "CP949";
+    if (cleaned == "ANSI932" || cleaned == "SJIS" || cleaned == "SHIFTJIS") return "CP932";
+    if (cleaned.rfind("ANSI", 0) == 0) {
+        const std::string digits = cleaned.substr(4);
+        if (all_digits(digits)) {
+            return "CP" + digits;
+        }
+    }
+    if (cleaned.rfind("DOS", 0) == 0) {
+        const std::string digits = cleaned.substr(3);
+        if (all_digits(digits)) {
+            return "CP" + digits;
+        }
+    }
+    if (cleaned.rfind("CP", 0) == 0) {
+        const std::string digits = cleaned.substr(2);
+        if (all_digits(digits)) {
+            return "CP" + digits;
+        }
+    }
+    return {};
+}
+
+std::string convert_to_utf8_iconv(const std::string& value,
+                                  const std::string& encoding) {
+#if CADGF_HAVE_ICONV
+    if (encoding.empty()) return {};
+    iconv_t cd = iconv_open("UTF-8", encoding.c_str());
+    if (cd == reinterpret_cast<iconv_t>(-1)) return {};
+    size_t in_left = value.size();
+    size_t out_left = value.size() * 4 + 8;
+    std::string out(out_left, '\0');
+    char* in_buf = const_cast<char*>(value.data());
+    char* out_buf = out.data();
+    size_t result = iconv(cd, &in_buf, &in_left, &out_buf, &out_left);
+    iconv_close(cd);
+    if (result == static_cast<size_t>(-1)) return {};
+    out.resize(out.size() - out_left);
+    return out;
+#else
+    (void)value;
+    (void)encoding;
+    return {};
+#endif
+}
+
+std::string sanitize_utf8(const std::string& value,
+                          const std::string& codepage) {
+    if (value.empty()) {
+        return value;
+    }
+    if (is_valid_utf8(value)) {
+        return value;
+    }
+    const std::string encoding = normalize_dxf_codepage(codepage);
+    if (!encoding.empty() && encoding != "UTF-8") {
+        const std::string converted = convert_to_utf8_iconv(value, encoding);
+        if (!converted.empty() && is_valid_utf8(converted)) {
+            return converted;
+        }
+    }
+    return latin1_to_utf8(value);
+}

--- a/plugins/dxf_text_encoding.h
+++ b/plugins/dxf_text_encoding.h
@@ -1,0 +1,26 @@
+#pragma once
+// DXF text/encoding utilities extracted from dxf_importer_plugin.cpp.
+// Pure string functions with zero internal dependencies.
+
+#include <string>
+
+// Validate that a byte sequence is well-formed UTF-8.
+bool is_valid_utf8(const std::string& value);
+
+// Convert Latin-1 (ISO 8859-1) bytes to UTF-8.
+std::string latin1_to_utf8(const std::string& value);
+
+// Normalize a DXF $DWGCODEPAGE value to an iconv-compatible encoding name
+// (e.g. "ANSI_1252" -> "CP1252", "UTF8" -> "UTF-8").
+// Returns empty string if the codepage cannot be mapped.
+std::string normalize_dxf_codepage(const std::string& raw);
+
+// Attempt iconv-based conversion.  Returns empty string on failure or when
+// iconv is unavailable (Windows).
+std::string convert_to_utf8_iconv(const std::string& value,
+                                  const std::string& encoding);
+
+// High-level: ensure `value` is valid UTF-8.  Tries iconv with the given
+// codepage first; falls back to latin1_to_utf8 if that fails.
+std::string sanitize_utf8(const std::string& value,
+                          const std::string& codepage);

--- a/plugins/dxf_types.h
+++ b/plugins/dxf_types.h
@@ -1,0 +1,41 @@
+#pragma once
+// Minimal DXF types shared across extracted leaf modules.
+// Only the types needed by dxf_color, dxf_text_encoding, and dxf_math_utils
+// live here.  Everything else stays in dxf_importer_plugin.cpp until a later
+// extraction batch.
+
+#include <string>
+
+// ---------- DxfStyle ----------------------------------------------------------
+struct DxfStyle {
+    std::string line_type;
+    double line_weight = 0.0;
+    double line_type_scale = 0.0;
+    bool has_line_type = false;
+    bool has_line_weight = false;
+    bool has_line_scale = false;
+    bool byblock_line_type = false;
+    bool byblock_line_weight = false;
+    unsigned int color = 0;
+    bool has_color = false;
+    int color_aci = 0;
+    bool has_color_aci = false;
+    bool color_is_true = false;
+    bool byblock_color = false;
+    bool hidden = false;
+};
+
+// ---------- DxfColorSource / DxfColorMeta ------------------------------------
+enum class DxfColorSource {
+    None,
+    ByLayer,
+    ByBlock,
+    Index,
+    TrueColor
+};
+
+struct DxfColorMeta {
+    DxfColorSource source{DxfColorSource::None};
+    int aci{0};
+    bool has_aci{false};
+};


### PR DESCRIPTION
## Summary
- extract the first DXF importer leaf modules from `plugins/dxf_importer_plugin.cpp`
- add `dxf_types`, `dxf_text_encoding`, `dxf_color`, and `dxf_math_utils`
- update `plugins/CMakeLists.txt` and document packet boundaries

## Scope
- leaf-module extraction only
- no parser extraction
- no document committer extraction
- no plugin ABI changes

## Verification
- built `cadgf_dxf_importer_plugin`, `convert_cli`, and DXF/DWG test executables in a clean worktree build
- reproduced clean-baseline limitations from `origin/main`
- runnable `dxf|dwg` subset passed `22/26` after excluding known baseline blockers
- `git diff --check`

## Baseline Note
Known clean-baseline blockers already present on `origin/main` and reproduced independently:
- `test_dxf_leader_metadata_run` compile break against `core_c_api.h`
- `convert_cli_dxf_style_smoke` missing `cmake/RunConvertCliDxfLineStyle.cmake`
- runtime failures in:
  - `test_dxf_multi_layout_metadata_run`
  - `test_dxf_paperspace_insert_styles_run`
  - `test_dxf_paperspace_insert_dimension_run`
  - `test_dxf_paperspace_combo_run`
