### PR TITLE
refactor: extract simple DXF geometry entity parsers

### DIFF
--- a/docs/DXF_B3J_SIMPLE_GEOMETRY_ENTITIES_DESIGN.md
+++ b/docs/DXF_B3J_SIMPLE_GEOMETRY_ENTITIES_DESIGN.md
@@ -1,0 +1,45 @@
+## DXF B3j: Simple Geometry Entity Parsers Extraction
+
+### Goal
+Extract the simplest geometry entity parsing branches from `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_simple_geometry_entities.h`
+- Add `plugins/dxf_simple_geometry_entities.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract these `switch (current_kind)` branches:
+- `DxfEntityKind::Line`
+- `DxfEntityKind::Point`
+- `DxfEntityKind::Circle`
+- `DxfEntityKind::Arc`
+
+### Required invariants
+- Preserve `parse_entity_space(...)` passthrough behavior.
+- Preserve `parse_entity_owner(...)` passthrough behavior.
+- Preserve `parse_style_code(...)` passthrough behavior.
+- Preserve exact layer parsing via `sanitize_utf8(value_line, header_codepage)`.
+- Preserve exact field-to-group-code mapping:
+  - `Line`: `10/20/11/21`
+  - `Point`: `10/20`
+  - `Circle`: `10/20/40`
+  - `Arc`: `10/20/40/50/51`
+- Preserve all `has_*` flag semantics and timing.
+- Preserve the main parser's `break`/`continue` behavior via thin wrapper calls only.
+
+### Out of scope
+- `DxfEntityKind::Polyline`
+- `DxfEntityKind::Ellipse`
+- `DxfEntityKind::Spline`
+- `DxfEntityKind::Text`
+- `DxfEntityKind::Solid`
+- `DxfEntityKind::Hatch`
+- `DxfEntityKind::Insert`
+- `DxfEntityKind::Viewport`
+- `flush_current(...)`
+- Zero-record dispatch
+- Name routing / header vars / layout objects / block headers / table records
+- Finalizers
+- Committer / plugin ABI

--- a/docs/DXF_B3J_SIMPLE_GEOMETRY_ENTITIES_VERIFICATION.md
+++ b/docs/DXF_B3J_SIMPLE_GEOMETRY_ENTITIES_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B3j Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked `test_dxf_leader_metadata`
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_table_records.cpp
     dxf_view_finalizers.cpp
     dxf_table_block_finalizers.cpp
+    dxf_simple_geometry_entities.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -13,6 +13,7 @@
 #include "dxf_table_records.h"
 #include "dxf_view_finalizers.h"
 #include "dxf_table_block_finalizers.h"
+#include "dxf_simple_geometry_entities.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1661,126 +1662,63 @@ static bool parse_dxf_entities(const std::string& path,
                 }
                 break;
             case DxfEntityKind::Line:
-                if (parse_entity_space(code, value_line, &current_line.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_line.owner_handle,
-                                       &current_line.has_owner_handle)) break;
-                if (parse_style_code(&current_line.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_line.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 10:
-                        if (parse_double(value_line, &current_line.a.x)) {
-                            current_line.has_ax = true;
-                        }
-                        break;
-                    case 20:
-                        if (parse_double(value_line, &current_line.a.y)) {
-                            current_line.has_ay = true;
-                        }
-                        break;
-                    case 11:
-                        if (parse_double(value_line, &current_line.b.x)) {
-                            current_line.has_bx = true;
-                        }
-                        break;
-                    case 21:
-                        if (parse_double(value_line, &current_line.b.y)) {
-                            current_line.has_by = true;
-                        }
-                        break;
-                    default:
-                        break;
-                }
+                parse_line_entity_record({
+                    &current_line.layer,
+                    &current_line.owner_handle,
+                    &current_line.has_owner_handle,
+                    &current_line.style,
+                    &current_line.space,
+                    &current_line.a,
+                    &current_line.b,
+                    &current_line.has_ax,
+                    &current_line.has_ay,
+                    &current_line.has_bx,
+                    &current_line.has_by,
+                }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Point:
-                if (parse_entity_space(code, value_line, &current_point.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_point.owner_handle,
-                                       &current_point.has_owner_handle)) break;
-                if (parse_style_code(&current_point.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_point.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 10:
-                        if (parse_double(value_line, &current_point.p.x)) {
-                            current_point.has_x = true;
-                        }
-                        break;
-                    case 20:
-                        if (parse_double(value_line, &current_point.p.y)) {
-                            current_point.has_y = true;
-                        }
-                        break;
-                    default:
-                        break;
-                }
+                parse_point_entity_record({
+                    &current_point.layer,
+                    &current_point.owner_handle,
+                    &current_point.has_owner_handle,
+                    &current_point.style,
+                    &current_point.space,
+                    &current_point.p,
+                    &current_point.has_x,
+                    &current_point.has_y,
+                }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Circle:
-                if (parse_entity_space(code, value_line, &current_circle.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_circle.owner_handle,
-                                       &current_circle.has_owner_handle)) break;
-                if (parse_style_code(&current_circle.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_circle.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 10:
-                        if (parse_double(value_line, &current_circle.center.x)) {
-                            current_circle.has_cx = true;
-                        }
-                        break;
-                    case 20:
-                        if (parse_double(value_line, &current_circle.center.y)) {
-                            current_circle.has_cy = true;
-                        }
-                        break;
-                    case 40:
-                        if (parse_double(value_line, &current_circle.radius)) {
-                            current_circle.has_radius = true;
-                        }
-                        break;
-                    default:
-                        break;
-                }
+                parse_circle_entity_record({
+                    &current_circle.layer,
+                    &current_circle.owner_handle,
+                    &current_circle.has_owner_handle,
+                    &current_circle.style,
+                    &current_circle.space,
+                    &current_circle.center,
+                    &current_circle.radius,
+                    &current_circle.has_cx,
+                    &current_circle.has_cy,
+                    &current_circle.has_radius,
+                }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Arc:
-                if (parse_entity_space(code, value_line, &current_arc.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_arc.owner_handle,
-                                       &current_arc.has_owner_handle)) break;
-                if (parse_style_code(&current_arc.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_arc.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 10:
-                        if (parse_double(value_line, &current_arc.center.x)) {
-                            current_arc.has_cx = true;
-                        }
-                        break;
-                    case 20:
-                        if (parse_double(value_line, &current_arc.center.y)) {
-                            current_arc.has_cy = true;
-                        }
-                        break;
-                    case 40:
-                        if (parse_double(value_line, &current_arc.radius)) {
-                            current_arc.has_radius = true;
-                        }
-                        break;
-                    case 50:
-                        if (parse_double(value_line, &current_arc.start_deg)) {
-                            current_arc.has_start = true;
-                        }
-                        break;
-                    case 51:
-                        if (parse_double(value_line, &current_arc.end_deg)) {
-                            current_arc.has_end = true;
-                        }
-                        break;
-                    default:
-                        break;
-                }
+                parse_arc_entity_record({
+                    &current_arc.layer,
+                    &current_arc.owner_handle,
+                    &current_arc.has_owner_handle,
+                    &current_arc.style,
+                    &current_arc.space,
+                    &current_arc.center,
+                    &current_arc.radius,
+                    &current_arc.start_deg,
+                    &current_arc.end_deg,
+                    &current_arc.has_cx,
+                    &current_arc.has_cy,
+                    &current_arc.has_radius,
+                    &current_arc.has_start,
+                    &current_arc.has_end,
+                }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Ellipse:
                 if (parse_entity_space(code, value_line, &current_ellipse.space, &has_paperspace)) break;

--- a/plugins/dxf_simple_geometry_entities.cpp
+++ b/plugins/dxf_simple_geometry_entities.cpp
@@ -1,0 +1,160 @@
+#include "dxf_simple_geometry_entities.h"
+
+#include "dxf_parser_helpers.h"
+#include "dxf_style.h"
+#include "dxf_text_encoding.h"
+
+void parse_line_entity_record(const DxfLineParseState& state,
+                              int code,
+                              const std::string& value_line,
+                              const std::string& header_codepage,
+                              bool* has_paperspace) {
+    if (!state.layer || !state.owner_handle || !state.has_owner_handle || !state.style || !state.space ||
+        !state.a || !state.b || !state.has_ax || !state.has_ay || !state.has_bx || !state.has_by) {
+        return;
+    }
+    if (parse_entity_space(code, value_line, state.space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, state.owner_handle, state.has_owner_handle)) return;
+    if (parse_style_code(state.style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            *state.layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 10:
+            if (parse_double(value_line, &state.a->x)) {
+                *state.has_ax = true;
+            }
+            break;
+        case 20:
+            if (parse_double(value_line, &state.a->y)) {
+                *state.has_ay = true;
+            }
+            break;
+        case 11:
+            if (parse_double(value_line, &state.b->x)) {
+                *state.has_bx = true;
+            }
+            break;
+        case 21:
+            if (parse_double(value_line, &state.b->y)) {
+                *state.has_by = true;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void parse_point_entity_record(const DxfPointParseState& state,
+                               int code,
+                               const std::string& value_line,
+                               const std::string& header_codepage,
+                               bool* has_paperspace) {
+    if (!state.layer || !state.owner_handle || !state.has_owner_handle || !state.style || !state.space ||
+        !state.point || !state.has_x || !state.has_y) {
+        return;
+    }
+    if (parse_entity_space(code, value_line, state.space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, state.owner_handle, state.has_owner_handle)) return;
+    if (parse_style_code(state.style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            *state.layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 10:
+            if (parse_double(value_line, &state.point->x)) {
+                *state.has_x = true;
+            }
+            break;
+        case 20:
+            if (parse_double(value_line, &state.point->y)) {
+                *state.has_y = true;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void parse_circle_entity_record(const DxfCircleParseState& state,
+                                int code,
+                                const std::string& value_line,
+                                const std::string& header_codepage,
+                                bool* has_paperspace) {
+    if (!state.layer || !state.owner_handle || !state.has_owner_handle || !state.style || !state.space ||
+        !state.center || !state.radius || !state.has_cx || !state.has_cy || !state.has_radius) {
+        return;
+    }
+    if (parse_entity_space(code, value_line, state.space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, state.owner_handle, state.has_owner_handle)) return;
+    if (parse_style_code(state.style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            *state.layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 10:
+            if (parse_double(value_line, &state.center->x)) {
+                *state.has_cx = true;
+            }
+            break;
+        case 20:
+            if (parse_double(value_line, &state.center->y)) {
+                *state.has_cy = true;
+            }
+            break;
+        case 40:
+            if (parse_double(value_line, state.radius)) {
+                *state.has_radius = true;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void parse_arc_entity_record(const DxfArcParseState& state,
+                             int code,
+                             const std::string& value_line,
+                             const std::string& header_codepage,
+                             bool* has_paperspace) {
+    if (!state.layer || !state.owner_handle || !state.has_owner_handle || !state.style || !state.space ||
+        !state.center || !state.radius || !state.start_deg || !state.end_deg ||
+        !state.has_cx || !state.has_cy || !state.has_radius || !state.has_start || !state.has_end) {
+        return;
+    }
+    if (parse_entity_space(code, value_line, state.space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, state.owner_handle, state.has_owner_handle)) return;
+    if (parse_style_code(state.style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            *state.layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 10:
+            if (parse_double(value_line, &state.center->x)) {
+                *state.has_cx = true;
+            }
+            break;
+        case 20:
+            if (parse_double(value_line, &state.center->y)) {
+                *state.has_cy = true;
+            }
+            break;
+        case 40:
+            if (parse_double(value_line, state.radius)) {
+                *state.has_radius = true;
+            }
+            break;
+        case 50:
+            if (parse_double(value_line, state.start_deg)) {
+                *state.has_start = true;
+            }
+            break;
+        case 51:
+            if (parse_double(value_line, state.end_deg)) {
+                *state.has_end = true;
+            }
+            break;
+        default:
+            break;
+    }
+}

--- a/plugins/dxf_simple_geometry_entities.h
+++ b/plugins/dxf_simple_geometry_entities.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "dxf_types.h"
+
+#include <string>
+
+struct DxfLineParseState {
+    std::string* layer;
+    std::string* owner_handle;
+    bool* has_owner_handle;
+    DxfStyle* style;
+    int* space;
+    cadgf_vec2* a;
+    cadgf_vec2* b;
+    bool* has_ax;
+    bool* has_ay;
+    bool* has_bx;
+    bool* has_by;
+};
+
+struct DxfPointParseState {
+    std::string* layer;
+    std::string* owner_handle;
+    bool* has_owner_handle;
+    DxfStyle* style;
+    int* space;
+    cadgf_vec2* point;
+    bool* has_x;
+    bool* has_y;
+};
+
+struct DxfCircleParseState {
+    std::string* layer;
+    std::string* owner_handle;
+    bool* has_owner_handle;
+    DxfStyle* style;
+    int* space;
+    cadgf_vec2* center;
+    double* radius;
+    bool* has_cx;
+    bool* has_cy;
+    bool* has_radius;
+};
+
+struct DxfArcParseState {
+    std::string* layer;
+    std::string* owner_handle;
+    bool* has_owner_handle;
+    DxfStyle* style;
+    int* space;
+    cadgf_vec2* center;
+    double* radius;
+    double* start_deg;
+    double* end_deg;
+    bool* has_cx;
+    bool* has_cy;
+    bool* has_radius;
+    bool* has_start;
+    bool* has_end;
+};
+
+void parse_line_entity_record(const DxfLineParseState& state,
+                              int code,
+                              const std::string& value_line,
+                              const std::string& header_codepage,
+                              bool* has_paperspace);
+
+void parse_point_entity_record(const DxfPointParseState& state,
+                               int code,
+                               const std::string& value_line,
+                               const std::string& header_codepage,
+                               bool* has_paperspace);
+
+void parse_circle_entity_record(const DxfCircleParseState& state,
+                                int code,
+                                const std::string& value_line,
+                                const std::string& header_codepage,
+                                bool* has_paperspace);
+
+void parse_arc_entity_record(const DxfArcParseState& state,
+                             int code,
+                             const std::string& value_line,
+                             const std::string& header_codepage,
+                             bool* has_paperspace);


### PR DESCRIPTION
## Summary
- extract the Line, Point, Circle, and Arc parser branches from `parse_dxf_entities(...)`
- add `dxf_simple_geometry_entities.*` as a leaf helper for the four simplest geometry entities
- keep the main parser on thin wrapper call sites only

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin`
- `cmake --build build-codex --target test_dxf_importer_entities test_dxf_text_metadata test_dxf_mleader_metadata test_dxf_table_metadata test_dxf_dimension_geometry_metadata test_dxf_paperspace_insert_leader test_dxf_paperspace_insert_dimension_hatch test_dxf_paperspace_annotation_bundle test_dxf_text_alignment_partial test_dxf_text_alignment_extended test_dxf_importer_blocks test_dxf_insert_attributes test_dxf_viewport_layout_metadata test_dxf_hatch_dash test_dxf_hatch_dense_cap test_dxf_hatch_large_boundary_budget test_dxf_nonfinite_numbers test_dxf_roundtrip test_dxf_roundtrip_styles test_dxf_exporter_plugin_smoke test_dwg_importer_plugin test_dwg_matrix`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`