### PR TITLE
refactor: extract dxf table records

### DIFF
--- a/docs/DXF_B3G_TABLE_RECORDS_DESIGN.md
+++ b/docs/DXF_B3G_TABLE_RECORDS_DESIGN.md
@@ -1,0 +1,33 @@
+## DXF B3g: Table Record Fields Extraction
+
+### Goal
+Extract the table-record field handling inside `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_table_records.h`
+- Add `plugins/dxf_table_records.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract these three branches:
+- `if (in_layer_table && in_layer_record) { ... }`
+- `if (in_style_table && in_style_record) { ... }`
+- `if (in_vport_table && in_vport_record) { ... }`
+
+### Required invariants
+- Preserve `parse_style_code(...)` handling for layer records exactly.
+- Preserve `sanitize_utf8(..., header_codepage)` handling for layer/style/vport names.
+- Preserve layer flag decoding for `frozen`, `locked`, and `printable`.
+- Preserve style height parsing and `has_height` semantics.
+- Preserve vport center/view-height/aspect parsing and `has_*` flag semantics.
+- Preserve record-consumption behavior: handled table-record lines must still `continue`.
+
+### Out of scope
+- Zero-record dispatch
+- Section/table name routing
+- Header vars
+- Layout objects
+- Block header parsing
+- Entity parsing
+- Committer / plugin ABI

--- a/docs/DXF_B3G_TABLE_RECORDS_VERIFICATION.md
+++ b/docs/DXF_B3G_TABLE_RECORDS_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B3g Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked `test_dxf_leader_metadata`
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_header_vars.cpp
     dxf_parser_name_routing.cpp
     dxf_layout_objects.cpp
+    dxf_table_records.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -10,6 +10,7 @@
 #include "dxf_parser_name_routing.h"
 #include "dxf_block_header.h"
 #include "dxf_layout_objects.h"
+#include "dxf_table_records.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -218,22 +219,8 @@ struct HatchEdgeEllipse {
     bool has_end = false;
 };
 
-struct DxfLayer {
-    std::string name;
-    bool has_name = false;
-    bool visible = true;
-    bool locked = false;
-    bool frozen = false;
-    bool printable = true;
-    DxfStyle style;
-};
-
-struct DxfTextStyle {
-    std::string name;
-    bool has_name = false;
-    double height = 0.0;
-    bool has_height = false;
-};
+// DxfLayer is defined in dxf_table_records.h
+// DxfTextStyle is defined in dxf_table_records.h
 
 // DxfLayout is defined in dxf_layout_objects.h
 
@@ -1638,79 +1625,17 @@ static bool parse_dxf_entities(const std::string& path,
         }
 
         if (in_layer_table && in_layer_record) {
-            if (parse_style_code(&current_layer.style, code, value_line, header_codepage)) {
-                if (current_layer.style.hidden) current_layer.visible = false;
-                continue;
-            }
-            switch (code) {
-                case 2:
-                    current_layer.name = sanitize_utf8(value_line, header_codepage);
-                    current_layer.has_name = true;
-                    break;
-                case 70: {
-                    int flags = 0;
-                    if (parse_int(value_line, &flags)) {
-                        current_layer.frozen = (flags & 1) != 0 || (flags & 2) != 0;
-                        current_layer.locked = (flags & 4) != 0;
-                        current_layer.printable = (flags & 128) == 0;
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
+            handle_layer_record_field(code, value_line, header_codepage, current_layer);
             continue;
         }
 
         if (in_style_table && in_style_record) {
-            switch (code) {
-                case 2:
-                    current_text_style.name = sanitize_utf8(value_line, header_codepage);
-                    current_text_style.has_name = !current_text_style.name.empty();
-                    break;
-                case 40: {
-                    double height = 0.0;
-                    if (parse_double(value_line, &height)) {
-                        current_text_style.height = height;
-                        current_text_style.has_height = height > 0.0;
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
+            handle_style_record_field(code, value_line, header_codepage, current_text_style);
             continue;
         }
 
         if (in_vport_table && in_vport_record) {
-            switch (code) {
-                case 2:
-                    current_vport.name = sanitize_utf8(value_line, header_codepage);
-                    current_vport.has_name = !current_vport.name.empty();
-                    break;
-                case 12:
-                    if (parse_double(value_line, &current_vport.center.x)) {
-                        current_vport.has_center_x = true;
-                    }
-                    break;
-                case 22:
-                    if (parse_double(value_line, &current_vport.center.y)) {
-                        current_vport.has_center_y = true;
-                    }
-                    break;
-                case 40:
-                    if (parse_double(value_line, &current_vport.view_height)) {
-                        current_vport.has_view_height = true;
-                    }
-                    break;
-                case 41:
-                    if (parse_double(value_line, &current_vport.aspect)) {
-                        current_vport.has_aspect = current_vport.aspect > 0.0;
-                    }
-                    break;
-                default:
-                    break;
-            }
+            handle_vport_record_field(code, value_line, header_codepage, current_vport);
             continue;
         }
 

--- a/plugins/dxf_table_records.cpp
+++ b/plugins/dxf_table_records.cpp
@@ -1,0 +1,88 @@
+#include "dxf_table_records.h"
+
+#include "dxf_style.h"
+#include "dxf_math_utils.h"
+#include "dxf_text_encoding.h"
+
+bool handle_layer_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfLayer& layer) {
+    if (parse_style_code(&layer.style, code, value_line, header_codepage)) {
+        if (layer.style.hidden) layer.visible = false;
+        return true;
+    }
+    switch (code) {
+        case 2:
+            layer.name = sanitize_utf8(value_line, header_codepage);
+            layer.has_name = true;
+            return true;
+        case 70: {
+            int flags = 0;
+            if (parse_int(value_line, &flags)) {
+                layer.frozen = (flags & 1) != 0 || (flags & 2) != 0;
+                layer.locked = (flags & 4) != 0;
+                layer.printable = (flags & 128) == 0;
+            }
+            return true;
+        }
+        default:
+            break;
+    }
+    return false;
+}
+
+bool handle_style_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfTextStyle& style) {
+    switch (code) {
+        case 2:
+            style.name = sanitize_utf8(value_line, header_codepage);
+            style.has_name = !style.name.empty();
+            return true;
+        case 40: {
+            double height = 0.0;
+            if (parse_double(value_line, &height)) {
+                style.height = height;
+                style.has_height = height > 0.0;
+            }
+            return true;
+        }
+        default:
+            break;
+    }
+    return false;
+}
+
+bool handle_vport_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfView& vport) {
+    switch (code) {
+        case 2:
+            vport.name = sanitize_utf8(value_line, header_codepage);
+            vport.has_name = !vport.name.empty();
+            return true;
+        case 12:
+            if (parse_double(value_line, &vport.center.x)) {
+                vport.has_center_x = true;
+            }
+            return true;
+        case 22:
+            if (parse_double(value_line, &vport.center.y)) {
+                vport.has_center_y = true;
+            }
+            return true;
+        case 40:
+            if (parse_double(value_line, &vport.view_height)) {
+                vport.has_view_height = true;
+            }
+            return true;
+        case 41:
+            if (parse_double(value_line, &vport.aspect)) {
+                vport.has_aspect = vport.aspect > 0.0;
+            }
+            return true;
+        default:
+            break;
+    }
+    return false;
+}

--- a/plugins/dxf_table_records.h
+++ b/plugins/dxf_table_records.h
@@ -1,0 +1,48 @@
+#pragma once
+// DXF table-record field handlers extracted from dxf_importer_plugin.cpp.
+// Handles group codes inside LAYER, STYLE and VPORT table records.
+//
+// Dependencies: dxf_types.h (DxfStyle, DxfView, cadgf_vec2),
+//               dxf_style.h (parse_style_code), dxf_math_utils.h (parse_int,
+//               parse_double), dxf_text_encoding.h (sanitize_utf8).
+
+#include "dxf_types.h"
+
+#include <string>
+
+// ---------- DxfLayer ---------------------------------------------------------
+struct DxfLayer {
+    std::string name;
+    bool has_name = false;
+    bool visible = true;
+    bool locked = false;
+    bool frozen = false;
+    bool printable = true;
+    DxfStyle style;
+};
+
+// ---------- DxfTextStyle -----------------------------------------------------
+struct DxfTextStyle {
+    std::string name;
+    bool has_name = false;
+    double height = 0.0;
+    bool has_height = false;
+};
+
+// Handle a single group-code/value pair for an in-progress LAYER record.
+// Returns true (and the caller should `continue`) when the code was consumed.
+bool handle_layer_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfLayer& layer);
+
+// Handle a single group-code/value pair for an in-progress STYLE record.
+// Returns true (and the caller should `continue`) when the code was consumed.
+bool handle_style_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfTextStyle& style);
+
+// Handle a single group-code/value pair for an in-progress VPORT record.
+// Returns true (and the caller should `continue`) when the code was consumed.
+bool handle_vport_record_field(int code, const std::string& value_line,
+                               const std::string& header_codepage,
+                               DxfView& vport);


### PR DESCRIPTION
## Summary
- extract LAYER/STYLE/VPORT table-record field handling into `dxf_table_records.*`
- keep `parse_dxf_entities(...)` delegating through a narrow helper seam
- preserve layer flags, style height, and view record parsing behavior

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`
