### PR TITLE
refactor: extract dxf header vars

### DIFF
--- a/docs/DXF_B3D_HEADER_VARS_DESIGN.md
+++ b/docs/DXF_B3D_HEADER_VARS_DESIGN.md
@@ -1,0 +1,99 @@
+## Scope
+
+Implement the fourth parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only the `HEADER` section parsing branch from
+`parse_dxf_entities(...)`.
+
+## Goal
+
+Reduce parser branching inside `parse_dxf_entities(...)` by moving the DXF
+header-variable parsing block into a dedicated helper module:
+
+- `plugins/dxf_header_vars.h`
+- `plugins/dxf_header_vars.cpp`
+
+## Included
+
+Extract only this branch:
+
+- `if (current_section == DxfSection::Header) { ... }`
+
+That includes:
+
+- `code == 9` header-variable selection
+- `$DWGCODEPAGE` handling for group codes `3` and `1`
+- `$LTSCALE`, `$CELTSCALE`, `$TEXTSIZE` handling for group code `40`
+
+The helper may introduce a narrow context struct for the mutable parser state.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- zero-record dispatch
+- `code == 2` section/table name routing
+- layout object parsing
+- layer/style/vport table record parsing
+- block header parsing
+- entity property decoding
+- parser main loop
+- committer code
+- plugin ABI
+
+Do **not** change:
+
+- header variable selection semantics
+- `$DWGCODEPAGE` assignment semantics
+- `$LTSCALE` / `$CELTSCALE` / `$TEXTSIZE` parsing semantics
+- `has_header_*` flag behavior
+- parse-double failure handling
+
+## Design Constraints
+
+### 1. Keep the parser loop in place
+
+`parse_dxf_entities(...)` must remain in `dxf_importer_plugin.cpp`.
+
+This packet only absorbs the `HEADER` branch.
+
+### 2. Keep dependencies narrow
+
+The new helper may depend on:
+
+- `dxf_parser_zero_record.h` for `DxfSection`
+- `dxf_math_utils.h` for `parse_double` if needed
+- standard headers
+
+Avoid new dependencies into higher-level DXF modules.
+
+### 3. Preserve continue behavior
+
+The helper should report whether it consumed the record so the parser loop can
+continue exactly as before.
+
+### 4. Preserve variable/flag timing
+
+The helper must preserve:
+
+- when `current_header_var` changes
+- when `header_codepage` / `has_header_codepage` update
+- when `header_ltscale` / `header_celtscale` / `header_textsize` update
+- when `has_header_ltscale` / `has_header_celtscale` / `has_header_textsize`
+  update
+
+## Expected Files
+
+- `plugins/dxf_header_vars.h`
+- `plugins/dxf_header_vars.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- `HEADER` branch only
+- no widened parser extraction
+- preserved header-variable semantics
+- unchanged `continue` behavior

--- a/docs/DXF_B3D_HEADER_VARS_VERIFICATION.md
+++ b/docs/DXF_B3D_HEADER_VARS_VERIFICATION.md
@@ -1,0 +1,50 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets, excluding the known baseline-blocked
+`test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to B3c
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- zero-record dispatch changes
+- `code == 2` name-routing changes
+- layout object parsing changes
+- parser full state-machine extraction
+- committer extraction

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
     dxf_parser_helpers.cpp
     dxf_parser_zero_record.cpp
+    dxf_header_vars.cpp
     dxf_parser_name_routing.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp

--- a/plugins/dxf_header_vars.cpp
+++ b/plugins/dxf_header_vars.cpp
@@ -1,0 +1,37 @@
+#include "dxf_header_vars.h"
+#include "dxf_math_utils.h"
+
+bool handle_header_var(int code, const std::string& value_line,
+                       DxfHeaderVarsContext& ctx) {
+    if (*ctx.current_section != DxfSection::Header) {
+        return false;
+    }
+
+    if (code == 9) {
+        *ctx.current_header_var = value_line;
+        return true;
+    }
+    if ((code == 3 || code == 1) && *ctx.current_header_var == "$DWGCODEPAGE") {
+        *ctx.header_codepage = value_line;
+        *ctx.has_header_codepage = true;
+        return true;
+    }
+    if (code == 40) {
+        double scale = 0.0;
+        if (parse_double(value_line, &scale)) {
+            if (*ctx.current_header_var == "$LTSCALE") {
+                *ctx.header_ltscale = scale;
+                *ctx.has_header_ltscale = true;
+            } else if (*ctx.current_header_var == "$CELTSCALE") {
+                *ctx.header_celtscale = scale;
+                *ctx.has_header_celtscale = true;
+            } else if (*ctx.current_header_var == "$TEXTSIZE") {
+                *ctx.header_textsize = scale;
+                *ctx.has_header_textsize = true;
+            }
+        }
+    }
+    // The original code always falls through to `continue` when in Header section,
+    // regardless of whether a specific code was matched above.
+    return true;
+}

--- a/plugins/dxf_header_vars.h
+++ b/plugins/dxf_header_vars.h
@@ -1,0 +1,33 @@
+#pragma once
+// DXF parser HEADER section variable handler.
+// Extracted from dxf_importer_plugin.cpp to reduce branching in
+// parse_dxf_entities().
+//
+// Dependencies: dxf_parser_zero_record.h (for DxfSection enum),
+//               dxf_math_utils.h (for parse_double), standard headers.
+
+#include "dxf_parser_zero_record.h"
+
+#include <string>
+
+// ---------- DxfHeaderVarsContext --------------------------------------------------
+// Bundles the parser state pointers needed by the HEADER section handler.
+// The caller sets up pointers into its own local state so that the handler can
+// read and write parser variables directly.
+struct DxfHeaderVarsContext {
+    DxfSection* current_section;
+    std::string* current_header_var;
+    std::string* header_codepage;
+    bool* has_header_codepage;
+    double* header_ltscale;
+    bool* has_header_ltscale;
+    double* header_celtscale;
+    bool* has_header_celtscale;
+    double* header_textsize;
+    bool* has_header_textsize;
+};
+
+// Handles a single DXF record when current_section == DxfSection::Header.
+// Returns true if the record was consumed (caller should `continue`).
+bool handle_header_var(int code, const std::string& value_line,
+                       DxfHeaderVarsContext& ctx);

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -6,6 +6,7 @@
 #include "dxf_math_utils.h"
 #include "dxf_parser_helpers.h"
 #include "dxf_parser_zero_record.h"
+#include "dxf_header_vars.h"
 #include "dxf_parser_name_routing.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
@@ -1594,6 +1595,18 @@ static bool parse_dxf_entities(const std::string& path,
     name_ctx.in_style_table = &in_style_table;
     name_ctx.in_vport_table = &in_vport_table;
 
+    DxfHeaderVarsContext hdr_ctx{};
+    hdr_ctx.current_section = &current_section;
+    hdr_ctx.current_header_var = &current_header_var;
+    hdr_ctx.header_codepage = &header_codepage;
+    hdr_ctx.has_header_codepage = &has_header_codepage;
+    hdr_ctx.header_ltscale = &header_ltscale;
+    hdr_ctx.has_header_ltscale = &has_header_ltscale;
+    hdr_ctx.header_celtscale = &header_celtscale;
+    hdr_ctx.has_header_celtscale = &has_header_celtscale;
+    hdr_ctx.header_textsize = &header_textsize;
+    hdr_ctx.has_header_textsize = &has_header_textsize;
+
     while (std::getline(in, code_line)) {
         if (!std::getline(in, value_line)) break;
         trim_code_line(&code_line);
@@ -1611,31 +1624,7 @@ static bool parse_dxf_entities(const std::string& path,
             continue;
         }
 
-        if (current_section == DxfSection::Header) {
-            if (code == 9) {
-                current_header_var = value_line;
-                continue;
-            }
-            if ((code == 3 || code == 1) && current_header_var == "$DWGCODEPAGE") {
-                header_codepage = value_line;
-                has_header_codepage = true;
-                continue;
-            }
-            if (code == 40) {
-                double scale = 0.0;
-                if (parse_double(value_line, &scale)) {
-                    if (current_header_var == "$LTSCALE") {
-                        header_ltscale = scale;
-                        has_header_ltscale = true;
-                    } else if (current_header_var == "$CELTSCALE") {
-                        header_celtscale = scale;
-                        has_header_celtscale = true;
-                    } else if (current_header_var == "$TEXTSIZE") {
-                        header_textsize = scale;
-                        has_header_textsize = true;
-                    }
-                }
-            }
+        if (handle_header_var(code, value_line, hdr_ctx)) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- extract the `HEADER` branch from `parse_dxf_entities(...)`
- add a dedicated `dxf_header_vars` helper module
- keep zero-record dispatch, `code == 2` name routing, and all non-header parsing in `dxf_importer_plugin.cpp`

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- build runnable `dxf|dwg` test targets excluding known baseline-blocked `test_dxf_leader_metadata`
- `ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- repeated `test_dxf_roundtrip_run` verification
- `git diff --check`

## Notes
- preserves `current_header_var`, `$DWGCODEPAGE`, `$LTSCALE`, `$CELTSCALE`, `$TEXTSIZE`, and all `has_header_*` flag semantics
- does not widen parser extraction beyond the `HEADER` branch
