### PR TITLE
refactor: extract DXF polyline entity parser

### DIFF
--- a/docs/DXF_B3K_POLYLINE_ENTITY_PARSER_DESIGN.md
+++ b/docs/DXF_B3K_POLYLINE_ENTITY_PARSER_DESIGN.md
@@ -1,0 +1,32 @@
+## DXF B3k: Polyline Entity Parser Extraction
+
+### Goal
+Extract the `DxfEntityKind::Polyline` parsing branch from `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_polyline_entity_parser.h`
+- Add `plugins/dxf_polyline_entity_parser.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract the `DxfEntityKind::Polyline` branch.
+
+### Required invariants
+- Preserve `parse_entity_space(...)` passthrough behavior.
+- Preserve `parse_entity_owner(...)` passthrough behavior.
+- Preserve `parse_style_code(...)` passthrough behavior.
+- Preserve exact layer parsing via `sanitize_utf8(value_line, header_codepage)`.
+- Preserve the `70` closed-flag parsing semantics.
+- Preserve `10/20` point accumulation semantics, including `pending_x` / `has_x` timing.
+- Preserve `current_polyline.points.push_back(...)` ordering exactly.
+- Preserve the main parser's `break`/`continue` behavior via thin wrapper calls only.
+
+### Out of scope
+- Line / Point / Circle / Arc branches
+- Ellipse / Spline / Text / Solid / Hatch / Insert / Viewport
+- `flush_current(...)`
+- Zero-record dispatch
+- Name routing / header vars / layout objects / block headers / table records
+- Finalizers
+- Committer / plugin ABI

--- a/docs/DXF_B3K_POLYLINE_ENTITY_PARSER_VERIFICATION.md
+++ b/docs/DXF_B3K_POLYLINE_ENTITY_PARSER_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B3k Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked set
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_view_finalizers.cpp
     dxf_table_block_finalizers.cpp
     dxf_simple_geometry_entities.cpp
+    dxf_polyline_entity_parser.cpp
     dxf_math_utils.cpp
     dxf_text_encoding.cpp
     dxf_color.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -14,6 +14,7 @@
 #include "dxf_view_finalizers.h"
 #include "dxf_table_block_finalizers.h"
 #include "dxf_simple_geometry_entities.h"
+#include "dxf_polyline_entity_parser.h"
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
@@ -1625,41 +1626,17 @@ static bool parse_dxf_entities(const std::string& path,
 
         switch (current_kind) {
             case DxfEntityKind::Polyline:
-                if (parse_entity_space(code, value_line, &current_polyline.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_polyline.owner_handle,
-                                       &current_polyline.has_owner_handle)) break;
-                if (parse_style_code(&current_polyline.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_polyline.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 70: {
-                        int flags = 0;
-                        if (parse_int(value_line, &flags)) {
-                            current_polyline.closed = (flags & 1) != 0;
-                        }
-                        break;
-                    }
-                    case 10: {
-                        double x = 0.0;
-                        if (parse_double(value_line, &x)) {
-                            pending_x = x;
-                            has_x = true;
-                        }
-                        break;
-                    }
-                    case 20: {
-                        if (!has_x) break;
-                        double y = 0.0;
-                        if (parse_double(value_line, &y)) {
-                            current_polyline.points.push_back(cadgf_vec2{pending_x, y});
-                        }
-                        has_x = false;
-                        break;
-                    }
-                    default:
-                        break;
-                }
+                parse_polyline_entity_record({
+                    &current_polyline.layer,
+                    &current_polyline.owner_handle,
+                    &current_polyline.has_owner_handle,
+                    &current_polyline.style,
+                    &current_polyline.space,
+                    &current_polyline.points,
+                    &current_polyline.closed,
+                    &pending_x,
+                    &has_x,
+                }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Line:
                 parse_line_entity_record({

--- a/plugins/dxf_polyline_entity_parser.cpp
+++ b/plugins/dxf_polyline_entity_parser.cpp
@@ -1,0 +1,50 @@
+#include "dxf_polyline_entity_parser.h"
+
+#include "dxf_parser_helpers.h"
+#include "dxf_style.h"
+#include "dxf_text_encoding.h"
+
+void parse_polyline_entity_record(const DxfPolylineParseState& state,
+                                  int code,
+                                  const std::string& value_line,
+                                  const std::string& header_codepage,
+                                  bool* has_paperspace) {
+    if (!state.layer || !state.owner_handle || !state.has_owner_handle || !state.style || !state.space ||
+        !state.points || !state.closed || !state.pending_x || !state.has_x) {
+        return;
+    }
+    if (parse_entity_space(code, value_line, state.space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, state.owner_handle, state.has_owner_handle)) return;
+    if (parse_style_code(state.style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            *state.layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 70: {
+            int flags = 0;
+            if (parse_int(value_line, &flags)) {
+                *state.closed = (flags & 1) != 0;
+            }
+            break;
+        }
+        case 10: {
+            double x = 0.0;
+            if (parse_double(value_line, &x)) {
+                *state.pending_x = x;
+                *state.has_x = true;
+            }
+            break;
+        }
+        case 20: {
+            if (!*state.has_x) break;
+            double y = 0.0;
+            if (parse_double(value_line, &y)) {
+                state.points->push_back(cadgf_vec2{*state.pending_x, y});
+            }
+            *state.has_x = false;
+            break;
+        }
+        default:
+            break;
+    }
+}

--- a/plugins/dxf_polyline_entity_parser.h
+++ b/plugins/dxf_polyline_entity_parser.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "dxf_types.h"
+
+#include <string>
+#include <vector>
+
+struct DxfPolylineParseState {
+    std::string* layer;
+    std::string* owner_handle;
+    bool* has_owner_handle;
+    DxfStyle* style;
+    int* space;
+    std::vector<cadgf_vec2>* points;
+    bool* closed;
+    double* pending_x;
+    bool* has_x;
+};
+
+void parse_polyline_entity_record(const DxfPolylineParseState& state,
+                                  int code,
+                                  const std::string& value_line,
+                                  const std::string& header_codepage,
+                                  bool* has_paperspace);


### PR DESCRIPTION
## Summary
- extract the DxfEntityKind::Polyline parser branch from `parse_dxf_entities(...)`
- add `dxf_polyline_entity_parser.*` as a leaf helper for polyline record parsing
- keep the main parser on thin wrapper call sites only

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin`
- `cmake --build build-codex --target test_dxf_importer_entities test_dxf_text_metadata test_dxf_mleader_metadata test_dxf_table_metadata test_dxf_dimension_geometry_metadata test_dxf_paperspace_insert_leader test_dxf_paperspace_insert_dimension_hatch test_dxf_paperspace_annotation_bundle test_dxf_text_alignment_partial test_dxf_text_alignment_extended test_dxf_importer_blocks test_dxf_insert_attributes test_dxf_viewport_layout_metadata test_dxf_hatch_dash test_dxf_hatch_dense_cap test_dxf_hatch_large_boundary_budget test_dxf_nonfinite_numbers test_dxf_roundtrip test_dxf_roundtrip_styles test_dxf_exporter_plugin_smoke test_dwg_importer_plugin test_dwg_matrix`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`