### PR TITLE
refactor: extract dxf table block finalizers

### DIFF
--- a/docs/DXF_B3I_TABLE_BLOCK_FINALIZERS_DESIGN.md
+++ b/docs/DXF_B3I_TABLE_BLOCK_FINALIZERS_DESIGN.md
@@ -1,0 +1,35 @@
+## DXF B3i: Table And Block Finalizers Extraction
+
+### Goal
+Extract the table/block finalizers from `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_table_block_finalizers.h`
+- Add `plugins/dxf_table_block_finalizers.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract these lambdas:
+- `finalize_layer(...)`
+- `finalize_text_style(...)`
+- `finalize_block(...)`
+
+### Required invariants
+- Preserve the layer-name gate before insertion into `layers`.
+- Preserve the `layer.style.hidden => layer.visible = false` side effect.
+- Preserve `layers[layer.name] = layer` assignment semantics.
+- Preserve the text-style name gate and `text_styles[style.name] = style`.
+- Preserve the block-name gate and `blocks[block.name] = block`.
+- Preserve all zero-record call sites via thin wrappers only; do not change reset timing.
+
+### Out of scope
+- View/layout finalizers
+- Reset helpers
+- `flush_current(...)`
+- Zero-record dispatch
+- Name routing / header vars / table-record handlers
+- Layout-object parsing
+- Block-header parsing
+- Entity parsing
+- Committer / plugin ABI

--- a/docs/DXF_B3I_TABLE_BLOCK_FINALIZERS_VERIFICATION.md
+++ b/docs/DXF_B3I_TABLE_BLOCK_FINALIZERS_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B3i Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked `test_dxf_leader_metadata`
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_layout_objects.cpp
     dxf_table_records.cpp
     dxf_view_finalizers.cpp
+    dxf_table_block_finalizers.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -12,6 +12,7 @@
 #include "dxf_layout_objects.h"
 #include "dxf_table_records.h"
 #include "dxf_view_finalizers.h"
+#include "dxf_table_block_finalizers.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1463,22 +1464,17 @@ static bool parse_dxf_entities(const std::string& path,
         current_kind = DxfEntityKind::None;
     };
 
+
     auto finalize_layer = [&](DxfLayer& layer) {
-        if (!layer.has_name) return;
-        if (layer.style.hidden) {
-            layer.visible = false;
-        }
-        layers[layer.name] = layer;
+        ::finalize_layer(layer, layers);
     };
 
     auto finalize_text_style = [&](DxfTextStyle& style) {
-        if (!style.has_name) return;
-        text_styles[style.name] = style;
+        ::finalize_text_style(style, text_styles);
     };
 
     auto finalize_block = [&](DxfBlock& block) {
-        if (!block.has_name) return;
-        blocks[block.name] = block;
+        ::finalize_block(block, blocks);
     };
 
     DxfZeroRecordContext zero_ctx{};

--- a/plugins/dxf_table_block_finalizers.cpp
+++ b/plugins/dxf_table_block_finalizers.cpp
@@ -1,0 +1,16 @@
+#include "dxf_table_block_finalizers.h"
+
+void finalize_layer(DxfLayer& layer,
+                    std::unordered_map<std::string, DxfLayer>& layers) {
+    if (!layer.has_name) return;
+    if (layer.style.hidden) {
+        layer.visible = false;
+    }
+    layers[layer.name] = layer;
+}
+
+void finalize_text_style(DxfTextStyle& style,
+                         std::unordered_map<std::string, DxfTextStyle>& text_styles) {
+    if (!style.has_name) return;
+    text_styles[style.name] = style;
+}

--- a/plugins/dxf_table_block_finalizers.h
+++ b/plugins/dxf_table_block_finalizers.h
@@ -1,0 +1,23 @@
+#pragma once
+// DXF table/block finalizers extracted from parse_dxf_entities().
+// Each finalizer gates on has_name before inserting into the target map.
+
+#include "dxf_table_records.h"
+
+#include <string>
+#include <unordered_map>
+
+void finalize_layer(DxfLayer& layer,
+                    std::unordered_map<std::string, DxfLayer>& layers);
+
+void finalize_text_style(DxfTextStyle& style,
+                         std::unordered_map<std::string, DxfTextStyle>& text_styles);
+
+// DxfBlock is defined locally in dxf_importer_plugin.cpp, so finalize_block
+// is a template instantiated at the call site where the full type is visible.
+template <typename Block>
+inline void finalize_block(Block& block,
+                           std::unordered_map<std::string, Block>& blocks) {
+    if (!block.has_name) return;
+    blocks[block.name] = block;
+}


### PR DESCRIPTION
## Summary
- extract layer/style/block finalizers into `dxf_table_block_finalizers.*`
- keep `parse_dxf_entities(...)` delegating through thin wrappers
- preserve layer visibility fixup and table/block registration semantics

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin --parallel 8`
- `cmake --build build-codex --parallel 8 --target ...DXF/DWG targets...`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`
