### PR TITLE
refactor: extract dxf zero-record transitions

### DIFF
--- a/docs/DXF_B3B_ZERO_RECORD_TRANSITIONS_DESIGN.md
+++ b/docs/DXF_B3B_ZERO_RECORD_TRANSITIONS_DESIGN.md
@@ -1,0 +1,151 @@
+## Scope
+
+Implement the second parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only the `code == 0` transition logic from
+`parse_dxf_entities(...)`. It does **not** extract the full parser state
+machine.
+
+## Goal
+
+Reduce the amount of zero-record transition branching embedded inside
+`parse_dxf_entities(...)` by moving that logic into a narrow helper module:
+
+- `plugins/dxf_parser_zero_record.h`
+- `plugins/dxf_parser_zero_record.cpp`
+
+## Included
+
+Extract only the `code == 0` transition handling for:
+
+- section open/close transitions:
+  - `SECTION`
+  - `ENDSEC`
+  - `TABLE`
+  - `ENDTAB`
+- table-record transitions:
+  - `LAYER`
+  - `STYLE`
+  - `VPORT`
+- block/layout transitions:
+  - `BLOCK`
+  - `ENDBLK`
+  - `LAYOUT`
+- entity-activation transitions:
+  - `SEQEND`
+  - `ATTRIB`
+  - top-level entity kind selection for
+    - `INSERT`
+    - `LWPOLYLINE`
+    - `LINE`
+    - `POINT`
+    - `CIRCLE`
+    - `ARC`
+    - `ELLIPSE`
+    - `SPLINE`
+    - `SOLID`
+    - `HATCH`
+    - `TEXT`
+    - `MTEXT`
+    - `DIMENSION`
+    - `LEADER`
+    - `VIEWPORT`
+    - `POLYLINE`
+    - `VERTEX`
+    - `ATTDEF`
+    - `ATTRIB`
+
+The helper may introduce a narrow parser-transition context struct if needed,
+but the packet must remain a zero-record extraction, not a parser rewrite.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- `parse_dxf_entities(...)`
+- non-zero group-code field parsing
+- entity property decoding
+- block/layout finalization internals
+- committer code
+- insert handler extraction
+- hatch pattern extraction
+- plugin ABI
+
+Do **not** change:
+
+- entity ordering
+- section/table semantics
+- block/header semantics
+- active insert attribute owner semantics
+- `entities_parsed` counting
+- error reporting semantics
+
+## Design Constraints
+
+### 1. Keep the parser loop in place
+
+`parse_dxf_entities(...)` must remain in `dxf_importer_plugin.cpp`.
+
+The new helper should only absorb the zero-record transition branch and return
+enough information for the loop to continue with the existing non-zero parsing
+logic.
+
+### 2. Keep dependencies narrow
+
+The new zero-record helper module may depend on:
+
+- `dxf_types.h`
+- `dxf_parser_helpers.h`
+- standard headers as needed
+
+Avoid new dependencies into committer or higher-level DXF modules.
+
+### 3. Preserve flush/finalize behavior exactly
+
+The existing zero-record path currently coordinates:
+
+- `flush_current()`
+- old-style polyline sequence handling
+- table-record finalize/reset
+- block finalize/reset
+- layout finalize/reset
+
+That behavior must remain byte-for-byte equivalent at the call level.
+
+### 4. Preserve entity-kind activation behavior
+
+The packet must preserve:
+
+- `current_kind` transitions
+- `has_last_top_level_insert`
+- `has_active_insert_attribute_owner`
+- `active_insert_attribute_owner`
+- `import_stats->entities_parsed`
+
+### 5. Prefer reviewable helper boundaries
+
+If one helper becomes too wide, split it into two or three narrow helpers such
+as:
+
+- section/table transitions
+- block/layout transitions
+- entity-kind transitions
+
+But do not move unrelated parser code in this packet.
+
+## Expected Files
+
+- `plugins/dxf_parser_zero_record.h`
+- `plugins/dxf_parser_zero_record.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- zero-record branch only
+- no parser state-machine rewrite
+- no new dependency cycle
+- preserved finalize/reset semantics
+- preserved entity-kind activation semantics

--- a/docs/DXF_B3B_ZERO_RECORD_TRANSITIONS_VERIFICATION.md
+++ b/docs/DXF_B3B_ZERO_RECORD_TRANSITIONS_VERIFICATION.md
@@ -1,0 +1,51 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets, excluding the known baseline-blocked
+`test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to B3a
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- non-zero entity field parsing changes
+- parser full state-machine extraction
+- committer extraction
+- insert handler extraction
+- hatch pattern extraction
+- final plugin-shell slimming

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(cadgf_sample_plugin PROPERTIES
 add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
     dxf_parser_helpers.cpp
+    dxf_parser_zero_record.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -5,6 +5,7 @@
 #include "dxf_style.h"
 #include "dxf_math_utils.h"
 #include "dxf_parser_helpers.h"
+#include "dxf_parser_zero_record.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1089,38 +1090,6 @@ static void finalize_insert(DxfInsert& insert, std::vector<DxfInsert>& out) {
     out.push_back(insert);
 }
 
-enum class DxfEntityKind {
-    None,
-    Polyline,
-    Line,
-    Point,
-    Circle,
-    Arc,
-    Ellipse,
-    Spline,
-    Text,
-    Solid,
-    Hatch,
-    Insert,
-    Viewport
-};
-
-enum class DxfSection {
-    None,
-    Header,
-    Tables,
-    Blocks,
-    Entities,
-    Objects
-};
-
-struct DxfImportStats {
-    int entities_parsed = 0;
-    int entities_imported = 0;
-    int entities_skipped = 0;
-    std::unordered_map<std::string, int> unsupported_types;
-    std::vector<std::string> warnings;
-};
 
 static bool parse_dxf_entities(const std::string& path,
                                std::vector<DxfPolyline>& polylines,
@@ -1554,6 +1523,64 @@ static bool parse_dxf_entities(const std::string& path,
         blocks[block.name] = block;
     };
 
+    DxfZeroRecordContext zero_ctx{};
+    zero_ctx.current_kind = &current_kind;
+    zero_ctx.current_section = &current_section;
+    zero_ctx.current_table = &current_table;
+    zero_ctx.in_old_style_polyline = &in_old_style_polyline;
+    zero_ctx.expect_section_name = &expect_section_name;
+    zero_ctx.expect_table_name = &expect_table_name;
+    zero_ctx.in_layer_table = &in_layer_table;
+    zero_ctx.in_layer_record = &in_layer_record;
+    zero_ctx.in_style_table = &in_style_table;
+    zero_ctx.in_style_record = &in_style_record;
+    zero_ctx.in_vport_table = &in_vport_table;
+    zero_ctx.in_vport_record = &in_vport_record;
+    zero_ctx.in_block = &in_block;
+    zero_ctx.in_block_header = &in_block_header;
+    zero_ctx.in_layout_object = &in_layout_object;
+    zero_ctx.has_active_insert_attribute_owner = &has_active_insert_attribute_owner;
+    zero_ctx.has_last_top_level_insert = &has_last_top_level_insert;
+    zero_ctx.active_insert_attribute_owner = &active_insert_attribute_owner;
+    zero_ctx.last_top_level_insert = &last_top_level_insert;
+    zero_ctx.next_insert_attribute_group_tag = &next_insert_attribute_group_tag;
+    zero_ctx.next_hatch_id = &next_hatch_id;
+    zero_ctx.current_text = &current_text;
+    zero_ctx.current_insert = &current_insert;
+    zero_ctx.current_polyline_origin_meta = &current_polyline.origin_meta;
+    zero_ctx.current_hatch_hatch_id = &current_hatch.hatch_id;
+    zero_ctx.import_stats = import_stats;
+    zero_ctx.inserts = &inserts;
+    zero_ctx.flush_current = flush_current;
+    zero_ctx.finalize_layout = finalize_layout;
+    zero_ctx.reset_layout = reset_layout;
+    zero_ctx.finalize_layer = [&]() { finalize_layer(current_layer); };
+    zero_ctx.reset_layer = reset_layer;
+    zero_ctx.finalize_text_style = [&]() { finalize_text_style(current_text_style); };
+    zero_ctx.reset_text_style = reset_text_style;
+    zero_ctx.finalize_vport = [&]() { finalize_vport(current_vport); };
+    zero_ctx.reset_vport = reset_vport;
+    zero_ctx.finalize_block = [&]() { finalize_block(current_block); };
+    zero_ctx.reset_block = reset_block;
+    zero_ctx.reset_polyline = reset_polyline;
+    zero_ctx.reset_line = reset_line;
+    zero_ctx.reset_point = reset_point;
+    zero_ctx.reset_circle = reset_circle;
+    zero_ctx.reset_arc = reset_arc;
+    zero_ctx.reset_ellipse = reset_ellipse;
+    zero_ctx.reset_spline = reset_spline;
+    zero_ctx.reset_text = reset_text;
+    zero_ctx.reset_solid = reset_solid;
+    zero_ctx.reset_hatch = reset_hatch;
+    zero_ctx.reset_insert = reset_insert;
+    zero_ctx.reset_viewport = reset_viewport;
+    zero_ctx.build_insert_origin_metadata = [](const DxfInsert& ins) {
+        return build_insert_origin_metadata(ins);
+    };
+    zero_ctx.build_leader_origin_metadata = []() {
+        return build_leader_origin_metadata();
+    };
+
     while (std::getline(in, code_line)) {
         if (!std::getline(in, value_line)) break;
         trim_code_line(&code_line);
@@ -1563,257 +1590,7 @@ static bool parse_dxf_entities(const std::string& path,
         if (!parse_int(code_line, &code)) continue;
 
         if (code == 0) {
-            if (in_layout_object) {
-                finalize_layout();
-                reset_layout();
-                in_layout_object = false;
-            }
-            // Skip flush for VERTEX within old-style POLYLINE sequence
-            if (in_old_style_polyline && value_line == "VERTEX") {
-                // Don't flush — VERTEX coords will be added to current_polyline
-            } else {
-                if (in_old_style_polyline && value_line != "VERTEX") {
-                    in_old_style_polyline = false; // sequence ended
-                }
-                flush_current();
-            }
-            if (value_line == "SECTION") {
-                expect_section_name = true;
-                continue;
-            }
-            if (value_line == "ENDSEC") {
-                if (in_layer_table && in_layer_record) {
-                    finalize_layer(current_layer);
-                    reset_layer();
-                    in_layer_record = false;
-                }
-                if (in_style_table && in_style_record) {
-                    finalize_text_style(current_text_style);
-                    reset_text_style();
-                    in_style_record = false;
-                }
-                if (in_vport_table && in_vport_record) {
-                    finalize_vport(current_vport);
-                    reset_vport();
-                    in_vport_record = false;
-                }
-                if (in_layout_object) {
-                    finalize_layout();
-                    reset_layout();
-                    in_layout_object = false;
-                }
-                if (in_block) {
-                    finalize_block(current_block);
-                    reset_block();
-                    in_block = false;
-                    in_block_header = false;
-                }
-                in_layer_table = false;
-                in_style_table = false;
-                in_vport_table = false;
-                in_layout_object = false;
-                current_table.clear();
-                current_section = DxfSection::None;
-                continue;
-            }
-            if (value_line == "TABLE" && current_section == DxfSection::Tables) {
-                expect_table_name = true;
-                continue;
-            }
-            if (value_line == "ENDTAB") {
-                if (in_layer_table && in_layer_record) {
-                    finalize_layer(current_layer);
-                    reset_layer();
-                    in_layer_record = false;
-                }
-                if (in_style_table && in_style_record) {
-                    finalize_text_style(current_text_style);
-                    reset_text_style();
-                    in_style_record = false;
-                }
-                if (in_vport_table && in_vport_record) {
-                    finalize_vport(current_vport);
-                    reset_vport();
-                    in_vport_record = false;
-                }
-                in_layer_table = false;
-                in_style_table = false;
-                in_vport_table = false;
-                current_table.clear();
-                continue;
-            }
-            if (in_layer_table && value_line == "LAYER") {
-                if (in_layer_record) {
-                    finalize_layer(current_layer);
-                    reset_layer();
-                }
-                in_layer_record = true;
-                continue;
-            }
-            if (in_style_table && value_line == "STYLE") {
-                if (in_style_record) {
-                    finalize_text_style(current_text_style);
-                    reset_text_style();
-                }
-                in_style_record = true;
-                continue;
-            }
-            if (in_vport_table && value_line == "VPORT") {
-                if (in_vport_record) {
-                    finalize_vport(current_vport);
-                    reset_vport();
-                }
-                reset_vport();
-                in_vport_record = true;
-                continue;
-            }
-            if (value_line == "BLOCK" && current_section == DxfSection::Blocks) {
-                if (in_block) {
-                    finalize_block(current_block);
-                }
-                reset_block();
-                in_block = true;
-                in_block_header = true;
-                continue;
-            }
-            if (value_line == "ENDBLK") {
-                if (in_block) {
-                    finalize_block(current_block);
-                    reset_block();
-                    in_block = false;
-                }
-                in_block_header = false;
-                continue;
-            }
-            if (in_block && in_block_header) {
-                in_block_header = false;
-            }
-            if (value_line == "LAYOUT" && current_section == DxfSection::Objects) {
-                reset_layout();
-                in_layout_object = true;
-                continue;
-            }
-            const bool in_entities = current_section == DxfSection::Entities;
-            const bool in_block_entities = current_section == DxfSection::Blocks && in_block && !in_block_header;
-            if (!in_entities && !in_block_entities) {
-                current_kind = DxfEntityKind::None;
-                continue;
-            }
-            if (value_line == "SEQEND" && in_entities) {
-                has_active_insert_attribute_owner = false;
-                has_last_top_level_insert = false;
-                current_kind = DxfEntityKind::None;
-                continue;
-            }
-            if (value_line == "ATTRIB" && in_entities) {
-                if (has_last_top_level_insert) {
-                    if (!inserts.empty()) {
-                        ensure_insert_attribute_group_tag(&inserts.back());
-                        active_insert_attribute_owner = inserts.back();
-                    } else {
-                        ensure_insert_attribute_group_tag(&last_top_level_insert);
-                        active_insert_attribute_owner = last_top_level_insert;
-                    }
-                    has_active_insert_attribute_owner = true;
-                }
-            } else {
-                has_active_insert_attribute_owner = false;
-            }
-            has_last_top_level_insert = false;
-            import_stats->entities_parsed++;
-            if (value_line == "INSERT" && (in_entities || in_block_entities)) {
-                current_kind = DxfEntityKind::Insert;
-                reset_insert();
-            } else if (value_line == "LWPOLYLINE") {
-                current_kind = DxfEntityKind::Polyline;
-                reset_polyline();
-            } else if (value_line == "LINE") {
-                current_kind = DxfEntityKind::Line;
-                reset_line();
-            } else if (value_line == "POINT") {
-                current_kind = DxfEntityKind::Point;
-                reset_point();
-            } else if (value_line == "CIRCLE") {
-                current_kind = DxfEntityKind::Circle;
-                reset_circle();
-            } else if (value_line == "ARC") {
-                current_kind = DxfEntityKind::Arc;
-                reset_arc();
-            } else if (value_line == "ELLIPSE") {
-                current_kind = DxfEntityKind::Ellipse;
-                reset_ellipse();
-            } else if (value_line == "SPLINE") {
-                current_kind = DxfEntityKind::Spline;
-                reset_spline();
-            } else if (value_line == "SOLID") {
-                current_kind = DxfEntityKind::Solid;
-                reset_solid();
-            } else if (value_line == "HATCH") {
-                current_kind = DxfEntityKind::Hatch;
-                reset_hatch();
-                current_hatch.hatch_id = next_hatch_id++;
-            } else if (value_line == "TEXT" || value_line == "MTEXT" || value_line == "ATTRIB" || value_line == "ATTDEF") {
-                current_kind = DxfEntityKind::Text;
-                reset_text();
-                if (value_line == "MTEXT") {
-                    current_text.allow_extended_text = true;
-                    current_text.is_mtext = true;
-                    current_text.kind = "mtext";
-                } else if (value_line == "ATTRIB") {
-                    current_text.kind = "attrib";
-                    if (has_active_insert_attribute_owner) {
-                        current_text.origin_meta = build_insert_origin_metadata(active_insert_attribute_owner);
-                        current_text.local_group_tag = active_insert_attribute_owner.local_group_tag;
-                    }
-                } else if (value_line == "ATTDEF") {
-                    current_text.kind = "attdef";
-                } else {
-                    current_text.kind = "text";
-                }
-            } else if (value_line == "LEADER" || value_line == "MLEADER") {
-                if (value_line == "MLEADER") {
-                    current_kind = DxfEntityKind::Text;
-                    reset_text();
-                    current_text.allow_extended_text = true;
-                    current_text.is_mtext = true;
-                    current_text.kind = "mleader";
-                } else {
-                    current_kind = DxfEntityKind::Polyline;
-                    reset_polyline();
-                    current_polyline.origin_meta = build_leader_origin_metadata();
-                }
-            } else if (value_line == "DIMENSION") {
-                current_kind = DxfEntityKind::Insert;
-                reset_insert();
-                current_insert.is_dimension = true;
-            } else if (value_line == "TABLE") {
-                current_kind = DxfEntityKind::Text;
-                reset_text();
-                current_text.allow_extended_text = true;
-                current_text.is_mtext = true;
-                current_text.kind = "table";
-            } else if (value_line == "VIEWPORT") {
-                current_kind = DxfEntityKind::Viewport;
-                reset_viewport();
-            } else if (value_line == "POLYLINE" && (in_entities || in_block_entities)) {
-                // Old-style 3D POLYLINE (followed by VERTEX entities then SEQEND)
-                current_kind = DxfEntityKind::Polyline;
-                reset_polyline();
-                in_old_style_polyline = true;
-            } else if (value_line == "VERTEX" && in_old_style_polyline) {
-                // VERTEX within old-style POLYLINE — don't change current_kind, coords parsed in Polyline switch
-            } else if (value_line == "TOLERANCE" && (in_entities || in_block_entities)) {
-                // GD&T tolerance frame — import as text entity with kind="tolerance"
-                current_kind = DxfEntityKind::Text;
-                reset_text();
-                current_text.kind = "tolerance";
-            } else {
-                current_kind = DxfEntityKind::None;
-                if (value_line != "SEQEND" && value_line != "ENDBLK" && value_line != "VERTEX") {
-                    import_stats->unsupported_types[value_line]++;
-                    import_stats->entities_skipped++;
-                }
-            }
+            handle_zero_record(value_line, zero_ctx);
             continue;
         }
 

--- a/plugins/dxf_parser_zero_record.cpp
+++ b/plugins/dxf_parser_zero_record.cpp
@@ -1,0 +1,295 @@
+#include "dxf_parser_zero_record.h"
+
+static void ensure_insert_group_tag(DxfInsert* insert, int* next_tag) {
+    if (!insert) return;
+    if (insert->local_group_tag < 0) {
+        insert->local_group_tag = (*next_tag)++;
+    }
+}
+
+void handle_zero_record(const std::string& value_line, DxfZeroRecordContext& ctx) {
+    // --- Layout finalize on any code==0 record ---
+    if (*ctx.in_layout_object) {
+        ctx.finalize_layout();
+        ctx.reset_layout();
+        *ctx.in_layout_object = false;
+    }
+
+    // --- Old-style polyline VERTEX / flush ---
+    if (*ctx.in_old_style_polyline && value_line == "VERTEX") {
+        // Don't flush — VERTEX coords will be added to current_polyline
+    } else {
+        if (*ctx.in_old_style_polyline && value_line != "VERTEX") {
+            *ctx.in_old_style_polyline = false; // sequence ended
+        }
+        ctx.flush_current();
+    }
+
+    // --- SECTION ---
+    if (value_line == "SECTION") {
+        *ctx.expect_section_name = true;
+        return;
+    }
+
+    // --- ENDSEC ---
+    if (value_line == "ENDSEC") {
+        if (*ctx.in_layer_table && *ctx.in_layer_record) {
+            ctx.finalize_layer();
+            ctx.reset_layer();
+            *ctx.in_layer_record = false;
+        }
+        if (*ctx.in_style_table && *ctx.in_style_record) {
+            ctx.finalize_text_style();
+            ctx.reset_text_style();
+            *ctx.in_style_record = false;
+        }
+        if (*ctx.in_vport_table && *ctx.in_vport_record) {
+            ctx.finalize_vport();
+            ctx.reset_vport();
+            *ctx.in_vport_record = false;
+        }
+        if (*ctx.in_layout_object) {
+            ctx.finalize_layout();
+            ctx.reset_layout();
+            *ctx.in_layout_object = false;
+        }
+        if (*ctx.in_block) {
+            ctx.finalize_block();
+            ctx.reset_block();
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        }
+        *ctx.in_layer_table = false;
+        *ctx.in_style_table = false;
+        *ctx.in_vport_table = false;
+        *ctx.in_layout_object = false;
+        ctx.current_table->clear();
+        *ctx.current_section = DxfSection::None;
+        return;
+    }
+
+    // --- TABLE (section-level, in Tables section) ---
+    if (value_line == "TABLE" && *ctx.current_section == DxfSection::Tables) {
+        *ctx.expect_table_name = true;
+        return;
+    }
+
+    // --- ENDTAB ---
+    if (value_line == "ENDTAB") {
+        if (*ctx.in_layer_table && *ctx.in_layer_record) {
+            ctx.finalize_layer();
+            ctx.reset_layer();
+            *ctx.in_layer_record = false;
+        }
+        if (*ctx.in_style_table && *ctx.in_style_record) {
+            ctx.finalize_text_style();
+            ctx.reset_text_style();
+            *ctx.in_style_record = false;
+        }
+        if (*ctx.in_vport_table && *ctx.in_vport_record) {
+            ctx.finalize_vport();
+            ctx.reset_vport();
+            *ctx.in_vport_record = false;
+        }
+        *ctx.in_layer_table = false;
+        *ctx.in_style_table = false;
+        *ctx.in_vport_table = false;
+        ctx.current_table->clear();
+        return;
+    }
+
+    // --- LAYER record start ---
+    if (*ctx.in_layer_table && value_line == "LAYER") {
+        if (*ctx.in_layer_record) {
+            ctx.finalize_layer();
+            ctx.reset_layer();
+        }
+        *ctx.in_layer_record = true;
+        return;
+    }
+
+    // --- STYLE record start ---
+    if (*ctx.in_style_table && value_line == "STYLE") {
+        if (*ctx.in_style_record) {
+            ctx.finalize_text_style();
+            ctx.reset_text_style();
+        }
+        *ctx.in_style_record = true;
+        return;
+    }
+
+    // --- VPORT record start ---
+    if (*ctx.in_vport_table && value_line == "VPORT") {
+        if (*ctx.in_vport_record) {
+            ctx.finalize_vport();
+            ctx.reset_vport();
+        }
+        ctx.reset_vport();
+        *ctx.in_vport_record = true;
+        return;
+    }
+
+    // --- BLOCK ---
+    if (value_line == "BLOCK" && *ctx.current_section == DxfSection::Blocks) {
+        if (*ctx.in_block) {
+            ctx.finalize_block();
+        }
+        ctx.reset_block();
+        *ctx.in_block = true;
+        *ctx.in_block_header = true;
+        return;
+    }
+
+    // --- ENDBLK ---
+    if (value_line == "ENDBLK") {
+        if (*ctx.in_block) {
+            ctx.finalize_block();
+            ctx.reset_block();
+            *ctx.in_block = false;
+        }
+        *ctx.in_block_header = false;
+        return;
+    }
+
+    // --- Exit block header on first entity ---
+    if (*ctx.in_block && *ctx.in_block_header) {
+        *ctx.in_block_header = false;
+    }
+
+    // --- LAYOUT object ---
+    if (value_line == "LAYOUT" && *ctx.current_section == DxfSection::Objects) {
+        ctx.reset_layout();
+        *ctx.in_layout_object = true;
+        return;
+    }
+
+    // --- Entity scope check ---
+    const bool in_entities = *ctx.current_section == DxfSection::Entities;
+    const bool in_block_entities = *ctx.current_section == DxfSection::Blocks
+                                   && *ctx.in_block && !*ctx.in_block_header;
+    if (!in_entities && !in_block_entities) {
+        *ctx.current_kind = DxfEntityKind::None;
+        return;
+    }
+
+    // --- SEQEND ---
+    if (value_line == "SEQEND" && in_entities) {
+        *ctx.has_active_insert_attribute_owner = false;
+        *ctx.has_last_top_level_insert = false;
+        *ctx.current_kind = DxfEntityKind::None;
+        return;
+    }
+
+    // --- ATTRIB ownership tracking ---
+    if (value_line == "ATTRIB" && in_entities) {
+        if (*ctx.has_last_top_level_insert) {
+            if (!ctx.inserts->empty()) {
+                ensure_insert_group_tag(&ctx.inserts->back(), ctx.next_insert_attribute_group_tag);
+                *ctx.active_insert_attribute_owner = ctx.inserts->back();
+            } else {
+                ensure_insert_group_tag(ctx.last_top_level_insert, ctx.next_insert_attribute_group_tag);
+                *ctx.active_insert_attribute_owner = *ctx.last_top_level_insert;
+            }
+            *ctx.has_active_insert_attribute_owner = true;
+        }
+    } else {
+        *ctx.has_active_insert_attribute_owner = false;
+    }
+    *ctx.has_last_top_level_insert = false;
+    ctx.import_stats->entities_parsed++;
+
+    // --- Entity kind selection ---
+    if (value_line == "INSERT" && (in_entities || in_block_entities)) {
+        *ctx.current_kind = DxfEntityKind::Insert;
+        ctx.reset_insert();
+    } else if (value_line == "LWPOLYLINE") {
+        *ctx.current_kind = DxfEntityKind::Polyline;
+        ctx.reset_polyline();
+    } else if (value_line == "LINE") {
+        *ctx.current_kind = DxfEntityKind::Line;
+        ctx.reset_line();
+    } else if (value_line == "POINT") {
+        *ctx.current_kind = DxfEntityKind::Point;
+        ctx.reset_point();
+    } else if (value_line == "CIRCLE") {
+        *ctx.current_kind = DxfEntityKind::Circle;
+        ctx.reset_circle();
+    } else if (value_line == "ARC") {
+        *ctx.current_kind = DxfEntityKind::Arc;
+        ctx.reset_arc();
+    } else if (value_line == "ELLIPSE") {
+        *ctx.current_kind = DxfEntityKind::Ellipse;
+        ctx.reset_ellipse();
+    } else if (value_line == "SPLINE") {
+        *ctx.current_kind = DxfEntityKind::Spline;
+        ctx.reset_spline();
+    } else if (value_line == "SOLID") {
+        *ctx.current_kind = DxfEntityKind::Solid;
+        ctx.reset_solid();
+    } else if (value_line == "HATCH") {
+        *ctx.current_kind = DxfEntityKind::Hatch;
+        ctx.reset_hatch();
+        *ctx.current_hatch_hatch_id = (*ctx.next_hatch_id)++;
+    } else if (value_line == "TEXT" || value_line == "MTEXT" || value_line == "ATTRIB" || value_line == "ATTDEF") {
+        *ctx.current_kind = DxfEntityKind::Text;
+        ctx.reset_text();
+        if (value_line == "MTEXT") {
+            ctx.current_text->allow_extended_text = true;
+            ctx.current_text->is_mtext = true;
+            ctx.current_text->kind = "mtext";
+        } else if (value_line == "ATTRIB") {
+            ctx.current_text->kind = "attrib";
+            if (*ctx.has_active_insert_attribute_owner) {
+                ctx.current_text->origin_meta = ctx.build_insert_origin_metadata(*ctx.active_insert_attribute_owner);
+                ctx.current_text->local_group_tag = ctx.active_insert_attribute_owner->local_group_tag;
+            }
+        } else if (value_line == "ATTDEF") {
+            ctx.current_text->kind = "attdef";
+        } else {
+            ctx.current_text->kind = "text";
+        }
+    } else if (value_line == "LEADER" || value_line == "MLEADER") {
+        if (value_line == "MLEADER") {
+            *ctx.current_kind = DxfEntityKind::Text;
+            ctx.reset_text();
+            ctx.current_text->allow_extended_text = true;
+            ctx.current_text->is_mtext = true;
+            ctx.current_text->kind = "mleader";
+        } else {
+            *ctx.current_kind = DxfEntityKind::Polyline;
+            ctx.reset_polyline();
+            *ctx.current_polyline_origin_meta = ctx.build_leader_origin_metadata();
+        }
+    } else if (value_line == "DIMENSION") {
+        *ctx.current_kind = DxfEntityKind::Insert;
+        ctx.reset_insert();
+        ctx.current_insert->is_dimension = true;
+    } else if (value_line == "TABLE") {
+        *ctx.current_kind = DxfEntityKind::Text;
+        ctx.reset_text();
+        ctx.current_text->allow_extended_text = true;
+        ctx.current_text->is_mtext = true;
+        ctx.current_text->kind = "table";
+    } else if (value_line == "VIEWPORT") {
+        *ctx.current_kind = DxfEntityKind::Viewport;
+        ctx.reset_viewport();
+    } else if (value_line == "POLYLINE" && (in_entities || in_block_entities)) {
+        // Old-style 3D POLYLINE (followed by VERTEX entities then SEQEND)
+        *ctx.current_kind = DxfEntityKind::Polyline;
+        ctx.reset_polyline();
+        *ctx.in_old_style_polyline = true;
+    } else if (value_line == "VERTEX" && *ctx.in_old_style_polyline) {
+        // VERTEX within old-style POLYLINE — don't change current_kind, coords parsed in Polyline switch
+    } else if (value_line == "TOLERANCE" && (in_entities || in_block_entities)) {
+        // GD&T tolerance frame — import as text entity with kind="tolerance"
+        *ctx.current_kind = DxfEntityKind::Text;
+        ctx.reset_text();
+        ctx.current_text->kind = "tolerance";
+    } else {
+        *ctx.current_kind = DxfEntityKind::None;
+        if (value_line != "SEQEND" && value_line != "ENDBLK" && value_line != "VERTEX") {
+            ctx.import_stats->unsupported_types[value_line]++;
+            ctx.import_stats->entities_skipped++;
+        }
+    }
+}

--- a/plugins/dxf_parser_zero_record.h
+++ b/plugins/dxf_parser_zero_record.h
@@ -1,0 +1,124 @@
+#pragma once
+// DXF parser zero-record (code == 0) transition handler.
+// Extracted from dxf_importer_plugin.cpp to reduce branching in
+// parse_dxf_entities().
+//
+// Dependencies: dxf_types.h, standard headers.
+
+#include "dxf_types.h"
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// ---------- DxfEntityKind ------------------------------------------------------
+enum class DxfEntityKind {
+    None,
+    Polyline,
+    Line,
+    Point,
+    Circle,
+    Arc,
+    Ellipse,
+    Spline,
+    Text,
+    Solid,
+    Hatch,
+    Insert,
+    Viewport
+};
+
+// ---------- DxfSection ---------------------------------------------------------
+enum class DxfSection {
+    None,
+    Header,
+    Tables,
+    Blocks,
+    Entities,
+    Objects
+};
+
+// ---------- DxfImportStats -----------------------------------------------------
+struct DxfImportStats {
+    int entities_parsed = 0;
+    int entities_imported = 0;
+    int entities_skipped = 0;
+    std::unordered_map<std::string, int> unsupported_types;
+    std::vector<std::string> warnings;
+};
+
+// ---------- DxfZeroRecordContext ------------------------------------------------
+// Bundles the parser state pointers and callbacks needed by the zero-record
+// transition handler.  The caller sets up pointers into its own local state
+// so that handle_zero_record can read and write parser variables without
+// needing direct access to entity containers or finalize/reset lambdas.
+struct DxfZeroRecordContext {
+    // --- Core parser state (all non-null) ---
+    DxfEntityKind* current_kind;
+    DxfSection* current_section;
+    std::string* current_table;
+    bool* in_old_style_polyline;
+    bool* expect_section_name;
+    bool* expect_table_name;
+    bool* in_layer_table;
+    bool* in_layer_record;
+    bool* in_style_table;
+    bool* in_style_record;
+    bool* in_vport_table;
+    bool* in_vport_record;
+    bool* in_block;
+    bool* in_block_header;
+    bool* in_layout_object;
+    bool* has_active_insert_attribute_owner;
+    bool* has_last_top_level_insert;
+
+    // --- Insert ownership tracking ---
+    DxfInsert* active_insert_attribute_owner;
+    DxfInsert* last_top_level_insert;
+    int* next_insert_attribute_group_tag;
+    int* next_hatch_id;
+
+    // --- Entity-specific writable fields for kind activation ---
+    DxfText* current_text;
+    DxfInsert* current_insert;
+    DxfEntityOriginMeta* current_polyline_origin_meta;
+    int* current_hatch_hatch_id;
+
+    // --- Import stats ---
+    DxfImportStats* import_stats;
+
+    // --- Inserts collection (for ATTRIB owner lookup) ---
+    std::vector<DxfInsert>* inserts;
+
+    // --- Callbacks for operations that depend on local parser state ---
+    std::function<void()> flush_current;
+    std::function<void()> finalize_layout;
+    std::function<void()> reset_layout;
+    std::function<void()> finalize_layer;
+    std::function<void()> reset_layer;
+    std::function<void()> finalize_text_style;
+    std::function<void()> reset_text_style;
+    std::function<void()> finalize_vport;
+    std::function<void()> reset_vport;
+    std::function<void()> finalize_block;
+    std::function<void()> reset_block;
+    std::function<void()> reset_polyline;
+    std::function<void()> reset_line;
+    std::function<void()> reset_point;
+    std::function<void()> reset_circle;
+    std::function<void()> reset_arc;
+    std::function<void()> reset_ellipse;
+    std::function<void()> reset_spline;
+    std::function<void()> reset_text;
+    std::function<void()> reset_solid;
+    std::function<void()> reset_hatch;
+    std::function<void()> reset_insert;
+    std::function<void()> reset_viewport;
+    std::function<DxfEntityOriginMeta(const DxfInsert&)> build_insert_origin_metadata;
+    std::function<DxfEntityOriginMeta()> build_leader_origin_metadata;
+};
+
+// Handles a single code-0 DXF record transition.  Caller must always
+// `continue` in its parser loop after calling this function.
+void handle_zero_record(const std::string& value_line, DxfZeroRecordContext& ctx);


### PR DESCRIPTION
## Summary
- extract the  transition dispatcher from 
- add a dedicated  helper module
- keep non-zero DXF field parsing in 

## Verification
- -- Earcut not found - triangulation will use stub
-- TinyGLTF not found - glTF export will not be available
-- Clipper2 not found - boolean/offset will be stubs
-- Eigen3 found and linked
-- TinyGLTF not found for editor - glTF export disabled (JSON/DXF still available)
-- GTest not found, test_complex_strict will use basic assertions
-- Configuring done (1.1s)
-- Generating done (0.5s)
-- Build files have been written to: /Users/huazhou/Downloads/Github/VemCAD/.worktrees/dxf-b3b-zero-record-transitions-cadgf/build-codex
- [ 37%] Built target core
[ 50%] Built target core_c
[ 50%] Building CXX object plugins/CMakeFiles/cadgf_dxf_importer_plugin.dir/dxf_parser_zero_record.cpp.o
[ 50%] Building CXX object plugins/CMakeFiles/cadgf_dxf_importer_plugin.dir/dxf_importer_plugin.cpp.o
[ 62%] Linking CXX shared library libcadgf_dxf_importer_plugin.dylib
[100%] Built target cadgf_dxf_importer_plugin
- build runnable  test targets excluding known baseline-blocked 
- Test project /Users/huazhou/Downloads/Github/VemCAD/.worktrees/dxf-b3b-zero-record-transitions-cadgf
- 

## Notes
- preserves zero-record finalize/reset and entity-kind activation semantics
- does not extract the full parser state machine
