### PR TITLE
refactor: extract dxf view finalizers

### DIFF
--- a/docs/DXF_B3H_VIEW_FINALIZERS_DESIGN.md
+++ b/docs/DXF_B3H_VIEW_FINALIZERS_DESIGN.md
@@ -1,0 +1,40 @@
+## DXF B3h: View And Layout Finalizers Extraction
+
+### Goal
+Extract the three view/layout finalizers from `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_view_finalizers.h`
+- Add `plugins/dxf_view_finalizers.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract these lambdas:
+- `finalize_viewport(...)`
+- `finalize_vport(...)`
+- `finalize_layout(...)`
+
+### Required invariants
+- Preserve the completeness gate for `DxfViewport` before it is emitted.
+- Preserve width/height/view-height positivity checks.
+- Preserve paperspace promotion logic:
+  - non-model `viewport.layout`
+  - paper block name fallback when `in_block`
+  - `has_paperspace = true` side effect
+- Preserve `viewports.push_back(viewport)` timing.
+- Preserve `*ACTIVE` detection for `DxfView`.
+- Preserve `active_view` / `has_active_view` assignment semantics.
+- Preserve `layout_by_block_record[current_layout.block_record] = current_layout.name`.
+
+### Out of scope
+- Reset helpers
+- `flush_current(...)`
+- Zero-record dispatch
+- Section/table name routing
+- Header vars
+- Table-record field handlers
+- Layout object field handling
+- Block header parsing
+- Entity parsing
+- Committer / plugin ABI

--- a/docs/DXF_B3H_VIEW_FINALIZERS_VERIFICATION.md
+++ b/docs/DXF_B3H_VIEW_FINALIZERS_VERIFICATION.md
@@ -1,0 +1,21 @@
+## DXF B3h Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_parser_name_routing.cpp
     dxf_layout_objects.cpp
     dxf_table_records.cpp
+    dxf_view_finalizers.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -11,6 +11,7 @@
 #include "dxf_block_header.h"
 #include "dxf_layout_objects.h"
 #include "dxf_table_records.h"
+#include "dxf_view_finalizers.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1341,44 +1342,15 @@ static bool parse_dxf_entities(const std::string& path,
     auto reset_layout = [&]() { current_layout = DxfLayout{}; };
 
     auto finalize_viewport = [&](DxfViewport& viewport) {
-        if (!(viewport.has_center_x && viewport.has_center_y &&
-              viewport.has_view_center_x && viewport.has_view_center_y &&
-              viewport.has_width && viewport.has_height && viewport.has_view_height)) {
-            return;
-        }
-        if (!(viewport.width > 0.0) || !(viewport.height > 0.0) || !(viewport.view_height > 0.0)) {
-            return;
-        }
-        if (viewport.space != 1) {
-            bool is_paper = false;
-            if (!viewport.layout.empty() && !is_model_layout_name(viewport.layout)) {
-                is_paper = true;
-            }
-            if (!is_paper && in_block && is_paper_block_name(current_block.name)) {
-                is_paper = true;
-            }
-            if (is_paper) {
-                viewport.space = 1;
-                has_paperspace = true;
-            }
-        }
-        viewports.push_back(viewport);
+        finalize_dxf_viewport(viewport, in_block, current_block.name, has_paperspace, viewports);
     };
 
     auto finalize_vport = [&](DxfView& view) {
-        if (!view.has_name) return;
-        if (!(view.has_center_x && view.has_center_y && view.has_view_height)) return;
-        if (!(view.view_height > 0.0)) return;
-        const std::string upper = uppercase_ascii(view.name);
-        if (upper == "*ACTIVE") {
-            active_view = view;
-            has_active_view = true;
-        }
+        finalize_dxf_vport(view, active_view, has_active_view);
     };
 
     auto finalize_layout = [&]() {
-        if (!(current_layout.has_name && current_layout.has_block_record)) return;
-        layout_by_block_record[current_layout.block_record] = current_layout.name;
+        finalize_dxf_layout(current_layout, layout_by_block_record);
     };
 
     auto flush_current = [&]() {

--- a/plugins/dxf_view_finalizers.cpp
+++ b/plugins/dxf_view_finalizers.cpp
@@ -1,0 +1,73 @@
+#include "dxf_view_finalizers.h"
+
+#include <cctype>
+
+namespace {
+
+std::string uppercase_ascii_local(const std::string& value) {
+    std::string out;
+    out.reserve(value.size());
+    for (char c : value) {
+        out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    }
+    return out;
+}
+
+bool is_paper_block_name_local(const std::string& name) {
+    if (name.empty()) return false;
+    const std::string upper = uppercase_ascii_local(name);
+    return upper.rfind("*PAPER_SPACE", 0) == 0;
+}
+
+bool is_model_layout_name_local(const std::string& name) {
+    if (name.empty()) return false;
+    const std::string upper = uppercase_ascii_local(name);
+    return upper == "MODEL" || upper == "MODEL_SPACE" || upper == "*MODEL_SPACE";
+}
+
+}  // namespace
+
+void finalize_dxf_viewport(DxfViewport& viewport, bool in_block,
+                           const std::string& current_block_name,
+                           bool& has_paperspace,
+                           std::vector<DxfViewport>& viewports) {
+    if (!(viewport.has_center_x && viewport.has_center_y &&
+          viewport.has_view_center_x && viewport.has_view_center_y &&
+          viewport.has_width && viewport.has_height && viewport.has_view_height)) {
+        return;
+    }
+    if (!(viewport.width > 0.0) || !(viewport.height > 0.0) || !(viewport.view_height > 0.0)) {
+        return;
+    }
+    if (viewport.space != 1) {
+        bool is_paper = false;
+        if (!viewport.layout.empty() && !is_model_layout_name_local(viewport.layout)) {
+            is_paper = true;
+        }
+        if (!is_paper && in_block && is_paper_block_name_local(current_block_name)) {
+            is_paper = true;
+        }
+        if (is_paper) {
+            viewport.space = 1;
+            has_paperspace = true;
+        }
+    }
+    viewports.push_back(viewport);
+}
+
+void finalize_dxf_vport(const DxfView& view, DxfView& active_view,
+                        bool& has_active_view) {
+    if (!view.has_name) return;
+    if (!(view.has_center_x && view.has_center_y && view.has_view_height)) return;
+    if (!(view.view_height > 0.0)) return;
+    if (uppercase_ascii_local(view.name) == "*ACTIVE") {
+        active_view = view;
+        has_active_view = true;
+    }
+}
+
+void finalize_dxf_layout(const DxfLayout& layout,
+                         std::unordered_map<std::string, std::string>& layout_by_block_record) {
+    if (!(layout.has_name && layout.has_block_record)) return;
+    layout_by_block_record[layout.block_record] = layout.name;
+}

--- a/plugins/dxf_view_finalizers.h
+++ b/plugins/dxf_view_finalizers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "dxf_types.h"
+#include "dxf_layout_objects.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Finalize a parsed DXF viewport record and append it when complete.
+void finalize_dxf_viewport(DxfViewport& viewport, bool in_block,
+                           const std::string& current_block_name,
+                           bool& has_paperspace,
+                           std::vector<DxfViewport>& viewports);
+
+// Finalize a parsed DXF VPORT table record and capture the active view.
+void finalize_dxf_vport(const DxfView& view, DxfView& active_view,
+                        bool& has_active_view);
+
+// Finalize a parsed DXF LAYOUT object and register its block-record mapping.
+void finalize_dxf_layout(const DxfLayout& layout,
+                         std::unordered_map<std::string, std::string>& layout_by_block_record);


### PR DESCRIPTION
## Summary
- extract viewport, VPORT, and layout finalizers into `dxf_view_finalizers.*`
- keep `parse_dxf_entities(...)` delegating through thin wrappers
- preserve paperspace promotion and active-view/layout registration behavior

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- `cmake --build build-codex --parallel 8 --target ...DXF/DWG targets...`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`
