### PR TITLE
refactor: extract dxf layout objects

### DIFF
--- a/docs/DXF_B3E_LAYOUT_OBJECTS_DESIGN.md
+++ b/docs/DXF_B3E_LAYOUT_OBJECTS_DESIGN.md
@@ -1,0 +1,97 @@
+## Scope
+
+Implement the fifth parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only the layout-object parsing branch from
+`parse_dxf_entities(...)`.
+
+## Goal
+
+Reduce parser branching inside `parse_dxf_entities(...)` by moving the layout
+object field parsing block into a dedicated helper module:
+
+- `plugins/dxf_layout_objects.h`
+- `plugins/dxf_layout_objects.cpp`
+
+## Included
+
+Extract only this branch:
+
+- `if (current_section == DxfSection::Objects && in_layout_object) { ... }`
+
+That includes:
+
+- layout name parsing for group code `1`
+- layout block-record parsing for group code `330`
+
+The helper may introduce a narrow context struct for the mutable parser state.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- zero-record dispatch
+- `code == 2` section/table name routing
+- `HEADER` parsing
+- layer/style/vport table record parsing
+- block header parsing
+- entity property decoding
+- parser main loop
+- committer code
+- plugin ABI
+
+Do **not** change:
+
+- `sanitize_utf8(..., header_codepage)` behavior for layout names
+- `has_name` semantics
+- block-record assignment semantics
+- `has_block_record` semantics
+- `continue` behavior for records inside layout objects
+
+## Design Constraints
+
+### 1. Keep the parser loop in place
+
+`parse_dxf_entities(...)` must remain in `dxf_importer_plugin.cpp`.
+
+This packet only absorbs the layout-object branch.
+
+### 2. Keep dependencies narrow
+
+The new helper may depend on:
+
+- `dxf_parser_zero_record.h` for `DxfSection`
+- `dxf_text_encoding.h` if needed for `sanitize_utf8`
+- standard headers
+
+Avoid new dependencies into higher-level DXF modules.
+
+### 3. Preserve continue behavior
+
+The helper should report whether it consumed the record so the parser loop can
+continue exactly as before.
+
+### 4. Preserve layout-field timing
+
+The helper must preserve:
+
+- when `current_layout.name` updates
+- when `current_layout.has_name` updates
+- when `current_layout.block_record` updates
+- when `current_layout.has_block_record` updates
+
+## Expected Files
+
+- `plugins/dxf_layout_objects.h`
+- `plugins/dxf_layout_objects.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- `Objects + in_layout_object` branch only
+- no widened parser extraction
+- preserved layout metadata semantics
+- unchanged `continue` behavior

--- a/docs/DXF_B3E_LAYOUT_OBJECTS_VERIFICATION.md
+++ b/docs/DXF_B3E_LAYOUT_OBJECTS_VERIFICATION.md
@@ -1,0 +1,51 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets, excluding the known baseline-blocked
+`test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to B3d
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- zero-record dispatch changes
+- `code == 2` name-routing changes
+- `HEADER` parsing changes
+- entity parsing changes
+- parser full state-machine extraction
+- committer extraction

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_parser_zero_record.cpp
     dxf_header_vars.cpp
     dxf_parser_name_routing.cpp
+    dxf_layout_objects.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -8,6 +8,7 @@
 #include "dxf_parser_zero_record.h"
 #include "dxf_header_vars.h"
 #include "dxf_parser_name_routing.h"
+#include "dxf_layout_objects.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -233,12 +234,7 @@ struct DxfTextStyle {
     bool has_height = false;
 };
 
-struct DxfLayout {
-    std::string name;
-    std::string block_record;
-    bool has_name = false;
-    bool has_block_record = false;
-};
+// DxfLayout is defined in dxf_layout_objects.h
 
 struct DxfBlock {
     std::string name;
@@ -1706,18 +1702,7 @@ static bool parse_dxf_entities(const std::string& path,
         }
 
         if (current_section == DxfSection::Objects && in_layout_object) {
-            switch (code) {
-                case 1:
-                    current_layout.name = sanitize_utf8(value_line, header_codepage);
-                    current_layout.has_name = !current_layout.name.empty();
-                    break;
-                case 330:
-                    current_layout.block_record = value_line;
-                    current_layout.has_block_record = !current_layout.block_record.empty();
-                    break;
-                default:
-                    break;
-            }
+            handle_layout_object_field(code, value_line, header_codepage, current_layout);
             continue;
         }
 

--- a/plugins/dxf_layout_objects.cpp
+++ b/plugins/dxf_layout_objects.cpp
@@ -1,0 +1,20 @@
+#include "dxf_layout_objects.h"
+#include "dxf_text_encoding.h"
+
+bool handle_layout_object_field(int code, const std::string& value_line,
+                                const std::string& header_codepage,
+                                DxfLayout& layout) {
+    switch (code) {
+        case 1:
+            layout.name = sanitize_utf8(value_line, header_codepage);
+            layout.has_name = !layout.name.empty();
+            break;
+        case 330:
+            layout.block_record = value_line;
+            layout.has_block_record = !layout.block_record.empty();
+            break;
+        default:
+            break;
+    }
+    return true;
+}

--- a/plugins/dxf_layout_objects.h
+++ b/plugins/dxf_layout_objects.h
@@ -1,0 +1,21 @@
+#pragma once
+// DXF layout-object field parser extracted from dxf_importer_plugin.cpp.
+// Handles group codes inside LAYOUT objects in the OBJECTS section.
+//
+// Dependencies: dxf_text_encoding.h, standard headers.
+
+#include <string>
+
+// ---------- DxfLayout ---------------------------------------------------------
+struct DxfLayout {
+    std::string name;
+    std::string block_record;
+    bool has_name = false;
+    bool has_block_record = false;
+};
+
+// Handles a single DXF record inside a LAYOUT object.
+// Always returns true (the record is always consumed; caller should `continue`).
+bool handle_layout_object_field(int code, const std::string& value_line,
+                                const std::string& header_codepage,
+                                DxfLayout& layout);


### PR DESCRIPTION
## Summary
- extract the `Objects + in_layout_object` branch from `parse_dxf_entities(...)`
- add a dedicated `dxf_layout_objects` helper module
- keep zero-record dispatch, `code == 2` name routing, `HEADER`, and non-layout parsing in `dxf_importer_plugin.cpp`

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- build runnable `dxf|dwg` test targets excluding known baseline-blocked `test_dxf_leader_metadata`
- `ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`

## Notes
- preserves layout name and block-record parsing semantics
- does not widen parser extraction beyond the layout-object branch
