### PR TITLE
refactor: extract dxf section table name routing

### DIFF
--- a/docs/DXF_B3C_SECTION_TABLE_NAME_ROUTING_DESIGN.md
+++ b/docs/DXF_B3C_SECTION_TABLE_NAME_ROUTING_DESIGN.md
@@ -1,0 +1,90 @@
+## Scope
+
+Implement the third parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only the `code == 2` section/table name routing that
+follows the zero-record dispatcher. It does **not** extract header/object/entity
+field parsing.
+
+## Goal
+
+Reduce the amount of section/table name routing embedded inside
+`parse_dxf_entities(...)` by moving that logic into a narrow helper module:
+
+- `plugins/dxf_parser_name_routing.h`
+- `plugins/dxf_parser_name_routing.cpp`
+
+## Included
+
+Extract only these branches:
+
+- `if (expect_section_name && code == 2) { ... }`
+- `if (expect_table_name && code == 2) { ... }`
+
+The helper may introduce a narrow routing context struct if needed.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- the zero-record dispatcher
+- non-`code == 2` field parsing
+- header variable parsing
+- layout object parsing
+- entity property decoding
+- parser main loop
+- committer code
+- plugin ABI
+
+Do **not** change:
+
+- section selection semantics for `TABLES`, `HEADER`, `ENTITIES`, `BLOCKS`, `OBJECTS`
+- `current_header_var.clear()` behavior for `HEADER`
+- `in_block` / `in_block_header` reset semantics
+- `current_table` semantics
+- `in_layer_table` / `in_style_table` / `in_vport_table` toggles
+
+## Design Constraints
+
+### 1. Keep the parser loop in place
+
+`parse_dxf_entities(...)` must remain in `dxf_importer_plugin.cpp`.
+
+This packet only absorbs the `code == 2` name-routing block.
+
+### 2. Keep dependencies narrow
+
+The new routing helper may depend on:
+
+- `dxf_parser_zero_record.h` if needed for shared enums/types
+- `dxf_types.h`
+- standard headers
+
+Avoid new dependencies into committer or higher-level DXF modules.
+
+### 3. Preserve transition ordering exactly
+
+The helper must preserve:
+
+- `expect_section_name = false` timing
+- `expect_table_name = false` timing
+- `current_section` updates
+- `current_table` assignment
+- block-state reset ordering
+- table-flag toggles
+
+## Expected Files
+
+- `plugins/dxf_parser_name_routing.h`
+- `plugins/dxf_parser_name_routing.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- `code == 2` routing only
+- no widened parser extraction
+- no behavior drift in section/table selection
+- preserved block-state reset semantics

--- a/docs/DXF_B3C_SECTION_TABLE_NAME_ROUTING_VERIFICATION.md
+++ b/docs/DXF_B3C_SECTION_TABLE_NAME_ROUTING_VERIFICATION.md
@@ -1,0 +1,50 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets, excluding the known baseline-blocked
+`test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to B3b
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- zero-record dispatcher changes
+- header/object/entity field parsing changes
+- parser full state-machine extraction
+- committer extraction
+- final plugin-shell slimming

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
     dxf_parser_helpers.cpp
     dxf_parser_zero_record.cpp
+    dxf_parser_name_routing.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -6,6 +6,7 @@
 #include "dxf_math_utils.h"
 #include "dxf_parser_helpers.h"
 #include "dxf_parser_zero_record.h"
+#include "dxf_parser_name_routing.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1581,6 +1582,18 @@ static bool parse_dxf_entities(const std::string& path,
         return build_leader_origin_metadata();
     };
 
+    DxfNameRoutingContext name_ctx{};
+    name_ctx.expect_section_name = &expect_section_name;
+    name_ctx.expect_table_name = &expect_table_name;
+    name_ctx.current_section = &current_section;
+    name_ctx.current_header_var = &current_header_var;
+    name_ctx.current_table = &current_table;
+    name_ctx.in_block = &in_block;
+    name_ctx.in_block_header = &in_block_header;
+    name_ctx.in_layer_table = &in_layer_table;
+    name_ctx.in_style_table = &in_style_table;
+    name_ctx.in_vport_table = &in_vport_table;
+
     while (std::getline(in, code_line)) {
         if (!std::getline(in, value_line)) break;
         trim_code_line(&code_line);
@@ -1594,43 +1607,7 @@ static bool parse_dxf_entities(const std::string& path,
             continue;
         }
 
-        if (expect_section_name && code == 2) {
-            expect_section_name = false;
-            if (value_line == "TABLES") {
-                current_section = DxfSection::Tables;
-                in_block = false;
-                in_block_header = false;
-            } else if (value_line == "HEADER") {
-                current_section = DxfSection::Header;
-                current_header_var.clear();
-                in_block = false;
-                in_block_header = false;
-            } else if (value_line == "ENTITIES") {
-                current_section = DxfSection::Entities;
-                in_block = false;
-                in_block_header = false;
-            } else if (value_line == "BLOCKS") {
-                current_section = DxfSection::Blocks;
-                in_block = false;
-                in_block_header = false;
-            } else if (value_line == "OBJECTS") {
-                current_section = DxfSection::Objects;
-                in_block = false;
-                in_block_header = false;
-            } else {
-                current_section = DxfSection::None;
-                in_block = false;
-                in_block_header = false;
-            }
-            continue;
-        }
-
-        if (expect_table_name && code == 2) {
-            expect_table_name = false;
-            current_table = value_line;
-            in_layer_table = (current_section == DxfSection::Tables && current_table == "LAYER");
-            in_style_table = (current_section == DxfSection::Tables && current_table == "STYLE");
-            in_vport_table = (current_section == DxfSection::Tables && current_table == "VPORT");
+        if (handle_name_routing(code, value_line, name_ctx)) {
             continue;
         }
 

--- a/plugins/dxf_parser_name_routing.cpp
+++ b/plugins/dxf_parser_name_routing.cpp
@@ -1,0 +1,46 @@
+#include "dxf_parser_name_routing.h"
+
+bool handle_name_routing(int code, const std::string& value_line,
+                         DxfNameRoutingContext& ctx) {
+    if (*ctx.expect_section_name && code == 2) {
+        *ctx.expect_section_name = false;
+        if (value_line == "TABLES") {
+            *ctx.current_section = DxfSection::Tables;
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        } else if (value_line == "HEADER") {
+            *ctx.current_section = DxfSection::Header;
+            ctx.current_header_var->clear();
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        } else if (value_line == "ENTITIES") {
+            *ctx.current_section = DxfSection::Entities;
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        } else if (value_line == "BLOCKS") {
+            *ctx.current_section = DxfSection::Blocks;
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        } else if (value_line == "OBJECTS") {
+            *ctx.current_section = DxfSection::Objects;
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        } else {
+            *ctx.current_section = DxfSection::None;
+            *ctx.in_block = false;
+            *ctx.in_block_header = false;
+        }
+        return true;
+    }
+
+    if (*ctx.expect_table_name && code == 2) {
+        *ctx.expect_table_name = false;
+        *ctx.current_table = value_line;
+        *ctx.in_layer_table = (*ctx.current_section == DxfSection::Tables && *ctx.current_table == "LAYER");
+        *ctx.in_style_table = (*ctx.current_section == DxfSection::Tables && *ctx.current_table == "STYLE");
+        *ctx.in_vport_table = (*ctx.current_section == DxfSection::Tables && *ctx.current_table == "VPORT");
+        return true;
+    }
+
+    return false;
+}

--- a/plugins/dxf_parser_name_routing.h
+++ b/plugins/dxf_parser_name_routing.h
@@ -1,0 +1,32 @@
+#pragma once
+// DXF parser code==2 section/table name routing handler.
+// Extracted from dxf_importer_plugin.cpp to reduce branching in
+// parse_dxf_entities().
+//
+// Dependencies: dxf_parser_zero_record.h (for DxfSection enum), standard headers.
+
+#include "dxf_parser_zero_record.h"
+
+#include <string>
+
+// ---------- DxfNameRoutingContext ------------------------------------------------
+// Bundles the parser state pointers needed by the code==2 name-routing handler.
+// The caller sets up pointers into its own local state so that the handler can
+// read and write parser variables directly.
+struct DxfNameRoutingContext {
+    bool* expect_section_name;
+    bool* expect_table_name;
+    DxfSection* current_section;
+    std::string* current_header_var;
+    std::string* current_table;
+    bool* in_block;
+    bool* in_block_header;
+    bool* in_layer_table;
+    bool* in_style_table;
+    bool* in_vport_table;
+};
+
+// Handles a code==2 DXF record for section/table name routing.
+// Returns true if the record was consumed (caller should `continue`).
+bool handle_name_routing(int code, const std::string& value_line,
+                         DxfNameRoutingContext& ctx);


### PR DESCRIPTION
## Summary
- extract the `code == 2` section/table name routing from `parse_dxf_entities(...)`
- add a dedicated `dxf_parser_name_routing` helper module
- keep zero-record dispatch and non-`code == 2` parsing in `dxf_importer_plugin.cpp`

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- build runnable `dxf|dwg` test targets excluding known baseline-blocked `test_dxf_leader_metadata`
- `ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`

## Notes
- preserves section/table routing semantics, HEADER header-var reset, and table-flag toggles
- does not widen parser extraction beyond the `code == 2` name-routing block
