### PR TITLE
refactor: extract DXF document commit context

### DIFF
--- a/docs/DXF_B5_DOCUMENT_COMMITTER_DESIGN.md
+++ b/docs/DXF_B5_DOCUMENT_COMMITTER_DESIGN.md
@@ -1,0 +1,51 @@
+## DXF B5: Document Committer Prelude And Layer Context
+
+### Goal
+Extract the document-committer prelude from `importer_import_document(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_document_commit_context.h`
+- Add `plugins/dxf_document_commit_context.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract the prelude/context block that currently:
+- filters paper-space viewports
+- resolves the default paper layout name
+- counts entities by space
+- computes `include_all_spaces`, `target_space`, and `default_space`
+- writes document-level DXF metadata:
+  - viewport list metadata
+  - default text height
+  - hatch stats
+  - text stats
+  - import stats / unsupported types
+  - active view metadata
+- initializes the document layer table and layer-id map
+- returns the commit-time context needed by later top-level entity emission
+
+### Required invariants
+- Preserve exact `default_space` selection behavior.
+- Preserve exact `default_paper_layout_name` resolution behavior.
+- Preserve exact `include_all_spaces` / `target_space` semantics.
+- Preserve exact metadata keys, value formatting, and omission rules for all `dxf.*` document meta writes.
+- Preserve deterministic sorting of `dxf.import.unsupported_types`.
+- Preserve layer bootstrap behavior for `"0"` and `""`.
+- Preserve layer metadata application behavior:
+  - visible
+  - locked
+  - frozen
+  - printable
+  - color
+- Preserve fallback color `0xFFFFFFu` when dynamically adding a missing layer.
+- Preserve later caller behavior by keeping `importer_import_document(...)` as a thin orchestration wrapper.
+
+### Out of scope
+- Top-level entity emission loops
+- Text-height resolution helpers for entity text emission
+- Dimension text generation
+- Block recursion / `emit_block`
+- Insert expansion / source bundle metadata
+- Parser extraction
+- Plugin ABI

--- a/docs/DXF_B5_DOCUMENT_COMMITTER_DESIGN.md
+++ b/docs/DXF_B5_DOCUMENT_COMMITTER_DESIGN.md
@@ -4,6 +4,7 @@
 Extract the document-committer prelude from `importer_import_document(...)` into a dedicated helper module without changing behavior.
 
 ### Scope
+- Add `plugins/dxf_importer_internal_types.h`
 - Add `plugins/dxf_document_commit_context.h`
 - Add `plugins/dxf_document_commit_context.cpp`
 - Update `plugins/dxf_importer_plugin.cpp`
@@ -24,6 +25,7 @@ Only extract the prelude/context block that currently:
   - active view metadata
 - initializes the document layer table and layer-id map
 - returns the commit-time context needed by later top-level entity emission
+- introduces a private importer-internal type header only as needed to share DXF importer structs with the new helper
 
 ### Required invariants
 - Preserve exact `default_space` selection behavior.

--- a/docs/DXF_B5_DOCUMENT_COMMITTER_VERIFICATION.md
+++ b/docs/DXF_B5_DOCUMENT_COMMITTER_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B5 Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked set
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_table_records.cpp
     dxf_view_finalizers.cpp
     dxf_table_block_finalizers.cpp
+    dxf_document_commit_context.cpp
     dxf_simple_geometry_entities.cpp
     dxf_polyline_entity_parser.cpp
     dxf_math_utils.cpp

--- a/plugins/dxf_document_commit_context.cpp
+++ b/plugins/dxf_document_commit_context.cpp
@@ -1,0 +1,279 @@
+#include "dxf_document_commit_context.h"
+
+#include "dxf_metadata_writer.h"
+
+#include <cctype>
+#include <algorithm>
+#include <cstdio>
+#include <utility>
+
+namespace {
+
+constexpr int kMaxHatchPatternKSteps = 5000;
+constexpr int kMaxHatchPatternEdgeChecksPerHatch = 10000000;
+constexpr int kMaxHatchPatternEdgeChecksPerDocument = 40000000;
+constexpr int kMaxHatchPatternBoundaryPointsForPattern = 20000;
+
+bool is_model_layout_name(const std::string& name) {
+    if (name.empty()) return false;
+    std::string upper;
+    upper.reserve(name.size());
+    for (char c : name) {
+        upper.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    }
+    return upper == "MODEL" || upper == "MODEL_SPACE" || upper == "*MODEL_SPACE";
+}
+
+std::vector<DxfViewport> filter_paper_viewports(const std::vector<DxfViewport>& viewports) {
+    std::vector<DxfViewport> paper_viewports;
+    if (viewports.empty()) return paper_viewports;
+    paper_viewports.reserve(viewports.size());
+    for (const auto& viewport : viewports) {
+        if (viewport.space == 1) {
+            paper_viewports.push_back(viewport);
+        }
+    }
+    return paper_viewports;
+}
+
+std::string resolve_default_paper_layout_name(const std::vector<DxfViewport>& paper_viewports,
+                                              bool has_paperspace) {
+    std::vector<std::string> names;
+    names.reserve(paper_viewports.size());
+    for (const auto& viewport : paper_viewports) {
+        if (viewport.layout.empty() || is_model_layout_name(viewport.layout)) continue;
+        if (std::find(names.begin(), names.end(), viewport.layout) == names.end()) {
+            names.push_back(viewport.layout);
+        }
+    }
+    if (names.size() == 1) {
+        return names.front();
+    }
+    if (names.empty() && (has_paperspace || !paper_viewports.empty())) {
+        return "PaperSpace";
+    }
+    return {};
+}
+
+size_t count_entities_in_space(const std::vector<DxfPolyline>& polylines,
+                               const std::vector<DxfLine>& lines,
+                               const std::vector<DxfPoint>& points,
+                               const std::vector<DxfCircle>& circles,
+                               const std::vector<DxfArc>& arcs,
+                               const std::vector<DxfEllipse>& ellipses,
+                               const std::vector<DxfSpline>& splines,
+                               const std::vector<DxfText>& texts,
+                               const std::vector<DxfInsert>& inserts,
+                               int space) {
+    size_t total = 0;
+    for (const auto& pl : polylines) total += (pl.space == space);
+    for (const auto& pt : points) total += (pt.space == space);
+    for (const auto& ln : lines) total += (ln.space == space);
+    for (const auto& circle : circles) total += (circle.space == space);
+    for (const auto& arc : arcs) total += (arc.space == space);
+    for (const auto& ellipse : ellipses) total += (ellipse.space == space);
+    for (const auto& spline : splines) total += (spline.space == space);
+    for (const auto& text : texts) total += (text.space == space);
+    for (const auto& insert : inserts) total += (insert.space == space);
+    return total;
+}
+
+void write_hatch_stats_metadata(cadgf_document* doc, const HatchPatternStats& hatch_stats) {
+    if (!doc) return;
+    char buf[64]{};
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.emitted_lines);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_emitted_lines", buf);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_clamped",
+                                        hatch_stats.clamped ? "1" : "0");
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.clamped_hatches);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_clamped_hatches", buf);
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.stride_max);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_stride_max", buf);
+    std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternKSteps);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_ksteps_limit", buf);
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.edge_checks);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks", buf);
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.edge_budget_exhausted_hatches);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_budget_exhausted_hatches", buf);
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.boundary_points_clamped_hatches);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_clamped_hatches", buf);
+    std::snprintf(buf, sizeof(buf), "%d", hatch_stats.boundary_points_max);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_max", buf);
+    std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternEdgeChecksPerHatch);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks_limit_per_hatch", buf);
+    std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternEdgeChecksPerDocument);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks_limit_per_doc", buf);
+    std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternBoundaryPointsForPattern);
+    (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_limit", buf);
+}
+
+void write_text_stats_metadata(cadgf_document* doc, const TextImportStats& text_stats) {
+    if (!doc) return;
+    char buf[64]{};
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_policy", "strict");
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.entities_seen);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.entities_seen", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.entities_emitted);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.entities_emitted", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.skipped_missing_xy);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.skipped_missing_xy", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.align_complete);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_complete", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial_x_only);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial_x_only", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial_y_only);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial_y_only", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.align_used);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.align_used", buf);
+    std::snprintf(buf, sizeof(buf), "%d", text_stats.nonfinite_values);
+    (void)cadgf_document_set_meta_value(doc, "dxf.text.nonfinite_values", buf);
+}
+
+void write_import_stats_metadata(cadgf_document* doc, const DxfImportStats& import_stats) {
+    if (!doc) return;
+    char buf[64]{};
+    std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_parsed);
+    (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_parsed", buf);
+    std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_imported);
+    (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_imported", buf);
+    std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_skipped);
+    (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_skipped", buf);
+    if (!import_stats.unsupported_types.empty()) {
+        std::string json = "{";
+        bool first = true;
+        std::vector<std::string> keys;
+        keys.reserve(import_stats.unsupported_types.size());
+        for (const auto& kv : import_stats.unsupported_types) {
+            keys.push_back(kv.first);
+        }
+        std::sort(keys.begin(), keys.end());
+        for (const auto& key : keys) {
+            if (!first) json += ",";
+            json += "\"" + key + "\":" + std::to_string(import_stats.unsupported_types.at(key));
+            first = false;
+        }
+        json += "}";
+        (void)cadgf_document_set_meta_value(doc, "dxf.import.unsupported_types", json.c_str());
+    }
+}
+
+bool apply_layer_metadata(cadgf_document* doc, int layer_id, const DxfLayer& layer) {
+    if (!cadgf_document_set_layer_visible(doc, layer_id, layer.visible ? 1 : 0)) return false;
+    if (!cadgf_document_set_layer_locked(doc, layer_id, layer.locked ? 1 : 0)) return false;
+    if (!cadgf_document_set_layer_frozen(doc, layer_id, layer.frozen ? 1 : 0)) return false;
+    if (!cadgf_document_set_layer_printable(doc, layer_id, layer.printable ? 1 : 0)) return false;
+    if (layer.style.has_color) {
+        if (!cadgf_document_set_layer_color(doc, layer_id, layer.style.color)) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+bool prepare_dxf_document_commit_context(
+    cadgf_document* doc,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfPoint>& points,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const std::vector<DxfViewport>& viewports,
+    const std::unordered_map<std::string, DxfLayer>& layers,
+    bool has_paperspace,
+    bool has_active_view,
+    const DxfView& active_view,
+    double default_text_height,
+    const HatchPatternStats& hatch_stats,
+    const TextImportStats& text_stats,
+    const DxfImportStats& import_stats,
+    DxfDocumentCommitContext* out_context,
+    std::string* out_error) {
+    if (!doc || !out_context) {
+        if (out_error) *out_error = "invalid context";
+        return false;
+    }
+
+    const std::vector<DxfViewport> paper_viewports = filter_paper_viewports(viewports);
+    const std::string default_paper_layout_name =
+        resolve_default_paper_layout_name(paper_viewports, has_paperspace);
+
+    const size_t count_space0 =
+        count_entities_in_space(polylines, lines, points, circles, arcs, ellipses, splines, texts,
+                                inserts, 0);
+    const size_t count_space1 =
+        count_entities_in_space(polylines, lines, points, circles, arcs, ellipses, splines, texts,
+                                inserts, 1);
+    const bool has_viewports = !paper_viewports.empty();
+    const bool include_all_spaces =
+        has_paperspace && count_space0 > 0 && (count_space1 > 0 || has_viewports);
+    int target_space = 0;
+    if (count_space1 > 0 && count_space0 == 0) {
+        target_space = 1;
+    } else if (has_paperspace && count_space1 > count_space0) {
+        target_space = 1;
+    }
+    if (has_viewports) {
+        target_space = 1;
+    }
+    const int default_space =
+        include_all_spaces ? (has_viewports ? 1 : ((count_space1 > count_space0) ? 1 : 0))
+                           : target_space;
+
+    (void)cadgf_document_set_meta_value(doc, "dxf.default_space", default_space == 1 ? "1" : "0");
+    write_viewport_list_metadata(doc, paper_viewports);
+    if (default_text_height > 0.0) {
+        char buf[64]{};
+        std::snprintf(buf, sizeof(buf), "%.6f", default_text_height);
+        (void)cadgf_document_set_meta_value(doc, "dxf.default_text_height", buf);
+    }
+    write_hatch_stats_metadata(doc, hatch_stats);
+    write_text_stats_metadata(doc, text_stats);
+    write_import_stats_metadata(doc, import_stats);
+    if (has_active_view) {
+        write_active_view_metadata(doc, active_view);
+    }
+
+    std::unordered_map<std::string, int> layer_ids;
+    layer_ids["0"] = 0;
+    layer_ids[""] = 0;
+
+    for (const auto& entry : layers) {
+        const std::string& layer_name = entry.first;
+        if (layer_name.empty()) continue;
+        if (layer_name == "0") {
+            if (!apply_layer_metadata(doc, 0, entry.second)) {
+                if (out_error) *out_error = "failed to apply layer metadata";
+                return false;
+            }
+            continue;
+        }
+        if (layer_ids.find(layer_name) != layer_ids.end()) continue;
+        const unsigned int color = entry.second.style.has_color ? entry.second.style.color : 0xFFFFFFu;
+        int new_id = -1;
+        if (!cadgf_document_add_layer(doc, layer_name.c_str(), color, &new_id)) {
+            if (out_error) *out_error = "failed to add layer";
+            return false;
+        }
+        layer_ids[layer_name] = new_id;
+        if (!apply_layer_metadata(doc, new_id, entry.second)) {
+            if (out_error) *out_error = "failed to apply layer metadata";
+            return false;
+        }
+    }
+
+    out_context->layer_ids = std::move(layer_ids);
+    out_context->default_paper_layout_name = default_paper_layout_name;
+    out_context->include_all_spaces = include_all_spaces;
+    out_context->target_space = target_space;
+    out_context->default_space = default_space;
+    out_context->count_space0 = count_space0;
+    out_context->count_space1 = count_space1;
+    if (out_error) out_error->clear();
+    return true;
+}

--- a/plugins/dxf_document_commit_context.h
+++ b/plugins/dxf_document_commit_context.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "dxf_importer_internal_types.h"
+#include "dxf_types.h"
+#include "dxf_table_records.h"
+#include "dxf_parser_zero_record.h"
+#include "dxf_text_handler.h"
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct DxfDocumentCommitContext {
+    std::unordered_map<std::string, int> layer_ids;
+    std::string default_paper_layout_name;
+    bool include_all_spaces = false;
+    int target_space = 0;
+    int default_space = 0;
+    size_t count_space0 = 0;
+    size_t count_space1 = 0;
+};
+
+bool prepare_dxf_document_commit_context(
+    cadgf_document* doc,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfPoint>& points,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const std::vector<DxfViewport>& viewports,
+    const std::unordered_map<std::string, DxfLayer>& layers,
+    bool has_paperspace,
+    bool has_active_view,
+    const DxfView& active_view,
+    double default_text_height,
+    const HatchPatternStats& hatch_stats,
+    const TextImportStats& text_stats,
+    const DxfImportStats& import_stats,
+    DxfDocumentCommitContext* out_context,
+    std::string* out_error);

--- a/plugins/dxf_importer_internal_types.h
+++ b/plugins/dxf_importer_internal_types.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include "dxf_types.h"
+
+#include <string>
+#include <vector>
+
+struct DxfPolyline {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    std::vector<cadgf_vec2> points;
+    bool closed = false;
+    std::string name;
+    DxfStyle style;
+    int space = 0;
+    DxfEntityOriginMeta origin_meta;
+    int local_group_tag = -1;
+};
+
+struct DxfLine {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 a{};
+    cadgf_vec2 b{};
+    bool has_ax = false;
+    bool has_ay = false;
+    bool has_bx = false;
+    bool has_by = false;
+    DxfStyle style;
+    int space = 0;
+    DxfEntityOriginMeta origin_meta;
+};
+
+struct DxfPoint {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 p{};
+    bool has_x = false;
+    bool has_y = false;
+    DxfStyle style;
+    int space = 0;
+    DxfEntityOriginMeta origin_meta;
+};
+
+struct DxfCircle {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 center{};
+    double radius = 0.0;
+    bool has_cx = false;
+    bool has_cy = false;
+    bool has_radius = false;
+    DxfStyle style;
+    int space = 0;
+};
+
+struct DxfArc {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 center{};
+    double radius = 0.0;
+    double start_deg = 0.0;
+    double end_deg = 0.0;
+    bool has_cx = false;
+    bool has_cy = false;
+    bool has_radius = false;
+    bool has_start = false;
+    bool has_end = false;
+    DxfStyle style;
+    int space = 0;
+};
+
+struct DxfSpline {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    int degree = 3;
+    std::vector<cadgf_vec2> control_points;
+    std::vector<double> knots;
+    DxfStyle style;
+    int space = 0;
+};
+
+struct DxfSolidPoint {
+    cadgf_vec2 pos{};
+    bool has_x = false;
+    bool has_y = false;
+};
+
+struct DxfSolid {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    DxfSolidPoint points[4];
+    DxfStyle style;
+    int space = 0;
+};
+
+struct DxfHatch {
+    std::string layer;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    std::vector<std::vector<cadgf_vec2>> boundaries;
+    std::string pattern_name;
+    double pattern_scale = 1.0;
+    bool has_pattern_scale = false;
+    struct PatternLine {
+        double angle_deg = 0.0;
+        double base_x = 0.0;
+        double base_y = 0.0;
+        double offset_x = 0.0;
+        double offset_y = 0.0;
+        std::vector<double> dashes;
+        bool has_angle = false;
+        bool has_base_x = false;
+        bool has_base_y = false;
+        bool has_offset_x = false;
+        bool has_offset_y = false;
+    };
+    std::vector<PatternLine> pattern_lines;
+    bool closed = true;
+    int hatch_id = -1;
+    DxfStyle style;
+    int space = 0;
+};
+
+struct HatchEdgeLine {
+    cadgf_vec2 start{};
+    cadgf_vec2 end{};
+    bool has_start_x = false;
+    bool has_start_y = false;
+    bool has_end_x = false;
+    bool has_end_y = false;
+};
+
+struct HatchEdgeArc {
+    cadgf_vec2 center{};
+    double radius = 0.0;
+    double start_deg = 0.0;
+    double end_deg = 0.0;
+    int ccw = 1;
+    bool has_cx = false;
+    bool has_cy = false;
+    bool has_radius = false;
+    bool has_start = false;
+    bool has_end = false;
+};
+
+struct HatchEdgeEllipse {
+    cadgf_vec2 center{};
+    cadgf_vec2 major_axis{};
+    double ratio = 0.0;
+    double start_param = 0.0;
+    double end_param = 0.0;
+    int ccw = 1;
+    bool has_cx = false;
+    bool has_cy = false;
+    bool has_ax = false;
+    bool has_ay = false;
+    bool has_ratio = false;
+    bool has_start = false;
+    bool has_end = false;
+};
+
+struct DxfBlock {
+    std::string name;
+    bool has_name = false;
+    std::string owner_handle;
+    bool has_owner_handle = false;
+    std::string layout_name;
+    cadgf_vec2 base{};
+    bool has_base = false;
+    std::vector<DxfPolyline> polylines;
+    std::vector<DxfLine> lines;
+    std::vector<DxfPoint> points;
+    std::vector<DxfCircle> circles;
+    std::vector<DxfArc> arcs;
+    std::vector<DxfEllipse> ellipses;
+    std::vector<DxfSpline> splines;
+    std::vector<DxfText> texts;
+    std::vector<DxfInsert> inserts;
+};
+
+struct HatchPatternStats {
+    int emitted_lines = 0;
+    bool clamped = false;
+    int clamped_hatches = 0;
+    int stride_max = 1;
+    int edge_checks = 0;
+    int edge_budget_exhausted_hatches = 0;
+    int boundary_points_clamped_hatches = 0;
+    int boundary_points_max = 0;
+};

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -12,6 +12,7 @@
 #include "dxf_layout_objects.h"
 #include "dxf_table_records.h"
 #include "dxf_view_finalizers.h"
+#include "dxf_document_commit_context.h"
 #include "dxf_table_block_finalizers.h"
 #include "dxf_simple_geometry_entities.h"
 #include "dxf_polyline_entity_parser.h"
@@ -29,203 +30,13 @@
 #include <fstream>
 #include <limits>
 #include <string>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-struct DxfPolyline {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    std::vector<cadgf_vec2> points;
-    bool closed = false;
-    std::string name;
-    DxfStyle style;
-    int space = 0;
-    DxfEntityOriginMeta origin_meta;
-    int local_group_tag = -1;
-};
-
-struct DxfLine {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 a{};
-    cadgf_vec2 b{};
-    bool has_ax = false;
-    bool has_ay = false;
-    bool has_bx = false;
-    bool has_by = false;
-    DxfStyle style;
-    int space = 0;
-    DxfEntityOriginMeta origin_meta;
-};
-
-struct DxfPoint {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 p{};
-    bool has_x = false;
-    bool has_y = false;
-    DxfStyle style;
-    int space = 0;
-    DxfEntityOriginMeta origin_meta;
-};
-
-struct DxfCircle {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 center{};
-    double radius = 0.0;
-    bool has_cx = false;
-    bool has_cy = false;
-    bool has_radius = false;
-    DxfStyle style;
-    int space = 0;
-};
-
-struct DxfArc {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 center{};
-    double radius = 0.0;
-    double start_deg = 0.0;
-    double end_deg = 0.0;
-    bool has_cx = false;
-    bool has_cy = false;
-    bool has_radius = false;
-    bool has_start = false;
-    bool has_end = false;
-    DxfStyle style;
-    int space = 0;
-};
-
-struct DxfSpline {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    int degree = 3;
-    std::vector<cadgf_vec2> control_points;
-    std::vector<double> knots;
-    DxfStyle style;
-    int space = 0;
-};
-
-struct DxfSolidPoint {
-    cadgf_vec2 pos{};
-    bool has_x = false;
-    bool has_y = false;
-};
-
-struct DxfSolid {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    DxfSolidPoint points[4];
-    DxfStyle style;
-    int space = 0;
-};
-
-struct DxfHatch {
-    std::string layer;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    std::vector<std::vector<cadgf_vec2>> boundaries;
-    std::string pattern_name;
-    double pattern_scale = 1.0;
-    bool has_pattern_scale = false;
-    struct PatternLine {
-        double angle_deg = 0.0;
-        double base_x = 0.0;
-        double base_y = 0.0;
-        double offset_x = 0.0;
-        double offset_y = 0.0;
-        std::vector<double> dashes;
-        bool has_angle = false;
-        bool has_base_x = false;
-        bool has_base_y = false;
-        bool has_offset_x = false;
-        bool has_offset_y = false;
-    };
-    std::vector<PatternLine> pattern_lines;
-    bool closed = true;
-    int hatch_id = -1;
-    DxfStyle style;
-    int space = 0;
-};
-
-struct HatchEdgeLine {
-    cadgf_vec2 start{};
-    cadgf_vec2 end{};
-    bool has_start_x = false;
-    bool has_start_y = false;
-    bool has_end_x = false;
-    bool has_end_y = false;
-};
-
-struct HatchEdgeArc {
-    cadgf_vec2 center{};
-    double radius = 0.0;
-    double start_deg = 0.0;
-    double end_deg = 0.0;
-    int ccw = 1;
-    bool has_cx = false;
-    bool has_cy = false;
-    bool has_radius = false;
-    bool has_start = false;
-    bool has_end = false;
-};
-
-struct HatchEdgeEllipse {
-    cadgf_vec2 center{};
-    cadgf_vec2 major_axis{};
-    double ratio = 0.0;
-    double start_param = 0.0;
-    double end_param = 0.0;
-    int ccw = 1;
-    bool has_cx = false;
-    bool has_cy = false;
-    bool has_ax = false;
-    bool has_ay = false;
-    bool has_ratio = false;
-    bool has_start = false;
-    bool has_end = false;
-};
-
-// DxfLayer is defined in dxf_table_records.h
-// DxfTextStyle is defined in dxf_table_records.h
-
-// DxfLayout is defined in dxf_layout_objects.h
-
-struct DxfBlock {
-    std::string name;
-    bool has_name = false;
-    std::string owner_handle;
-    bool has_owner_handle = false;
-    std::string layout_name;
-    cadgf_vec2 base{};
-    bool has_base = false;
-    std::vector<DxfPolyline> polylines;
-    std::vector<DxfLine> lines;
-    std::vector<DxfPoint> points;
-    std::vector<DxfCircle> circles;
-    std::vector<DxfArc> arcs;
-    std::vector<DxfEllipse> ellipses;
-    std::vector<DxfSpline> splines;
-    std::vector<DxfText> texts;
-    std::vector<DxfInsert> inserts;
-};
+// Internal DXF entity and block types are shared with narrow helper modules
+// via dxf_importer_internal_types.h.
 
 // kPi, kTwoPi, kDegToRad, sv(), nearly_equal(), points_nearly_equal()
 // are now provided by dxf_math_utils.h
@@ -728,17 +539,6 @@ static bool looks_nonfinite_number(const std::string& raw) {
     if (s.find("ind") != std::string::npos) return true;
     return false;
 }
-
-struct HatchPatternStats {
-    int emitted_lines = 0;
-    bool clamped = false;
-    int clamped_hatches = 0;
-    int stride_max = 1;
-    int edge_checks = 0;
-    int edge_budget_exhausted_hatches = 0;
-    int boundary_points_clamped_hatches = 0;
-    int boundary_points_max = 0;
-};
 
 // Guardrails for extreme HATCH patterns (very small spacing) to avoid long loops or line explosion.
 static constexpr int kMaxHatchPatternKSteps = 5000;
@@ -2537,192 +2337,22 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
 	            return 0;
 	        }
 
-        std::vector<DxfViewport> paper_viewports;
-        if (!viewports.empty()) {
-            paper_viewports.reserve(viewports.size());
-            for (const auto& viewport : viewports) {
-                if (viewport.space == 1) {
-                    paper_viewports.push_back(viewport);
-                }
-            }
+        DxfDocumentCommitContext commit_ctx{};
+        std::string commit_ctx_err;
+        if (!prepare_dxf_document_commit_context(doc, polylines, lines, points, circles, arcs, ellipses,
+                                                 splines, texts, inserts, viewports, layers,
+                                                 has_paperspace, has_active_view, active_view,
+                                                 default_text_height, hatch_stats, text_stats,
+                                                 import_stats, &commit_ctx, &commit_ctx_err)) {
+            set_error(out_err, 3, commit_ctx_err.empty() ? "failed to prepare commit context"
+                                                        : commit_ctx_err.c_str());
+            return 0;
         }
 
-        auto resolve_default_paper_layout_name = [&]() -> std::string {
-            std::vector<std::string> names;
-            names.reserve(paper_viewports.size());
-            for (const auto& viewport : paper_viewports) {
-                if (viewport.layout.empty() || is_model_layout_name(viewport.layout)) continue;
-                if (std::find(names.begin(), names.end(), viewport.layout) == names.end()) {
-                    names.push_back(viewport.layout);
-                }
-            }
-            if (names.size() == 1) {
-                return names.front();
-            }
-            if (names.empty() && (has_paperspace || !paper_viewports.empty())) {
-                return "PaperSpace";
-            }
-            return {};
-        };
-
-        auto count_entities_in_space = [&](int space) -> size_t {
-            size_t total = 0;
-            for (const auto& pl : polylines) total += (pl.space == space);
-            for (const auto& pt : points) total += (pt.space == space);
-            for (const auto& ln : lines) total += (ln.space == space);
-            for (const auto& circle : circles) total += (circle.space == space);
-            for (const auto& arc : arcs) total += (arc.space == space);
-            for (const auto& ellipse : ellipses) total += (ellipse.space == space);
-            for (const auto& spline : splines) total += (spline.space == space);
-            for (const auto& text : texts) total += (text.space == space);
-            for (const auto& insert : inserts) total += (insert.space == space);
-            return total;
-        };
-
-        const size_t count_space0 = count_entities_in_space(0);
-        const size_t count_space1 = count_entities_in_space(1);
-        const bool has_viewports = !paper_viewports.empty();
-        const bool include_all_spaces =
-            has_paperspace && count_space0 > 0 && (count_space1 > 0 || has_viewports);
-        int target_space = 0;
-        if (count_space1 > 0 && count_space0 == 0) {
-            target_space = 1;
-        } else if (has_paperspace && count_space1 > count_space0) {
-            target_space = 1;
-        }
-        if (has_viewports) {
-            target_space = 1;
-        }
-        const int default_space =
-            include_all_spaces ? (has_viewports ? 1 : ((count_space1 > count_space0) ? 1 : 0)) : target_space;
-        const std::string default_paper_layout_name = resolve_default_paper_layout_name();
-        (void)cadgf_document_set_meta_value(doc, "dxf.default_space",
-                                            default_space == 1 ? "1" : "0");
-	        write_viewport_list_metadata(doc, paper_viewports);
-	        if (default_text_height > 0.0) {
-	            char buf[64]{};
-	            std::snprintf(buf, sizeof(buf), "%.6f", default_text_height);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.default_text_height", buf);
-	        }
-	        {
-	            char buf[64]{};
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.emitted_lines);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_emitted_lines", buf);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_clamped",
-	                                                hatch_stats.clamped ? "1" : "0");
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.clamped_hatches);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_clamped_hatches", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.stride_max);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_stride_max", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternKSteps);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_ksteps_limit", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.edge_checks);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.edge_budget_exhausted_hatches);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_budget_exhausted_hatches", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.boundary_points_clamped_hatches);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_clamped_hatches", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", hatch_stats.boundary_points_max);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_max", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternEdgeChecksPerHatch);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks_limit_per_hatch", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternEdgeChecksPerDocument);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_edge_checks_limit_per_doc", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", kMaxHatchPatternBoundaryPointsForPattern);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.hatch_pattern_boundary_points_limit", buf);
-	        }
-	        {
-	            char buf[64]{};
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_policy", "strict");
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.entities_seen);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.entities_seen", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.entities_emitted);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.entities_emitted", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.skipped_missing_xy);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.skipped_missing_xy", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.align_complete);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_complete", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial_x_only);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial_x_only", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.align_partial_y_only);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_partial_y_only", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.align_used);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.align_used", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", text_stats.nonfinite_values);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.text.nonfinite_values", buf);
-	        }
-	        {
-	            char buf[64]{};
-	            std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_parsed);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_parsed", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_imported);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_imported", buf);
-	            std::snprintf(buf, sizeof(buf), "%d", import_stats.entities_skipped);
-	            (void)cadgf_document_set_meta_value(doc, "dxf.import.entities_skipped", buf);
-	            // Serialize unsupported_types as a JSON object string
-	            if (!import_stats.unsupported_types.empty()) {
-	                std::string json = "{";
-	                bool first = true;
-	                // Sort keys for deterministic output
-	                std::vector<std::string> keys;
-	                keys.reserve(import_stats.unsupported_types.size());
-	                for (const auto& kv : import_stats.unsupported_types) {
-	                    keys.push_back(kv.first);
-	                }
-	                std::sort(keys.begin(), keys.end());
-	                for (const auto& key : keys) {
-	                    if (!first) json += ",";
-	                    json += "\"" + key + "\":" + std::to_string(import_stats.unsupported_types.at(key));
-	                    first = false;
-	                }
-	                json += "}";
-	                (void)cadgf_document_set_meta_value(doc, "dxf.import.unsupported_types", json.c_str());
-	            }
-	        }
-	        if (has_active_view) {
-	            write_active_view_metadata(doc, active_view);
-	        }
-
-        std::unordered_map<std::string, int> layer_ids;
-        layer_ids["0"] = 0;
-        layer_ids[""] = 0;
-
-        auto apply_layer_metadata = [&](int layer_id, const DxfLayer& layer) -> bool {
-            if (!cadgf_document_set_layer_visible(doc, layer_id, layer.visible ? 1 : 0)) return false;
-            if (!cadgf_document_set_layer_locked(doc, layer_id, layer.locked ? 1 : 0)) return false;
-            if (!cadgf_document_set_layer_frozen(doc, layer_id, layer.frozen ? 1 : 0)) return false;
-            if (!cadgf_document_set_layer_printable(doc, layer_id, layer.printable ? 1 : 0)) return false;
-            if (layer.style.has_color) {
-                if (!cadgf_document_set_layer_color(doc, layer_id, layer.style.color)) return false;
-            }
-            return true;
-        };
-
-        for (const auto& entry : layers) {
-            const std::string& layer_name = entry.first;
-            if (layer_name.empty()) continue;
-            if (layer_name == "0") {
-                if (!apply_layer_metadata(0, entry.second)) {
-                    set_error(out_err, 3, "failed to apply layer metadata");
-                    return 0;
-                }
-                continue;
-            }
-            if (layer_ids.find(layer_name) != layer_ids.end()) continue;
-            const unsigned int color = entry.second.style.has_color ? entry.second.style.color : 0xFFFFFFu;
-            int new_id = -1;
-            if (!cadgf_document_add_layer(doc, layer_name.c_str(), color, &new_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            layer_ids[layer_name] = new_id;
-            if (!apply_layer_metadata(new_id, entry.second)) {
-                set_error(out_err, 3, "failed to apply layer metadata");
-                return 0;
-            }
-        }
+        const std::string& default_paper_layout_name = commit_ctx.default_paper_layout_name;
+        const bool include_all_spaces = commit_ctx.include_all_spaces;
+        const int target_space = commit_ctx.target_space;
+        std::unordered_map<std::string, int> layer_ids = std::move(commit_ctx.layer_ids);
 
         auto resolve_layer_id = [&](const std::string& layer, int* out_layer_id) -> bool {
             const std::string layer_name = layer.empty() ? "0" : layer;
@@ -3423,7 +3053,7 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
 
         if (has_paperspace && include_space(1)) {
             for (const DxfBlock* block : paper_blocks) {
-                bool should_emit = count_space1 == 0;
+                bool should_emit = commit_ctx.count_space1 == 0;
                 if (!should_emit) {
                     if (!block->layout_name.empty() && !is_model_layout_name(block->layout_name)) {
                         should_emit = top_level_paper_layouts.find(block->layout_name) ==


### PR DESCRIPTION
## Summary
- extract the document committer prelude into `dxf_document_commit_context.*`
- keep top-level entity emission loops and block recursion inside `importer_import_document(...)`
- introduce `dxf_importer_internal_types.h` as a private shared header for importer-only DXF structs needed by the new helper

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- `git diff --check`