### PR TITLE
refactor: extract dxf block header fields

### DIFF
--- a/docs/DXF_B3F_BLOCK_HEADER_DESIGN.md
+++ b/docs/DXF_B3F_BLOCK_HEADER_DESIGN.md
@@ -1,0 +1,91 @@
+## Scope
+
+Implement the sixth parser-layer extraction batch for the DXF importer in:
+
+- `plugins/dxf_importer_plugin.cpp`
+
+This packet extracts only the block-header parsing branch from
+`parse_dxf_entities(...)`.
+
+## Goal
+
+Reduce parser branching inside `parse_dxf_entities(...)` by moving the block
+header field parsing block into a dedicated helper module:
+
+- `plugins/dxf_block_header.h`
+- `plugins/dxf_block_header.cpp`
+
+## Included
+
+Extract only this branch:
+
+- `if (in_block_header) { ... }`
+
+That includes:
+
+- block name parsing for group code `2`
+- owner-handle parsing for group code `330`
+- base-point parsing for group codes `10` and `20`
+
+The helper may introduce a narrow context struct for the mutable parser state.
+
+## Explicit Non-Goals
+
+Do **not** extract:
+
+- zero-record dispatch
+- `code == 2` name routing
+- `HEADER` parsing
+- layout object parsing
+- table record parsing
+- entity property decoding
+- parser main loop
+- committer code
+- plugin ABI
+
+Do **not** change:
+
+- `sanitize_utf8(..., header_codepage)` behavior for block names
+- `has_name` semantics
+- owner-handle assignment semantics
+- `has_owner_handle` semantics
+- pending block-base parsing across codes `10` and `20`
+- `has_block_x` reset timing
+- `continue` behavior
+
+## Design Constraints
+
+### 1. Keep the parser loop in place
+
+`parse_dxf_entities(...)` must remain in `dxf_importer_plugin.cpp`.
+
+This packet only absorbs the block-header branch.
+
+### 2. Keep dependencies narrow
+
+The new helper may depend on:
+
+- `dxf_text_encoding.h` for `sanitize_utf8`
+- `dxf_math_utils.h` for `parse_double`
+- standard headers
+
+Avoid new dependencies into higher-level DXF modules.
+
+### 3. Preserve continue behavior
+
+The helper should report whether it consumed the record so the parser loop can
+continue exactly as before.
+
+## Expected Files
+
+- `plugins/dxf_block_header.h`
+- `plugins/dxf_block_header.cpp`
+- `plugins/dxf_importer_plugin.cpp`
+- `plugins/CMakeLists.txt`
+
+## Suggested Review Focus
+
+- `in_block_header` branch only
+- no widened parser extraction
+- preserved block metadata semantics
+- unchanged `continue` behavior

--- a/docs/DXF_B3F_BLOCK_HEADER_VERIFICATION.md
+++ b/docs/DXF_B3F_BLOCK_HEADER_VERIFICATION.md
@@ -1,0 +1,52 @@
+## Build
+
+From the worktree root:
+
+```bash
+cmake -S . -B build-codex
+cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8
+```
+
+## Required Tests
+
+Build runnable DXF/DWG test targets, excluding the known baseline-blocked
+`test_dxf_leader_metadata` compile target:
+
+```bash
+targets=($(python3 - <<'PY'
+import re
+from pathlib import Path
+text = Path('tests/tools/CMakeLists.txt').read_text()
+for name in re.findall(r'add_executable\\((test_[A-Za-z0-9_]+)', text):
+    if ('dxf' in name or 'dwg' in name) and name != 'test_dxf_leader_metadata':
+        print(name)
+PY
+))
+cmake --build build-codex --target "${targets[@]}" --parallel 8
+```
+
+Then run the same runnable subset gate:
+
+```bash
+cd build-codex
+ctest --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+## Acceptance Gate
+
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no newly widened failure surface relative to B3e
+- `git diff --check` is clean
+
+## Non-Goals For This Packet
+
+Failure here should not be explained by:
+
+- zero-record dispatch changes
+- `code == 2` name-routing changes
+- `HEADER` parsing changes
+- layout object parsing changes
+- entity parsing changes
+- parser full state-machine extraction
+- committer extraction

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(cadgf_sample_plugin PROPERTIES
 # DXF importer plugin (lite)
 add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
+    dxf_block_header.cpp
     dxf_parser_helpers.cpp
     dxf_parser_zero_record.cpp
     dxf_header_vars.cpp

--- a/plugins/dxf_block_header.cpp
+++ b/plugins/dxf_block_header.cpp
@@ -1,0 +1,37 @@
+#include "dxf_block_header.h"
+#include "dxf_math_utils.h"
+#include "dxf_text_encoding.h"
+
+bool handle_block_header_field(int code, const std::string& value_line,
+                               DxfBlockHeaderContext& ctx) {
+    if (!*ctx.in_block_header) return false;
+
+    switch (code) {
+        case 2:
+            *ctx.block_name = sanitize_utf8(value_line, *ctx.header_codepage);
+            *ctx.has_name = true;
+            break;
+        case 330:
+            *ctx.owner_handle = value_line;
+            *ctx.has_owner_handle = !ctx.owner_handle->empty();
+            break;
+        case 10:
+            if (parse_double(value_line, ctx.pending_block_x)) {
+                *ctx.has_block_x = true;
+            }
+            break;
+        case 20: {
+            if (!*ctx.has_block_x) break;
+            double y = 0.0;
+            if (parse_double(value_line, &y)) {
+                *ctx.block_base = cadgf_vec2{*ctx.pending_block_x, y};
+                *ctx.has_base = true;
+            }
+            *ctx.has_block_x = false;
+            break;
+        }
+        default:
+            break;
+    }
+    return true;
+}

--- a/plugins/dxf_block_header.h
+++ b/plugins/dxf_block_header.h
@@ -1,0 +1,33 @@
+#pragma once
+// DXF block-header field handler.
+// Extracted from dxf_importer_plugin.cpp to reduce branching in
+// parse_dxf_entities().
+//
+// Dependencies: dxf_text_encoding.h (for sanitize_utf8),
+//               dxf_math_utils.h (for parse_double), standard headers.
+
+#include "core/plugin_abi_c_v1.h"
+
+#include <string>
+
+// ---------- DxfBlockHeaderContext -----------------------------------------------
+// Bundles the parser state pointers needed by the block-header field handler.
+// The caller sets up pointers into its own local state so that the handler can
+// read and write parser variables directly.
+struct DxfBlockHeaderContext {
+    const bool* in_block_header;        // gate: currently inside block header?
+    std::string* block_name;            // -> current_block.name
+    bool* has_name;                     // -> current_block.has_name
+    std::string* owner_handle;          // -> current_block.owner_handle
+    bool* has_owner_handle;             // -> current_block.has_owner_handle
+    cadgf_vec2* block_base;             // -> current_block.base
+    bool* has_base;                     // -> current_block.has_base
+    double* pending_block_x;            // pending X coordinate for base point
+    bool* has_block_x;                  // has pending X?
+    const std::string* header_codepage; // codepage for sanitize_utf8
+};
+
+// Handles a single DXF record when in_block_header is true.
+// Returns true if the record was consumed (caller should `continue`).
+bool handle_block_header_field(int code, const std::string& value_line,
+                               DxfBlockHeaderContext& ctx);

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -8,6 +8,7 @@
 #include "dxf_parser_zero_record.h"
 #include "dxf_header_vars.h"
 #include "dxf_parser_name_routing.h"
+#include "dxf_block_header.h"
 #include "dxf_layout_objects.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
@@ -1603,6 +1604,18 @@ static bool parse_dxf_entities(const std::string& path,
     hdr_ctx.header_textsize = &header_textsize;
     hdr_ctx.has_header_textsize = &has_header_textsize;
 
+    DxfBlockHeaderContext blk_hdr_ctx{};
+    blk_hdr_ctx.in_block_header = &in_block_header;
+    blk_hdr_ctx.block_name = &current_block.name;
+    blk_hdr_ctx.has_name = &current_block.has_name;
+    blk_hdr_ctx.owner_handle = &current_block.owner_handle;
+    blk_hdr_ctx.has_owner_handle = &current_block.has_owner_handle;
+    blk_hdr_ctx.block_base = &current_block.base;
+    blk_hdr_ctx.has_base = &current_block.has_base;
+    blk_hdr_ctx.pending_block_x = &pending_block_x;
+    blk_hdr_ctx.has_block_x = &has_block_x;
+    blk_hdr_ctx.header_codepage = &header_codepage;
+
     while (std::getline(in, code_line)) {
         if (!std::getline(in, value_line)) break;
         trim_code_line(&code_line);
@@ -1706,34 +1719,7 @@ static bool parse_dxf_entities(const std::string& path,
             continue;
         }
 
-        if (in_block_header) {
-            switch (code) {
-                case 2:
-                    current_block.name = sanitize_utf8(value_line, header_codepage);
-                    current_block.has_name = true;
-                    break;
-                case 330:
-                    current_block.owner_handle = value_line;
-                    current_block.has_owner_handle = !current_block.owner_handle.empty();
-                    break;
-                case 10:
-                    if (parse_double(value_line, &pending_block_x)) {
-                        has_block_x = true;
-                    }
-                    break;
-                case 20: {
-                    if (!has_block_x) break;
-                    double y = 0.0;
-                    if (parse_double(value_line, &y)) {
-                        current_block.base = cadgf_vec2{pending_block_x, y};
-                        current_block.has_base = true;
-                    }
-                    has_block_x = false;
-                    break;
-                }
-                default:
-                    break;
-            }
+        if (handle_block_header_field(code, value_line, blk_hdr_ctx)) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- extract the DXF block-header field handler into `dxf_block_header.*`
- keep `parse_dxf_entities(...)` delegating through a narrow helper seam
- preserve block name, owner handle, and base-point parsing behavior

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --parallel 8 --target cadgf_dxf_importer_plugin ...DXF/DWG targets...`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`
