### PR TITLE
refactor: extract DXF top-level entity committers

### DIFF
--- a/docs/DXF_B5B_TOP_LEVEL_ENTITY_COMMITTERS_DESIGN.md
+++ b/docs/DXF_B5B_TOP_LEVEL_ENTITY_COMMITTERS_DESIGN.md
@@ -1,0 +1,46 @@
+## DXF B5b: Top-Level Entity Committers
+
+### Goal
+Extract the top-level entity commit loops from `importer_import_document(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_top_level_entity_committers.h`
+- Add `plugins/dxf_top_level_entity_committers.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract the top-level entity emission block that currently commits:
+- polylines
+- lines
+- points
+- circles
+- arcs
+- ellipses
+- splines
+- text entities
+- top-level DIMENSION text emitted from inserts
+
+The new helper may depend on:
+- `DxfDocumentCommitContext`
+- `dxf_importer_internal_types.h`
+- existing metadata/style writers
+
+### Required invariants
+- Preserve exact top-level entity emission order.
+- Preserve exact layer resolution behavior and error strings.
+- Preserve exact `include_space(...)` behavior from the prepared commit context.
+- Preserve exact layout metadata behavior, including default paper layout fallback.
+- Preserve exact group assignment behavior for top-level polylines and texts.
+- Preserve exact origin metadata and text metadata writes.
+- Preserve exact line-style application behavior and default line scale threading.
+- Preserve exact DIMENSION text formatting, trimming, fallback measurement formatting, and omission behavior.
+- Keep `emit_block(...)` and later block/insert expansion logic in `dxf_importer_plugin.cpp`.
+
+### Out of scope
+- Document commit context preparation
+- Layer bootstrap/context preparation
+- Block recursion / `emit_block(...)`
+- Root block fallback emission
+- Insert expansion and source-bundle recursion
+- Plugin ABI

--- a/docs/DXF_B5B_TOP_LEVEL_ENTITY_COMMITTERS_VERIFICATION.md
+++ b/docs/DXF_B5B_TOP_LEVEL_ENTITY_COMMITTERS_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B5b Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked set
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_view_finalizers.cpp
     dxf_table_block_finalizers.cpp
     dxf_document_commit_context.cpp
+    dxf_top_level_entity_committers.cpp
     dxf_simple_geometry_entities.cpp
     dxf_polyline_entity_parser.cpp
     dxf_math_utils.cpp

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -13,6 +13,7 @@
 #include "dxf_table_records.h"
 #include "dxf_view_finalizers.h"
 #include "dxf_document_commit_context.h"
+#include "dxf_top_level_entity_committers.h"
 #include "dxf_table_block_finalizers.h"
 #include "dxf_simple_geometry_entities.h"
 #include "dxf_polyline_entity_parser.h"
@@ -2386,147 +2387,6 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             }
         };
 
-        constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
-        constexpr double kTwoPi = 6.28318530717958647692;
-        auto include_space = [&](int space) -> bool {
-            return include_all_spaces || space == target_space;
-        };
-        auto apply_group = [&](cadgf_entity_id id, int group_id) {
-            if (id == 0 || group_id < 0) return;
-            (void)cadgf_document_set_entity_group_id(doc, id, group_id);
-        };
-        std::unordered_map<int, int> top_level_local_groups;
-
-        for (const auto& pl : polylines) {
-            if (!include_space(pl.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(pl.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            if (pl.points.size() < 2) continue;
-            cadgf_entity_id id = cadgf_document_add_polyline_ex(doc, pl.points.data(),
-                                                                static_cast<int>(pl.points.size()),
-                                                                pl.name.empty() ? "" : pl.name.c_str(), layer_id);
-            apply_group(id, resolve_local_group_id(doc, top_level_local_groups, pl.local_group_tag, -1));
-            write_space_metadata(doc, id, pl.space);
-            maybe_write_layout_metadata(id, pl.space, pl.layout_name);
-            write_entity_origin_metadata(doc, id, pl.origin_meta);
-            apply_line_style(doc, id, pl.style, layer_style_for(pl.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& ln : lines) {
-            if (!include_space(ln.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(ln.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            cadgf_line line{};
-            line.a = ln.a;
-            line.b = ln.b;
-            cadgf_entity_id id = cadgf_document_add_line(doc, &line, "", layer_id);
-            write_space_metadata(doc, id, ln.space);
-            maybe_write_layout_metadata(id, ln.space, ln.layout_name);
-            write_entity_origin_metadata(doc, id, ln.origin_meta);
-            apply_line_style(doc, id, ln.style, layer_style_for(ln.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& pt_in : points) {
-            if (!include_space(pt_in.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(pt_in.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            cadgf_point pt{};
-            pt.p = pt_in.p;
-            cadgf_entity_id id = cadgf_document_add_point(doc, &pt, "", layer_id);
-            write_space_metadata(doc, id, pt_in.space);
-            maybe_write_layout_metadata(id, pt_in.space, pt_in.layout_name);
-            write_entity_origin_metadata(doc, id, pt_in.origin_meta);
-            apply_line_style(doc, id, pt_in.style, layer_style_for(pt_in.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& circle_in : circles) {
-            if (!include_space(circle_in.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(circle_in.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            cadgf_circle circle{};
-            circle.center = circle_in.center;
-            circle.radius = circle_in.radius;
-            cadgf_entity_id id = cadgf_document_add_circle(doc, &circle, "", layer_id);
-            write_space_metadata(doc, id, circle_in.space);
-            maybe_write_layout_metadata(id, circle_in.space, circle_in.layout_name);
-            apply_line_style(doc, id, circle_in.style, layer_style_for(circle_in.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& arc_in : arcs) {
-            if (!include_space(arc_in.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(arc_in.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            cadgf_arc arc{};
-            arc.center = arc_in.center;
-            arc.radius = arc_in.radius;
-            arc.start_angle = arc_in.start_deg * kDegToRad;
-            arc.end_angle = arc_in.end_deg * kDegToRad;
-            arc.clockwise = 0;
-            cadgf_entity_id id = cadgf_document_add_arc(doc, &arc, "", layer_id);
-            write_space_metadata(doc, id, arc_in.space);
-            maybe_write_layout_metadata(id, arc_in.space, arc_in.layout_name);
-            apply_line_style(doc, id, arc_in.style, layer_style_for(arc_in.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& ellipse_in : ellipses) {
-            if (!include_space(ellipse_in.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(ellipse_in.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            const double ax = ellipse_in.major_axis.x;
-            const double ay = ellipse_in.major_axis.y;
-            const double major_len = std::sqrt(ax * ax + ay * ay);
-            if (major_len <= 0.0 || ellipse_in.ratio <= 0.0) continue;
-            cadgf_ellipse ellipse{};
-            ellipse.center = ellipse_in.center;
-            ellipse.rx = major_len;
-            ellipse.ry = major_len * ellipse_in.ratio;
-            ellipse.rotation = std::atan2(ay, ax);
-            ellipse.start_angle = ellipse_in.has_start ? ellipse_in.start_param : 0.0;
-            ellipse.end_angle = ellipse_in.has_end ? ellipse_in.end_param : kTwoPi;
-            cadgf_entity_id id = cadgf_document_add_ellipse(doc, &ellipse, "", layer_id);
-            write_space_metadata(doc, id, ellipse_in.space);
-            maybe_write_layout_metadata(id, ellipse_in.space, ellipse_in.layout_name);
-            apply_line_style(doc, id, ellipse_in.style, layer_style_for(ellipse_in.layer), nullptr, default_line_scale);
-        }
-
-        for (const auto& spline_in : splines) {
-            if (!include_space(spline_in.space)) continue;
-            int layer_id = 0;
-            if (!resolve_layer_id(spline_in.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-            if (spline_in.control_points.size() < 2) continue;
-            const int degree = spline_in.degree > 0 ? spline_in.degree : 3;
-            cadgf_entity_id id = cadgf_document_add_spline(doc,
-                                                          spline_in.control_points.data(),
-                                                          static_cast<int>(spline_in.control_points.size()),
-                                                          spline_in.knots.empty() ? nullptr : spline_in.knots.data(),
-                                                          static_cast<int>(spline_in.knots.size()),
-                                                          degree, "", layer_id);
-            write_space_metadata(doc, id, spline_in.space);
-            maybe_write_layout_metadata(id, spline_in.space, spline_in.layout_name);
-            apply_line_style(doc, id, spline_in.style, layer_style_for(spline_in.layer), nullptr, default_line_scale);
-        }
-
         auto resolve_text_height = [&](const DxfText& text_in) -> double {
             double text_height = text_in.height;
             if (!(text_height > 0.0)) {
@@ -2545,82 +2405,25 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             return text_height;
         };
 
-        auto trim_ascii = [](const std::string& value) -> std::string {
-            const char* whitespace = " \t\r\n";
-            const size_t start = value.find_first_not_of(whitespace);
-            if (start == std::string::npos) return {};
-            const size_t end = value.find_last_not_of(whitespace);
-            return value.substr(start, end - start + 1);
+        constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
+        constexpr double kTwoPi = 6.28318530717958647692;
+        auto include_space = [&](int space) -> bool {
+            return include_all_spaces || space == target_space;
         };
-
-        auto format_measurement = [](double value) -> std::string {
-            char buf[64];
-            std::snprintf(buf, sizeof(buf), "%.3f", value);
-            std::string out(buf);
-            const size_t last_non_zero = out.find_last_not_of('0');
-            if (last_non_zero != std::string::npos) {
-                out.erase(last_non_zero + 1);
-            }
-            if (!out.empty() && out.back() == '.') {
-                out.pop_back();
-            }
-            return out;
+        auto apply_group = [&](cadgf_entity_id id, int group_id) {
+            if (id == 0 || group_id < 0) return;
+            (void)cadgf_document_set_entity_group_id(doc, id, group_id);
         };
+        std::unordered_map<int, int> top_level_local_groups;
 
-	        for (const auto& text_in : texts) {
-	            if (!include_space(text_in.space)) continue;
-	            int layer_id = 0;
-	            if (!resolve_layer_id(text_in.layer, &layer_id)) {
-	                set_error(out_err, 3, "failed to add layer");
-	                return 0;
-	            }
-	            // NOTE: finalize_text() applies strict alignment (only when both 11/21 exist).
-	            cadgf_vec2 pos = text_in.pos;
-	            const double rotation = text_in.rotation_deg * kDegToRad;
-	            double text_height = resolve_text_height(text_in);
-	            cadgf_entity_id id = cadgf_document_add_text(doc, &pos, text_height, rotation,
-	                                                         text_in.text.c_str(), "", layer_id);
-            apply_group(id, resolve_local_group_id(doc, top_level_local_groups, text_in.local_group_tag, -1));
-	            write_space_metadata(doc, id, text_in.space);
-            maybe_write_layout_metadata(id, text_in.space, text_in.layout_name);
-            write_entity_origin_metadata(doc, id, text_in.origin_meta);
-            write_text_metadata(doc, id, text_in);
-            apply_line_style(doc, id, text_in.style, layer_style_for(text_in.layer), nullptr, default_line_scale);
+        if (!commit_dxf_top_level_entities(doc, polylines, lines, points, circles, arcs, ellipses,
+                                           splines, texts, inserts, text_styles, layers,
+                                           default_paper_layout_name, include_all_spaces, target_space,
+                                           default_text_height, default_line_scale,
+                                           top_level_local_groups, layer_ids)) {
+            set_error(out_err, 3, "failed to add layer");
+            return 0;
         }
-
-        for (const auto& insert : inserts) {
-            if (!insert.is_dimension) continue;
-            if (!include_space(insert.space)) continue;
-
-            int layer_id = 0;
-            if (!resolve_layer_id(insert.layer, &layer_id)) {
-                set_error(out_err, 3, "failed to add layer");
-                return 0;
-            }
-
-            // NOTE: DIMENSION geometry (extension lines, dimension lines) comes from
-            // the associated *D block, which is rendered through the normal block
-            // rendering loop below. The defpoint coordinates in DIMENSION entities
-            // are in block definition space, not world coordinates.
-
-            // Generate dimension text
-            std::string dim_text = trim_ascii(insert.dim_text);
-            if (dim_text.empty() || dim_text == "<>") {
-                if (insert.has_dim_measurement) {
-                    dim_text = format_measurement(insert.dim_measurement);
-                }
-            }
-                if (!dim_text.empty()) {
-                    cadgf_vec2 pos = insert.has_dim_text_pos ? insert.dim_text_pos : insert.pos;
-                    const double text_height = default_text_height > 0.0 ? default_text_height : 1.0;
-                    cadgf_entity_id id = cadgf_document_add_text(doc, &pos, text_height, 0.0,
-                                                                 dim_text.c_str(), "", layer_id);
-                    write_space_metadata(doc, id, insert.space);
-                    maybe_write_layout_metadata(id, insert.space, insert.layout_name);
-                    write_dimension_metadata(doc, id, insert);
-                    apply_line_style(doc, id, insert.style, layer_style_for(insert.layer), nullptr, default_line_scale);
-                }
-            }
 
         auto resolve_entity_layer_name = [&](const std::string& entity_layer,
                                              const std::string& insert_layer) -> std::string {

--- a/plugins/dxf_top_level_entity_committers.cpp
+++ b/plugins/dxf_top_level_entity_committers.cpp
@@ -1,0 +1,312 @@
+#include "dxf_top_level_entity_committers.h"
+
+#include "dxf_math_utils.h"
+#include "dxf_metadata_writer.h"
+#include "dxf_style.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+
+namespace {
+
+static int resolve_local_group_id(cadgf_document* doc,
+                                  std::unordered_map<int, int>& local_to_doc_group,
+                                  int local_group_tag,
+                                  int fallback_group_id) {
+    if (!doc) return fallback_group_id;
+    if (local_group_tag < 0) return fallback_group_id;
+    auto it = local_to_doc_group.find(local_group_tag);
+    if (it != local_to_doc_group.end()) {
+        return it->second;
+    }
+    const int doc_group_id = cadgf_document_alloc_group_id(doc);
+    local_to_doc_group.emplace(local_group_tag, doc_group_id);
+    return doc_group_id;
+}
+
+static std::string trim_ascii(const std::string& value) {
+    const char* whitespace = " \t\r\n";
+    const size_t start = value.find_first_not_of(whitespace);
+    if (start == std::string::npos) return {};
+    const size_t end = value.find_last_not_of(whitespace);
+    return value.substr(start, end - start + 1);
+}
+
+static std::string format_measurement(double value) {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%.3f", value);
+    std::string out(buf);
+    const size_t last_non_zero = out.find_last_not_of('0');
+    if (last_non_zero != std::string::npos) {
+        out.erase(last_non_zero + 1);
+    }
+    if (!out.empty() && out.back() == '.') {
+        out.pop_back();
+    }
+    return out;
+}
+
+}  // namespace
+
+bool commit_dxf_top_level_entities(
+    cadgf_document* doc,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfPoint>& points,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const std::unordered_map<std::string, DxfTextStyle>& text_styles,
+    const std::unordered_map<std::string, DxfLayer>& layers,
+    const std::string& default_paper_layout_name,
+    bool include_all_spaces,
+    int target_space,
+    double default_text_height,
+    double default_line_scale,
+    std::unordered_map<int, int>& top_level_local_groups,
+    std::unordered_map<std::string, int>& layer_ids) {
+    if (!doc) return false;
+
+    auto resolve_layer_id = [&](const std::string& layer, int* out_layer_id) -> bool {
+        const std::string layer_name = layer.empty() ? "0" : layer;
+        auto it = layer_ids.find(layer_name);
+        if (it != layer_ids.end()) {
+            *out_layer_id = it->second;
+            return true;
+        }
+        int new_id = -1;
+        if (!cadgf_document_add_layer(doc, layer_name.c_str(), 0xFFFFFFu, &new_id)) {
+            return false;
+        }
+        layer_ids[layer_name] = new_id;
+        *out_layer_id = new_id;
+        return true;
+    };
+
+    auto layer_style_for = [&](const std::string& layer) -> const DxfStyle* {
+        const std::string layer_name = layer.empty() ? "0" : layer;
+        auto it = layers.find(layer_name);
+        if (it == layers.end()) return nullptr;
+        return &it->second.style;
+    };
+
+    auto maybe_write_layout_metadata = [&](cadgf_entity_id id, int space,
+                                           const std::string& layout_name = std::string()) {
+        if (space != 1) return;
+        const std::string effective_layout =
+            !layout_name.empty() ? layout_name : default_paper_layout_name;
+        if (!effective_layout.empty()) {
+            write_layout_metadata(doc, id, effective_layout);
+        }
+    };
+
+    auto include_space = [&](int space) -> bool {
+        return include_all_spaces || space == target_space;
+    };
+
+    auto apply_group = [&](cadgf_entity_id id, int group_id) {
+        if (id == 0 || group_id < 0) return;
+        (void)cadgf_document_set_entity_group_id(doc, id, group_id);
+    };
+
+    auto resolve_text_height = [&](const DxfText& text_in) -> double {
+        double text_height = text_in.height;
+        if (!(text_height > 0.0)) {
+            std::string style_name = text_in.style_name;
+            if (style_name.empty()) {
+                style_name = "STANDARD";
+            }
+            auto it = text_styles.find(style_name);
+            if (it != text_styles.end() && it->second.has_height) {
+                text_height = it->second.height;
+            }
+        }
+        if (!(text_height > 0.0)) {
+            text_height = default_text_height > 0.0 ? default_text_height : 1.0;
+        }
+        return text_height;
+    };
+
+    for (const auto& pl : polylines) {
+        if (!include_space(pl.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(pl.layer, &layer_id)) {
+            return false;
+        }
+        if (pl.points.size() < 2) continue;
+        cadgf_entity_id id = cadgf_document_add_polyline_ex(doc, pl.points.data(),
+                                                            static_cast<int>(pl.points.size()),
+                                                            pl.name.empty() ? "" : pl.name.c_str(), layer_id);
+        apply_group(id, resolve_local_group_id(doc, top_level_local_groups, pl.local_group_tag, -1));
+        write_space_metadata(doc, id, pl.space);
+        maybe_write_layout_metadata(id, pl.space, pl.layout_name);
+        write_entity_origin_metadata(doc, id, pl.origin_meta);
+        apply_line_style(doc, id, pl.style, layer_style_for(pl.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& ln : lines) {
+        if (!include_space(ln.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(ln.layer, &layer_id)) {
+            return false;
+        }
+        cadgf_line line{};
+        line.a = ln.a;
+        line.b = ln.b;
+        cadgf_entity_id id = cadgf_document_add_line(doc, &line, "", layer_id);
+        write_space_metadata(doc, id, ln.space);
+        maybe_write_layout_metadata(id, ln.space, ln.layout_name);
+        write_entity_origin_metadata(doc, id, ln.origin_meta);
+        apply_line_style(doc, id, ln.style, layer_style_for(ln.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& pt_in : points) {
+        if (!include_space(pt_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(pt_in.layer, &layer_id)) {
+            return false;
+        }
+        cadgf_point pt{};
+        pt.p = pt_in.p;
+        cadgf_entity_id id = cadgf_document_add_point(doc, &pt, "", layer_id);
+        write_space_metadata(doc, id, pt_in.space);
+        maybe_write_layout_metadata(id, pt_in.space, pt_in.layout_name);
+        write_entity_origin_metadata(doc, id, pt_in.origin_meta);
+        apply_line_style(doc, id, pt_in.style, layer_style_for(pt_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& circle_in : circles) {
+        if (!include_space(circle_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(circle_in.layer, &layer_id)) {
+            return false;
+        }
+        cadgf_circle circle{};
+        circle.center = circle_in.center;
+        circle.radius = circle_in.radius;
+        cadgf_entity_id id = cadgf_document_add_circle(doc, &circle, "", layer_id);
+        write_space_metadata(doc, id, circle_in.space);
+        maybe_write_layout_metadata(id, circle_in.space, circle_in.layout_name);
+        apply_line_style(doc, id, circle_in.style, layer_style_for(circle_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& arc_in : arcs) {
+        if (!include_space(arc_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(arc_in.layer, &layer_id)) {
+            return false;
+        }
+        cadgf_arc arc{};
+        arc.center = arc_in.center;
+        arc.radius = arc_in.radius;
+        arc.start_angle = arc_in.start_deg * kDegToRad;
+        arc.end_angle = arc_in.end_deg * kDegToRad;
+        arc.clockwise = 0;
+        cadgf_entity_id id = cadgf_document_add_arc(doc, &arc, "", layer_id);
+        write_space_metadata(doc, id, arc_in.space);
+        maybe_write_layout_metadata(id, arc_in.space, arc_in.layout_name);
+        apply_line_style(doc, id, arc_in.style, layer_style_for(arc_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& ellipse_in : ellipses) {
+        if (!include_space(ellipse_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(ellipse_in.layer, &layer_id)) {
+            return false;
+        }
+        const double ax = ellipse_in.major_axis.x;
+        const double ay = ellipse_in.major_axis.y;
+        const double major_len = std::sqrt(ax * ax + ay * ay);
+        if (major_len <= 0.0 || ellipse_in.ratio <= 0.0) continue;
+        cadgf_ellipse ellipse{};
+        ellipse.center = ellipse_in.center;
+        ellipse.rx = major_len;
+        ellipse.ry = major_len * ellipse_in.ratio;
+        ellipse.rotation = std::atan2(ay, ax);
+        ellipse.start_angle = ellipse_in.has_start ? ellipse_in.start_param : 0.0;
+        ellipse.end_angle = ellipse_in.has_end ? ellipse_in.end_param : kTwoPi;
+        cadgf_entity_id id = cadgf_document_add_ellipse(doc, &ellipse, "", layer_id);
+        write_space_metadata(doc, id, ellipse_in.space);
+        maybe_write_layout_metadata(id, ellipse_in.space, ellipse_in.layout_name);
+        apply_line_style(doc, id, ellipse_in.style, layer_style_for(ellipse_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& spline_in : splines) {
+        if (!include_space(spline_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(spline_in.layer, &layer_id)) {
+            return false;
+        }
+        if (spline_in.control_points.size() < 2) continue;
+        const int degree = spline_in.degree > 0 ? spline_in.degree : 3;
+        cadgf_entity_id id = cadgf_document_add_spline(doc,
+                                                      spline_in.control_points.data(),
+                                                      static_cast<int>(spline_in.control_points.size()),
+                                                      spline_in.knots.empty() ? nullptr : spline_in.knots.data(),
+                                                      static_cast<int>(spline_in.knots.size()),
+                                                      degree, "", layer_id);
+        write_space_metadata(doc, id, spline_in.space);
+        maybe_write_layout_metadata(id, spline_in.space, spline_in.layout_name);
+        apply_line_style(doc, id, spline_in.style, layer_style_for(spline_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& text_in : texts) {
+        if (!include_space(text_in.space)) continue;
+        int layer_id = 0;
+        if (!resolve_layer_id(text_in.layer, &layer_id)) {
+            return false;
+        }
+        // NOTE: finalize_text() applies strict alignment (only when both 11/21 exist).
+        cadgf_vec2 pos = text_in.pos;
+        const double rotation = text_in.rotation_deg * kDegToRad;
+        double text_height = resolve_text_height(text_in);
+        cadgf_entity_id id = cadgf_document_add_text(doc, &pos, text_height, rotation,
+                                                     text_in.text.c_str(), "", layer_id);
+        apply_group(id, resolve_local_group_id(doc, top_level_local_groups, text_in.local_group_tag, -1));
+        write_space_metadata(doc, id, text_in.space);
+        maybe_write_layout_metadata(id, text_in.space, text_in.layout_name);
+        write_entity_origin_metadata(doc, id, text_in.origin_meta);
+        write_text_metadata(doc, id, text_in);
+        apply_line_style(doc, id, text_in.style, layer_style_for(text_in.layer), nullptr, default_line_scale);
+    }
+
+    for (const auto& insert : inserts) {
+        if (!insert.is_dimension) continue;
+        if (!include_space(insert.space)) continue;
+
+        int layer_id = 0;
+        if (!resolve_layer_id(insert.layer, &layer_id)) {
+            return false;
+        }
+
+        // NOTE: DIMENSION geometry (extension lines, dimension lines) comes from
+        // the associated *D block, which is rendered through the normal block
+        // rendering loop below. The defpoint coordinates in DIMENSION entities
+        // are in block definition space, not world coordinates.
+
+        std::string dim_text = trim_ascii(insert.dim_text);
+        if (dim_text.empty() || dim_text == "<>") {
+            if (insert.has_dim_measurement) {
+                dim_text = format_measurement(insert.dim_measurement);
+            }
+        }
+        if (!dim_text.empty()) {
+            cadgf_vec2 pos = insert.has_dim_text_pos ? insert.dim_text_pos : insert.pos;
+            const double text_height = default_text_height > 0.0 ? default_text_height : 1.0;
+            cadgf_entity_id id = cadgf_document_add_text(doc, &pos, text_height, 0.0,
+                                                         dim_text.c_str(), "", layer_id);
+            write_space_metadata(doc, id, insert.space);
+            maybe_write_layout_metadata(id, insert.space, insert.layout_name);
+            write_dimension_metadata(doc, id, insert);
+            apply_line_style(doc, id, insert.style, layer_style_for(insert.layer), nullptr, default_line_scale);
+        }
+    }
+
+    return true;
+}

--- a/plugins/dxf_top_level_entity_committers.h
+++ b/plugins/dxf_top_level_entity_committers.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "dxf_document_commit_context.h"
+#include "dxf_table_records.h"
+#include "dxf_types.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+bool commit_dxf_top_level_entities(
+    cadgf_document* doc,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfPoint>& points,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const std::unordered_map<std::string, DxfTextStyle>& text_styles,
+    const std::unordered_map<std::string, DxfLayer>& layers,
+    const std::string& default_paper_layout_name,
+    bool include_all_spaces,
+    int target_space,
+    double default_text_height,
+    double default_line_scale,
+    std::unordered_map<int, int>& top_level_local_groups,
+    std::unordered_map<std::string, int>& layer_ids);


### PR DESCRIPTION
## Summary
- extract the top-level DXF entity commit loops into `dxf_top_level_entity_committers.*`
- keep `importer_import_document(...)` focused on orchestration and downstream block/insert expansion
- preserve top-level entity emission order, layout metadata, grouping, and style threading

## Verification
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target cadgf_dxf_importer_plugin test_dxf_importer_entities test_dxf_text_metadata test_dxf_mleader_metadata test_dxf_table_metadata test_dxf_dimension_geometry_metadata test_dxf_paperspace_insert_leader test_dxf_paperspace_insert_dimension_hatch test_dxf_paperspace_annotation_bundle test_dxf_text_alignment_partial test_dxf_text_alignment_extended test_dxf_importer_blocks test_dxf_insert_attributes test_dxf_viewport_layout_metadata test_dxf_hatch_dash test_dxf_hatch_dense_cap test_dxf_hatch_large_boundary_budget test_dxf_nonfinite_numbers test_dxf_roundtrip test_dxf_roundtrip_styles test_dxf_exporter_plugin_smoke test_dwg_importer_plugin test_dwg_matrix -j8`
- `ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
- runnable subset: `22/22` pass
- `git diff --check`