### PR TITLE
refactor: extract DXF ellipse entity parser

### DIFF
--- a/docs/DXF_B3L_ELLIPSE_ENTITY_PARSER_DESIGN.md
+++ b/docs/DXF_B3L_ELLIPSE_ENTITY_PARSER_DESIGN.md
@@ -1,0 +1,35 @@
+## DXF B3l: Ellipse Entity Parser Extraction
+
+### Goal
+Extract the `DxfEntityKind::Ellipse` parsing branch from `parse_dxf_entities(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_ellipse_entity_parser.h`
+- Add `plugins/dxf_ellipse_entity_parser.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract the `DxfEntityKind::Ellipse` branch.
+
+### Required invariants
+- Preserve `parse_entity_space(...)` passthrough behavior.
+- Preserve `parse_entity_owner(...)` passthrough behavior.
+- Preserve `parse_style_code(...)` passthrough behavior.
+- Preserve exact layer parsing via `sanitize_utf8(value_line, header_codepage)`.
+- Preserve exact field-to-group-code mapping:
+  - `10/20` center
+  - `11/21` major axis
+  - `40` ratio
+  - `41/42` start/end param
+- Preserve all `has_*` flag semantics and timing.
+- Preserve the main parser's `break`/`continue` behavior via thin wrapper calls only.
+
+### Out of scope
+- Polyline / Line / Point / Circle / Arc
+- Spline / Text / Solid / Hatch / Insert / Viewport
+- `flush_current(...)`
+- Zero-record dispatch
+- Name routing / header vars / layout objects / block headers / table records
+- Finalizers
+- Committer / plugin ABI

--- a/docs/DXF_B3L_ELLIPSE_ENTITY_PARSER_VERIFICATION.md
+++ b/docs/DXF_B3L_ELLIPSE_ENTITY_PARSER_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B3l Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked set
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_metadata_writer.cpp
     dxf_style.cpp
     dxf_text_handler.cpp
+    dxf_ellipse_entity_parser.cpp
 )
 target_link_libraries(cadgf_dxf_importer_plugin PRIVATE core_c)
 target_include_directories(cadgf_dxf_importer_plugin PRIVATE ${CMAKE_SOURCE_DIR}/core/include)

--- a/plugins/dxf_ellipse_entity_parser.cpp
+++ b/plugins/dxf_ellipse_entity_parser.cpp
@@ -1,0 +1,57 @@
+#include "dxf_ellipse_entity_parser.h"
+
+#include "dxf_math_utils.h"
+#include "dxf_parser_helpers.h"
+#include "dxf_style.h"
+#include "dxf_text_encoding.h"
+
+void parse_ellipse_entity_record(int code, const std::string& value_line,
+                                 DxfEllipse* ellipse, bool* has_paperspace,
+                                 const std::string& header_codepage) {
+    if (parse_entity_space(code, value_line, &ellipse->space, has_paperspace)) return;
+    if (parse_entity_owner(code, value_line, &ellipse->owner_handle,
+                           &ellipse->has_owner_handle)) return;
+    if (parse_style_code(&ellipse->style, code, value_line, header_codepage)) return;
+    switch (code) {
+        case 8:
+            ellipse->layer = sanitize_utf8(value_line, header_codepage);
+            break;
+        case 10:
+            if (parse_double(value_line, &ellipse->center.x)) {
+                ellipse->has_cx = true;
+            }
+            break;
+        case 20:
+            if (parse_double(value_line, &ellipse->center.y)) {
+                ellipse->has_cy = true;
+            }
+            break;
+        case 11:
+            if (parse_double(value_line, &ellipse->major_axis.x)) {
+                ellipse->has_ax = true;
+            }
+            break;
+        case 21:
+            if (parse_double(value_line, &ellipse->major_axis.y)) {
+                ellipse->has_ay = true;
+            }
+            break;
+        case 40:
+            if (parse_double(value_line, &ellipse->ratio)) {
+                ellipse->has_ratio = true;
+            }
+            break;
+        case 41:
+            if (parse_double(value_line, &ellipse->start_param)) {
+                ellipse->has_start = true;
+            }
+            break;
+        case 42:
+            if (parse_double(value_line, &ellipse->end_param)) {
+                ellipse->has_end = true;
+            }
+            break;
+        default:
+            break;
+    }
+}

--- a/plugins/dxf_ellipse_entity_parser.h
+++ b/plugins/dxf_ellipse_entity_parser.h
@@ -1,0 +1,15 @@
+#pragma once
+// DXF ellipse entity record parser extracted from dxf_importer_plugin.cpp.
+// Handles group codes for the ELLIPSE entity kind.
+
+#include "dxf_types.h"
+
+#include <string>
+
+// Parse a single group-code/value pair for an ELLIPSE entity.
+// Delegates space (67), owner (330), and style codes to shared helpers;
+// maps 8 -> layer, 10/20 -> center, 11/21 -> major axis, 40 -> ratio,
+// 41/42 -> start/end param.
+void parse_ellipse_entity_record(int code, const std::string& value_line,
+                                 DxfEllipse* ellipse, bool* has_paperspace,
+                                 const std::string& header_codepage);

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -18,6 +18,7 @@
 #include "dxf_text_encoding.h"
 #include "dxf_color.h"
 #include "dxf_text_handler.h"
+#include "dxf_ellipse_entity_parser.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -101,27 +102,6 @@ struct DxfArc {
     bool has_cx = false;
     bool has_cy = false;
     bool has_radius = false;
-    bool has_start = false;
-    bool has_end = false;
-    DxfStyle style;
-    int space = 0;
-};
-
-struct DxfEllipse {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 center{};
-    cadgf_vec2 major_axis{};
-    double ratio = 0.0;
-    double start_param = 0.0;
-    double end_param = 0.0;
-    bool has_cx = false;
-    bool has_cy = false;
-    bool has_ax = false;
-    bool has_ay = false;
-    bool has_ratio = false;
     bool has_start = false;
     bool has_end = false;
     DxfStyle style;
@@ -1698,52 +1678,7 @@ static bool parse_dxf_entities(const std::string& path,
                 }, code, value_line, header_codepage, &has_paperspace);
                 break;
             case DxfEntityKind::Ellipse:
-                if (parse_entity_space(code, value_line, &current_ellipse.space, &has_paperspace)) break;
-                if (parse_entity_owner(code, value_line, &current_ellipse.owner_handle,
-                                       &current_ellipse.has_owner_handle)) break;
-                if (parse_style_code(&current_ellipse.style, code, value_line, header_codepage)) break;
-                switch (code) {
-                    case 8:
-                        current_ellipse.layer = sanitize_utf8(value_line, header_codepage);
-                        break;
-                    case 10:
-                        if (parse_double(value_line, &current_ellipse.center.x)) {
-                            current_ellipse.has_cx = true;
-                        }
-                        break;
-                    case 20:
-                        if (parse_double(value_line, &current_ellipse.center.y)) {
-                            current_ellipse.has_cy = true;
-                        }
-                        break;
-                    case 11:
-                        if (parse_double(value_line, &current_ellipse.major_axis.x)) {
-                            current_ellipse.has_ax = true;
-                        }
-                        break;
-                    case 21:
-                        if (parse_double(value_line, &current_ellipse.major_axis.y)) {
-                            current_ellipse.has_ay = true;
-                        }
-                        break;
-                    case 40:
-                        if (parse_double(value_line, &current_ellipse.ratio)) {
-                            current_ellipse.has_ratio = true;
-                        }
-                        break;
-                    case 41:
-                        if (parse_double(value_line, &current_ellipse.start_param)) {
-                            current_ellipse.has_start = true;
-                        }
-                        break;
-                    case 42:
-                        if (parse_double(value_line, &current_ellipse.end_param)) {
-                            current_ellipse.has_end = true;
-                        }
-                        break;
-                    default:
-                        break;
-                }
+                parse_ellipse_entity_record(code, value_line, &current_ellipse, &has_paperspace, header_codepage);
                 break;
             case DxfEntityKind::Spline:
                 if (parse_entity_space(code, value_line, &current_spline.space, &has_paperspace)) break;

--- a/plugins/dxf_types.h
+++ b/plugins/dxf_types.h
@@ -136,6 +136,28 @@ struct DxfInsert {
     int local_group_tag = -1;
 };
 
+// ---------- DxfEllipse ------------------------------------------------------
+struct DxfEllipse {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 center{};
+    cadgf_vec2 major_axis{};
+    double ratio = 0.0;
+    double start_param = 0.0;
+    double end_param = 0.0;
+    bool has_cx = false;
+    bool has_cy = false;
+    bool has_ax = false;
+    bool has_ay = false;
+    bool has_ratio = false;
+    bool has_start = false;
+    bool has_end = false;
+    DxfStyle style;
+    int space = 0;
+};
+
 // ---------- DxfViewport / DxfView -------------------------------------------
 struct DxfViewport {
     int space = 0;


### PR DESCRIPTION
## Summary
- extract the DXF ellipse parsing branch into `dxf_ellipse_entity_parser.*`
- keep `parse_dxf_entities(...)` as a thin wrapper around the ellipse branch
- centralize the shared `DxfEllipse` type in `dxf_types.h` to match the ongoing DXF modularization direction

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`