### PR TITLE
refactor: extract dxf parser helpers

### DIFF
--- a/docs/DXF_B3A_PARSER_HELPERS_DESIGN.md
+++ b/docs/DXF_B3A_PARSER_HELPERS_DESIGN.md
@@ -1,0 +1,111 @@
+## Scope
+
+Implement the first parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only reusable parser helpers. It does **not** extract the
+main `parse_dxf_entities(...)` state machine.
+
+## Goal
+
+Reduce the amount of low-level parsing utility code embedded inside
+`dxf_importer_plugin.cpp` by moving shared parser helpers into a dedicated leaf
+module:
+
+- `plugins/dxf_parser_helpers.h`
+- `plugins/dxf_parser_helpers.cpp`
+
+## Included
+
+Extract only these helpers:
+
+- `parse_entity_space(...)`
+- `parse_entity_owner(...)`
+- any tiny helper state or parameter plumbing needed to support them cleanly
+
+And re-home the existing low-level parsing utility includes/usage so the parser
+state machine can consume them through the new helper header.
+
+If useful, the new helper module may also wrap the already shared low-level
+utilities from `dxf_math_utils.h`:
+
+- `parse_int(...)`
+- `parse_double(...)`
+- `trim_code_line(...)`
+- `strip_cr(...)`
+
+But this packet must stay a **thin parser-helper extraction**, not a parser
+rewrite.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- `parse_dxf_entities(...)`
+- entity-kind switch/state-machine logic
+- block/layout finalization
+- parser object model structs
+- insert handler extraction
+- hatch pattern extraction
+- document committer code
+- final plugin-shell slimming
+
+Do **not** change:
+
+- plugin ABI
+- DXF behavior
+- entity ordering
+- text/style/layout semantics
+- error reporting semantics
+
+## Design Constraints
+
+### 1. Keep the state machine in place
+
+`parse_dxf_entities(...)` should remain in `dxf_importer_plugin.cpp`.
+
+The new helper module should only reduce local clutter by moving repeatable
+entity-level parse helpers out of the monolith.
+
+### 2. Keep helper dependencies narrow
+
+The new parser-helper module should depend only on:
+
+- `dxf_types.h`
+- `dxf_math_utils.h`
+- standard headers as needed
+
+Avoid introducing new dependencies back into higher-level DXF modules.
+
+### 3. Preserve current call shape
+
+The call sites inside the parser switch should stay straightforward. Prefer a
+drop-in helper API so the packet remains reviewable and behavior-neutral.
+
+### 4. Preserve paperspace detection behavior
+
+`parse_entity_space(...)` currently influences `has_paperspace`. Keep that exact
+behavior unchanged.
+
+### 5. Preserve owner-handle semantics
+
+`parse_entity_owner(...)` must preserve:
+
+- group code `330`
+- empty/non-empty owner handling
+- `has_owner_handle` updates
+
+## Expected Files
+
+- `plugins/dxf_parser_helpers.h`
+- `plugins/dxf_parser_helpers.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- narrow helper-only extraction
+- no parser state-machine movement
+- no dependency cycle
+- no behavior drift in `space` / `owner` parsing

--- a/docs/DXF_B3A_PARSER_HELPERS_VERIFICATION.md
+++ b/docs/DXF_B3A_PARSER_HELPERS_VERIFICATION.md
@@ -1,0 +1,50 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets as in the previous DXF packets, excluding
+the known baseline-blocked `test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to recent DXF packets
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- parser state-machine extraction
+- committer extraction
+- insert handler extraction
+- hatch pattern extraction
+- final plugin-shell slimming

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(cadgf_sample_plugin PROPERTIES
 # DXF importer plugin (lite)
 add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
+    dxf_parser_helpers.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -4,6 +4,7 @@
 #include "dxf_metadata_writer.h"
 #include "dxf_style.h"
 #include "dxf_math_utils.h"
+#include "dxf_parser_helpers.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1553,23 +1554,6 @@ static bool parse_dxf_entities(const std::string& path,
         blocks[block.name] = block;
     };
 
-    auto parse_entity_space = [&](int code, const std::string& value, int* space_out) -> bool {
-        if (code != 67 || !space_out) return false;
-        int space = 0;
-        if (parse_int(value, &space)) {
-            *space_out = space;
-            if (space == 1) has_paperspace = true;
-        }
-        return true;
-    };
-    auto parse_entity_owner = [&](int code, const std::string& value,
-                                  std::string* owner_out, bool* has_owner_out) -> bool {
-        if (code != 330 || !owner_out || !has_owner_out) return false;
-        *owner_out = value;
-        *has_owner_out = !owner_out->empty();
-        return true;
-    };
-
     while (std::getline(in, code_line)) {
         if (!std::getline(in, value_line)) break;
         trim_code_line(&code_line);
@@ -2033,7 +2017,7 @@ static bool parse_dxf_entities(const std::string& path,
 
         switch (current_kind) {
             case DxfEntityKind::Polyline:
-                if (parse_entity_space(code, value_line, &current_polyline.space)) break;
+                if (parse_entity_space(code, value_line, &current_polyline.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_polyline.owner_handle,
                                        &current_polyline.has_owner_handle)) break;
                 if (parse_style_code(&current_polyline.style, code, value_line, header_codepage)) break;
@@ -2070,7 +2054,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Line:
-                if (parse_entity_space(code, value_line, &current_line.space)) break;
+                if (parse_entity_space(code, value_line, &current_line.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_line.owner_handle,
                                        &current_line.has_owner_handle)) break;
                 if (parse_style_code(&current_line.style, code, value_line, header_codepage)) break;
@@ -2103,7 +2087,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Point:
-                if (parse_entity_space(code, value_line, &current_point.space)) break;
+                if (parse_entity_space(code, value_line, &current_point.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_point.owner_handle,
                                        &current_point.has_owner_handle)) break;
                 if (parse_style_code(&current_point.style, code, value_line, header_codepage)) break;
@@ -2126,7 +2110,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Circle:
-                if (parse_entity_space(code, value_line, &current_circle.space)) break;
+                if (parse_entity_space(code, value_line, &current_circle.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_circle.owner_handle,
                                        &current_circle.has_owner_handle)) break;
                 if (parse_style_code(&current_circle.style, code, value_line, header_codepage)) break;
@@ -2154,7 +2138,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Arc:
-                if (parse_entity_space(code, value_line, &current_arc.space)) break;
+                if (parse_entity_space(code, value_line, &current_arc.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_arc.owner_handle,
                                        &current_arc.has_owner_handle)) break;
                 if (parse_style_code(&current_arc.style, code, value_line, header_codepage)) break;
@@ -2192,7 +2176,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Ellipse:
-                if (parse_entity_space(code, value_line, &current_ellipse.space)) break;
+                if (parse_entity_space(code, value_line, &current_ellipse.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_ellipse.owner_handle,
                                        &current_ellipse.has_owner_handle)) break;
                 if (parse_style_code(&current_ellipse.style, code, value_line, header_codepage)) break;
@@ -2240,7 +2224,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Spline:
-                if (parse_entity_space(code, value_line, &current_spline.space)) break;
+                if (parse_entity_space(code, value_line, &current_spline.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_spline.owner_handle,
                                        &current_spline.has_owner_handle)) break;
                 if (parse_style_code(&current_spline.style, code, value_line, header_codepage)) break;
@@ -2284,7 +2268,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Text:
-                if (parse_entity_space(code, value_line, &current_text.space)) break;
+                if (parse_entity_space(code, value_line, &current_text.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_text.owner_handle,
                                        &current_text.has_owner_handle)) break;
                 if (parse_style_code(&current_text.style, code, value_line, header_codepage)) break;
@@ -2409,7 +2393,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Solid:
-                if (parse_entity_space(code, value_line, &current_solid.space)) break;
+                if (parse_entity_space(code, value_line, &current_solid.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_solid.owner_handle,
                                        &current_solid.has_owner_handle)) break;
                 if (parse_style_code(&current_solid.style, code, value_line, header_codepage)) break;
@@ -2462,7 +2446,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Hatch:
-                if (parse_entity_space(code, value_line, &current_hatch.space)) break;
+                if (parse_entity_space(code, value_line, &current_hatch.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_hatch.owner_handle,
                                        &current_hatch.has_owner_handle)) break;
                 if (parse_style_code(&current_hatch.style, code, value_line, header_codepage)) break;
@@ -2768,7 +2752,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Insert:
-                if (parse_entity_space(code, value_line, &current_insert.space)) break;
+                if (parse_entity_space(code, value_line, &current_insert.space, &has_paperspace)) break;
                 if (parse_entity_owner(code, value_line, &current_insert.owner_handle,
                                        &current_insert.has_owner_handle)) break;
                 if (parse_style_code(&current_insert.style, code, value_line, header_codepage)) break;
@@ -2877,7 +2861,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Viewport:
-                if (parse_entity_space(code, value_line, &current_viewport.space)) break;
+                if (parse_entity_space(code, value_line, &current_viewport.space, &has_paperspace)) break;
                 switch (code) {
                     case 330:
                         current_viewport.owner_handle = value_line;

--- a/plugins/dxf_parser_helpers.cpp
+++ b/plugins/dxf_parser_helpers.cpp
@@ -1,0 +1,20 @@
+#include "dxf_parser_helpers.h"
+
+bool parse_entity_space(int code, const std::string& value, int* space_out,
+                        bool* has_paperspace_out) {
+    if (code != 67 || !space_out) return false;
+    int space = 0;
+    if (parse_int(value, &space)) {
+        *space_out = space;
+        if (space == 1 && has_paperspace_out) *has_paperspace_out = true;
+    }
+    return true;
+}
+
+bool parse_entity_owner(int code, const std::string& value, std::string* owner_out,
+                        bool* has_owner_out) {
+    if (code != 330 || !owner_out || !has_owner_out) return false;
+    *owner_out = value;
+    *has_owner_out = !owner_out->empty();
+    return true;
+}

--- a/plugins/dxf_parser_helpers.h
+++ b/plugins/dxf_parser_helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+// DXF parser helper utilities extracted from dxf_importer_plugin.cpp.
+// Leaf module -- depends only on dxf_math_utils.h and standard headers.
+
+#include "dxf_math_utils.h"
+
+#include <string>
+
+// Returns true if group code 67 was handled (entity space field).
+// Updates *space_out and sets *has_paperspace_out to true when space == 1.
+bool parse_entity_space(int code, const std::string& value, int* space_out,
+                        bool* has_paperspace_out);
+
+// Returns true if group code 330 was handled (owner handle field).
+// Updates *owner_out and *has_owner_out.
+bool parse_entity_owner(int code, const std::string& value, std::string* owner_out,
+                        bool* has_owner_out);


### PR DESCRIPTION
## Summary
- extract the first parser-helper seam from the DXF importer
- move entity-level `space` / `owner` parser helpers into a dedicated leaf module
- keep the main `parse_dxf_entities(...)` state machine in place

## Included
- `plugins/dxf_parser_helpers.{h,cpp}`
- `plugins/dxf_importer_plugin.cpp` call-site rewiring
- `plugins/CMakeLists.txt` source registration
- packet docs for B3a

## Not Included
- parser state-machine extraction
- document committer extraction
- insert handler extraction
- hatch pattern extraction
- final plugin-shell slimming

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- built runnable DXF/DWG test targets excluding known baseline-blocked `test_dxf_leader_metadata`
- `cd build-codex && ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- result: `22/22` passed in the runnable subset
- `git diff --check`

## Claude Scope In This Packet
Claude was constrained to the narrow B3a seam only:
- extract `parse_entity_space(...)`
- extract `parse_entity_owner(...)`
- update `plugins/CMakeLists.txt`
- rewire `plugins/dxf_importer_plugin.cpp`

The parser main switch/state machine was intentionally left in the monolith.
