### PR TITLE
refactor: extract DXF block entity committers

### DIFF
--- a/docs/DXF_B5C_BLOCK_ENTITY_COMMITTERS_DESIGN.md
+++ b/docs/DXF_B5C_BLOCK_ENTITY_COMMITTERS_DESIGN.md
@@ -1,0 +1,44 @@
+## DXF B5c: Block Entity Committers
+
+### Goal
+Extract the recursive block-entity emission path from `importer_import_document(...)` into a dedicated helper module without changing behavior.
+
+### Scope
+- Add `plugins/dxf_block_entity_committers.h`
+- Add `plugins/dxf_block_entity_committers.cpp`
+- Update `plugins/dxf_importer_plugin.cpp`
+- Update `plugins/CMakeLists.txt`
+
+### Allowed extraction
+Only extract the recursive `emit_block(...)` path and the small helper logic tightly coupled to it:
+- `resolve_entity_layer_name(...)`
+- block-local group resolution
+- source-bundle propagation for dimension-derived entities
+- transform-sensitive block entity emission for:
+  - block polylines
+  - block lines
+  - block points
+  - block circles
+  - block arcs
+  - block ellipses
+  - block splines
+  - block texts
+  - nested inserts within blocks
+
+### Required invariants
+- Preserve exact recursive emission order inside blocks.
+- Preserve exact `kMaxBlockDepth` handling.
+- Preserve exact transform behavior for uniform and non-uniform scaling.
+- Preserve exact layer inheritance from entity layer `"0"` to insert layer.
+- Preserve exact layout metadata propagation and source-bundle metadata propagation.
+- Preserve exact insert-derived metadata behavior.
+- Preserve exact group assignment behavior for nested/local groups.
+- Preserve exact text-height scaling, rotation threading, and width metadata behavior for block text.
+- Keep `emit_root_block(...)`, fallback block selection, and top-level insert expansion orchestration in `dxf_importer_plugin.cpp`.
+
+### Out of scope
+- Document commit context preparation
+- Top-level entity committers
+- Root block fallback selection/emission
+- Top-level insert iteration in `importer_import_document(...)`
+- Plugin ABI

--- a/docs/DXF_B5C_BLOCK_ENTITY_COMMITTERS_VERIFICATION.md
+++ b/docs/DXF_B5C_BLOCK_ENTITY_COMMITTERS_VERIFICATION.md
@@ -1,0 +1,22 @@
+## DXF B5c Verification
+
+Run from the repository root.
+
+### Configure
+`cmake -S . -B build-codex`
+
+### Build
+Build:
+- `cadgf_dxf_importer_plugin`
+- runnable DXF/DWG tool tests, excluding the known baseline-blocked set
+
+### Test
+Run:
+
+`ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"`
+
+### Acceptance
+- `cadgf_dxf_importer_plugin` builds
+- runnable DXF/DWG subset passes
+- no widened failure surface versus current `main`
+- `git diff --check` is clean

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_table_block_finalizers.cpp
     dxf_document_commit_context.cpp
     dxf_top_level_entity_committers.cpp
+    dxf_block_entity_committers.cpp
     dxf_simple_geometry_entities.cpp
     dxf_polyline_entity_parser.cpp
     dxf_math_utils.cpp

--- a/plugins/dxf_block_entity_committers.cpp
+++ b/plugins/dxf_block_entity_committers.cpp
@@ -1,0 +1,537 @@
+#include "dxf_block_entity_committers.h"
+
+#include "dxf_math_utils.h"
+#include "dxf_metadata_writer.h"
+#include "dxf_style.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+static int resolve_local_group_id(cadgf_document* doc,
+                                  std::unordered_map<int, int>& local_to_doc_group,
+                                  int local_group_tag,
+                                  int fallback_group_id) {
+    if (!doc) return fallback_group_id;
+    if (local_group_tag < 0) return fallback_group_id;
+    auto it = local_to_doc_group.find(local_group_tag);
+    if (it != local_to_doc_group.end()) {
+        return it->second;
+    }
+    const int doc_group_id = cadgf_document_alloc_group_id(doc);
+    local_to_doc_group.emplace(local_group_tag, doc_group_id);
+    return doc_group_id;
+}
+
+static std::string resolve_entity_layer_name(const std::string& entity_layer,
+                                             const std::string& insert_layer) {
+    if (entity_layer.empty() || entity_layer == "0") {
+        return insert_layer.empty() ? std::string("0") : insert_layer;
+    }
+    return entity_layer;
+}
+
+}  // namespace
+
+Transform2D make_transform(double sx, double sy, double rotation_rad,
+                           const cadgf_vec2& pos, const cadgf_vec2& base) {
+    const double cos_r = std::cos(rotation_rad);
+    const double sin_r = std::sin(rotation_rad);
+    Transform2D tr;
+    tr.m00 = cos_r * sx;
+    tr.m01 = -sin_r * sy;
+    tr.m10 = sin_r * sx;
+    tr.m11 = cos_r * sy;
+    tr.t.x = pos.x - (tr.m00 * base.x + tr.m01 * base.y);
+    tr.t.y = pos.y - (tr.m10 * base.x + tr.m11 * base.y);
+    return tr;
+}
+
+Transform2D combine_transform(const Transform2D& a, const Transform2D& b) {
+    Transform2D out;
+    out.m00 = a.m00 * b.m00 + a.m01 * b.m10;
+    out.m01 = a.m00 * b.m01 + a.m01 * b.m11;
+    out.m10 = a.m10 * b.m00 + a.m11 * b.m10;
+    out.m11 = a.m10 * b.m01 + a.m11 * b.m11;
+    out.t.x = a.m00 * b.t.x + a.m01 * b.t.y + a.t.x;
+    out.t.y = a.m10 * b.t.x + a.m11 * b.t.y + a.t.y;
+    return out;
+}
+
+cadgf_vec2 apply_transform(const Transform2D& tr, const cadgf_vec2& p) {
+    cadgf_vec2 out{};
+    out.x = tr.m00 * p.x + tr.m01 * p.y + tr.t.x;
+    out.y = tr.m10 * p.x + tr.m11 * p.y + tr.t.y;
+    return out;
+}
+
+cadgf_vec2 apply_linear(const Transform2D& tr, const cadgf_vec2& p) {
+    cadgf_vec2 out{};
+    out.x = tr.m00 * p.x + tr.m01 * p.y;
+    out.y = tr.m10 * p.x + tr.m11 * p.y;
+    return out;
+}
+
+void transform_scales(const Transform2D& tr, double* out_sx, double* out_sy) {
+    if (out_sx) *out_sx = std::hypot(tr.m00, tr.m10);
+    if (out_sy) *out_sy = std::hypot(tr.m01, tr.m11);
+}
+
+bool emit_dxf_block_entities(const DxfBlockEntityCommitterContext& ctx,
+                             const DxfBlock& block,
+                             const Transform2D& tr,
+                             const std::string& insert_layer,
+                             const DxfStyle* insert_style,
+                             int group_id,
+                             int source_bundle_id,
+                             int space,
+                             const std::string& layout_name,
+                             const DxfInsert* origin_insert,
+                             std::vector<std::string>& stack,
+                             int depth,
+                             cadgf_error_v1* out_error) {
+    if (!ctx.doc || !ctx.layer_ids || !ctx.layers || !ctx.text_styles || !ctx.blocks) return false;
+    if (depth > 8) return true;
+
+    std::unordered_map<int, int> block_local_groups;
+    std::unordered_map<std::string, int> dimension_block_source_bundles;
+    auto resolve_entity_group = [&](int local_group_tag) {
+        return resolve_local_group_id(ctx.doc, block_local_groups, local_group_tag, group_id);
+    };
+    auto resolve_source_bundle_group = [&](int entity_group_id, const DxfEntityOriginMeta& meta) {
+        if (source_bundle_id >= 0) {
+            return source_bundle_id;
+        }
+        if (entity_group_id < 0 || meta.source_type != "DIMENSION" || meta.block_name.empty()) {
+            return -1;
+        }
+        auto it = dimension_block_source_bundles.find(meta.block_name);
+        if (it != dimension_block_source_bundles.end()) {
+            return it->second;
+        }
+        dimension_block_source_bundles.emplace(meta.block_name, entity_group_id);
+        return entity_group_id;
+    };
+
+    auto resolve_layer_id = [&](const std::string& layer, int* out_layer_id) -> bool {
+        const std::string layer_name = layer.empty() ? "0" : layer;
+        auto it = ctx.layer_ids->find(layer_name);
+        if (it != ctx.layer_ids->end()) {
+            *out_layer_id = it->second;
+            return true;
+        }
+        int new_id = -1;
+        if (!cadgf_document_add_layer(ctx.doc, layer_name.c_str(), 0xFFFFFFu, &new_id)) {
+            return false;
+        }
+        (*ctx.layer_ids)[layer_name] = new_id;
+        *out_layer_id = new_id;
+        return true;
+    };
+
+    auto layer_style_for = [&](const std::string& layer) -> const DxfStyle* {
+        const std::string layer_name = layer.empty() ? "0" : layer;
+        auto it = ctx.layers->find(layer_name);
+        if (it == ctx.layers->end()) return nullptr;
+        return &it->second.style;
+    };
+
+    auto maybe_write_layout_metadata = [&](cadgf_entity_id id, int emit_space,
+                                           const std::string& block_layout_name = std::string()) {
+        if (emit_space != 1) return;
+        const std::string effective_layout =
+            !block_layout_name.empty() ? block_layout_name : ctx.default_paper_layout_name;
+        if (!effective_layout.empty()) {
+            write_layout_metadata(ctx.doc, id, effective_layout);
+        }
+    };
+
+    auto resolve_text_height = [&](const DxfText& text_in) -> double {
+        double text_height = text_in.height;
+        if (!(text_height > 0.0)) {
+            std::string style_name = text_in.style_name;
+            if (style_name.empty()) {
+                style_name = "STANDARD";
+            }
+            auto it = ctx.text_styles->find(style_name);
+            if (it != ctx.text_styles->end() && it->second.has_height) {
+                text_height = it->second.height;
+            }
+        }
+        if (!(text_height > 0.0)) {
+            text_height = ctx.default_text_height > 0.0 ? ctx.default_text_height : 1.0;
+        }
+        return text_height;
+    };
+
+    const DxfEntityOriginMeta insert_origin_meta =
+        origin_insert ? build_insert_origin_metadata(*origin_insert) : DxfEntityOriginMeta{};
+
+    constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
+    constexpr double kTwoPi = 6.28318530717958647692;
+    constexpr int kMaxBlockDepth = 8;
+
+    auto emit_block = [&](auto&& self, const DxfBlock& current_block, const Transform2D& current_tr,
+                          const std::string& current_insert_layer, const DxfStyle* current_insert_style,
+                          int current_group_id, int current_source_bundle_id, int current_space,
+                          const std::string& current_layout_name, const DxfInsert* current_origin_insert,
+                          std::vector<std::string>& current_stack, int current_depth) -> bool {
+        if (current_depth > kMaxBlockDepth) return true;
+
+        std::unordered_map<int, int> current_block_local_groups;
+        std::unordered_map<std::string, int> current_dimension_block_source_bundles;
+        auto current_resolve_entity_group = [&](int local_group_tag) {
+            return resolve_local_group_id(ctx.doc, current_block_local_groups, local_group_tag,
+                                          current_group_id);
+        };
+        auto current_resolve_source_bundle_group = [&](int entity_group_id, const DxfEntityOriginMeta& meta) {
+            if (current_source_bundle_id >= 0) {
+                return current_source_bundle_id;
+            }
+            if (entity_group_id < 0 || meta.source_type != "DIMENSION" || meta.block_name.empty()) {
+                return -1;
+            }
+            auto it = current_dimension_block_source_bundles.find(meta.block_name);
+            if (it != current_dimension_block_source_bundles.end()) {
+                return it->second;
+            }
+            current_dimension_block_source_bundles.emplace(meta.block_name, entity_group_id);
+            return entity_group_id;
+        };
+
+        double scale_x = 1.0;
+        double scale_y = 1.0;
+        transform_scales(current_tr, &scale_x, &scale_y);
+        const bool uniform_scale = std::fabs(scale_x - scale_y) <= 1e-6;
+        const double rot = std::atan2(current_tr.m10, current_tr.m00);
+        const DxfEntityOriginMeta current_insert_origin_meta =
+            current_origin_insert ? build_insert_origin_metadata(*current_origin_insert) : DxfEntityOriginMeta{};
+
+        for (const auto& pl : current_block.polylines) {
+            if (pl.points.size() < 2) continue;
+            const std::string layer_name = resolve_entity_layer_name(pl.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            std::vector<cadgf_vec2> points;
+            points.reserve(pl.points.size());
+            for (const auto& p : pl.points) {
+                points.push_back(apply_transform(current_tr, p));
+            }
+            cadgf_entity_id id = cadgf_document_add_polyline_ex(
+                ctx.doc, points.data(), static_cast<int>(points.size()),
+                pl.name.empty() ? "" : pl.name.c_str(), layer_id);
+            const int entity_group_id = current_resolve_entity_group(pl.local_group_tag);
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_entity_origin_metadata(ctx.doc, id, pl.origin_meta);
+                if (current_origin_insert && pl.origin_meta.source_type.empty()) {
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                }
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, pl.origin_meta));
+                apply_line_style(ctx.doc, id, pl.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& ln : current_block.lines) {
+            const std::string layer_name = resolve_entity_layer_name(ln.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            cadgf_line line{};
+            line.a = apply_transform(current_tr, ln.a);
+            line.b = apply_transform(current_tr, ln.b);
+            cadgf_entity_id id = cadgf_document_add_line(ctx.doc, &line, "", layer_id);
+            const int entity_group_id = current_group_id;
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_entity_origin_metadata(ctx.doc, id, ln.origin_meta);
+                if (current_origin_insert && ln.origin_meta.source_type.empty()) {
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                }
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, ln.origin_meta));
+                apply_line_style(ctx.doc, id, ln.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& pt_in : current_block.points) {
+            const std::string layer_name = resolve_entity_layer_name(pt_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            cadgf_point pt{};
+            pt.p = apply_transform(current_tr, pt_in.p);
+            cadgf_entity_id id = cadgf_document_add_point(ctx.doc, &pt, "", layer_id);
+            const int entity_group_id = current_group_id;
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_entity_origin_metadata(ctx.doc, id, pt_in.origin_meta);
+                if (current_origin_insert && pt_in.origin_meta.source_type.empty()) {
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                }
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, pt_in.origin_meta));
+                apply_line_style(ctx.doc, id, pt_in.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& circle_in : current_block.circles) {
+            const std::string layer_name = resolve_entity_layer_name(circle_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            if (uniform_scale) {
+                cadgf_circle circle{};
+                circle.center = apply_transform(current_tr, circle_in.center);
+                circle.radius = circle_in.radius * scale_x;
+                cadgf_entity_id id = cadgf_document_add_circle(ctx.doc, &circle, "", layer_id);
+                const int entity_group_id = current_group_id;
+                if (id != 0) {
+                    (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                    write_space_metadata(ctx.doc, id, current_space);
+                    maybe_write_layout_metadata(id, current_space, current_layout_name);
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                    write_source_bundle_metadata(ctx.doc, id,
+                                                 current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                    apply_line_style(ctx.doc, id, circle_in.style, layer_style_for(layer_name), current_insert_style,
+                                     ctx.default_line_scale);
+                }
+            } else {
+                cadgf_ellipse ellipse{};
+                ellipse.center = apply_transform(current_tr, circle_in.center);
+                ellipse.rx = circle_in.radius * scale_x;
+                ellipse.ry = circle_in.radius * scale_y;
+                ellipse.rotation = rot;
+                ellipse.start_angle = 0.0;
+                ellipse.end_angle = kTwoPi;
+                cadgf_entity_id id = cadgf_document_add_ellipse(ctx.doc, &ellipse, "", layer_id);
+                const int entity_group_id = current_group_id;
+                if (id != 0) {
+                    (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                    write_space_metadata(ctx.doc, id, current_space);
+                    maybe_write_layout_metadata(id, current_space, current_layout_name);
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                    write_source_bundle_metadata(ctx.doc, id,
+                                                 current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                    apply_line_style(ctx.doc, id, circle_in.style, layer_style_for(layer_name), current_insert_style,
+                                     ctx.default_line_scale);
+                }
+            }
+        }
+
+        for (const auto& arc_in : current_block.arcs) {
+            const std::string layer_name = resolve_entity_layer_name(arc_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            if (uniform_scale) {
+                cadgf_arc arc{};
+                arc.center = apply_transform(current_tr, arc_in.center);
+                arc.radius = arc_in.radius * scale_x;
+                arc.start_angle = arc_in.start_deg * kDegToRad + rot;
+                arc.end_angle = arc_in.end_deg * kDegToRad + rot;
+                arc.clockwise = 0;
+                cadgf_entity_id id = cadgf_document_add_arc(ctx.doc, &arc, "", layer_id);
+                const int entity_group_id = current_group_id;
+                if (id != 0) {
+                    (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                    write_space_metadata(ctx.doc, id, current_space);
+                    maybe_write_layout_metadata(id, current_space, current_layout_name);
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                    write_source_bundle_metadata(ctx.doc, id,
+                                                 current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                    apply_line_style(ctx.doc, id, arc_in.style, layer_style_for(layer_name), current_insert_style,
+                                     ctx.default_line_scale);
+                }
+            } else {
+                cadgf_ellipse ellipse{};
+                ellipse.center = apply_transform(current_tr, arc_in.center);
+                ellipse.rx = arc_in.radius * scale_x;
+                ellipse.ry = arc_in.radius * scale_y;
+                ellipse.rotation = rot;
+                ellipse.start_angle = arc_in.start_deg * kDegToRad;
+                ellipse.end_angle = arc_in.end_deg * kDegToRad;
+                cadgf_entity_id id = cadgf_document_add_ellipse(ctx.doc, &ellipse, "", layer_id);
+                const int entity_group_id = current_group_id;
+                if (id != 0) {
+                    (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                    write_space_metadata(ctx.doc, id, current_space);
+                    maybe_write_layout_metadata(id, current_space, current_layout_name);
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                    write_source_bundle_metadata(ctx.doc, id,
+                                                 current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                    apply_line_style(ctx.doc, id, arc_in.style, layer_style_for(layer_name), current_insert_style,
+                                     ctx.default_line_scale);
+                }
+            }
+        }
+
+        for (const auto& ellipse_in : current_block.ellipses) {
+            const std::string layer_name = resolve_entity_layer_name(ellipse_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            const double ax = ellipse_in.major_axis.x;
+            const double ay = ellipse_in.major_axis.y;
+            const double major_len = std::sqrt(ax * ax + ay * ay);
+            if (major_len <= 0.0 || ellipse_in.ratio <= 0.0) continue;
+            const cadgf_vec2 major_unit{ax / major_len, ay / major_len};
+            const cadgf_vec2 minor_unit{-major_unit.y, major_unit.x};
+            const cadgf_vec2 major_vec{major_unit.x * major_len, major_unit.y * major_len};
+            const cadgf_vec2 minor_vec{minor_unit.x * major_len * ellipse_in.ratio,
+                                       minor_unit.y * major_len * ellipse_in.ratio};
+            const cadgf_vec2 major_tx = apply_linear(current_tr, major_vec);
+            const cadgf_vec2 minor_tx = apply_linear(current_tr, minor_vec);
+            cadgf_ellipse ellipse{};
+            ellipse.center = apply_transform(current_tr, ellipse_in.center);
+            ellipse.rx = std::hypot(major_tx.x, major_tx.y);
+            ellipse.ry = std::hypot(minor_tx.x, minor_tx.y);
+            ellipse.rotation = std::atan2(major_tx.y, major_tx.x);
+            ellipse.start_angle = ellipse_in.has_start ? ellipse_in.start_param : 0.0;
+            ellipse.end_angle = ellipse_in.has_end ? ellipse_in.end_param : kTwoPi;
+            cadgf_entity_id id = cadgf_document_add_ellipse(ctx.doc, &ellipse, "", layer_id);
+            const int entity_group_id = current_group_id;
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                apply_line_style(ctx.doc, id, ellipse_in.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& spline_in : current_block.splines) {
+            if (spline_in.control_points.size() < 2) continue;
+            const std::string layer_name = resolve_entity_layer_name(spline_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            std::vector<cadgf_vec2> control_points;
+            control_points.reserve(spline_in.control_points.size());
+            for (const auto& p : spline_in.control_points) {
+                control_points.push_back(apply_transform(current_tr, p));
+            }
+            const int degree = spline_in.degree > 0 ? spline_in.degree : 3;
+            cadgf_entity_id id = cadgf_document_add_spline(
+                ctx.doc, control_points.data(), static_cast<int>(control_points.size()),
+                spline_in.knots.empty() ? nullptr : spline_in.knots.data(),
+                static_cast<int>(spline_in.knots.size()), degree, "", layer_id);
+            const int entity_group_id = current_group_id;
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_insert_derived_metadata(ctx.doc, id, current_origin_insert);
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, insert_origin_meta));
+                apply_line_style(ctx.doc, id, spline_in.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& text_in : current_block.texts) {
+            const std::string layer_name = resolve_entity_layer_name(text_in.layer, current_insert_layer);
+            int layer_id = 0;
+            if (!resolve_layer_id(layer_name, &layer_id)) {
+                set_error(out_error, 3, "failed to add layer");
+                return false;
+            }
+            cadgf_vec2 base_pos = text_in.pos;
+            cadgf_vec2 pos_out = apply_transform(current_tr, base_pos);
+            const double rotation = text_in.rotation_deg * kDegToRad + rot;
+            double text_height = resolve_text_height(text_in);
+            cadgf_entity_id id = cadgf_document_add_text(ctx.doc, &pos_out, text_height * scale_y, rotation,
+                                                         text_in.text.c_str(), "", layer_id);
+            if (text_in.has_width) {
+                DxfText layout = text_in;
+                layout.width = std::fabs(text_in.width * scale_x);
+                write_text_metadata(ctx.doc, id, layout);
+            } else {
+                write_text_metadata(ctx.doc, id, text_in);
+            }
+            const int entity_group_id = current_resolve_entity_group(text_in.local_group_tag);
+            if (id != 0) {
+                (void)cadgf_document_set_entity_group_id(ctx.doc, id, entity_group_id);
+                write_space_metadata(ctx.doc, id, current_space);
+                maybe_write_layout_metadata(id, current_space, current_layout_name);
+                write_entity_origin_metadata(ctx.doc, id, text_in.origin_meta);
+                if (current_origin_insert && text_in.origin_meta.source_type.empty()) {
+                    write_insert_derived_metadata(ctx.doc, id, current_origin_insert,
+                                                  current_origin_insert && current_origin_insert->is_dimension);
+                }
+                write_source_bundle_metadata(ctx.doc, id,
+                                             current_resolve_source_bundle_group(entity_group_id, text_in.origin_meta));
+                apply_line_style(ctx.doc, id, text_in.style, layer_style_for(layer_name), current_insert_style,
+                                 ctx.default_line_scale);
+            }
+        }
+
+        for (const auto& nested_insert : current_block.inserts) {
+            if (nested_insert.block_name.empty()) continue;
+            auto nested_it = ctx.blocks->find(nested_insert.block_name);
+            if (nested_it == ctx.blocks->end()) continue;
+            const DxfBlock& nested_block = nested_it->second;
+            const std::string nested_layer =
+                (nested_insert.layer.empty() || nested_insert.layer == "0") ? current_insert_layer
+                                                                             : nested_insert.layer;
+            const bool is_dim_block = nested_insert.is_dimension || nested_block.name.rfind("*D", 0) == 0;
+            Transform2D combined;
+            if (is_dim_block) {
+                combined = Transform2D{};
+            } else {
+                const cadgf_vec2 nested_base = nested_block.has_base ? nested_block.base : cadgf_vec2{0.0, 0.0};
+                const double nested_rot = nested_insert.rotation_deg * kDegToRad;
+                const Transform2D local = make_transform(nested_insert.scale_x, nested_insert.scale_y, nested_rot,
+                                                         nested_insert.pos, nested_base);
+                combined = combine_transform(current_tr, local);
+            }
+            if (std::find(current_stack.begin(), current_stack.end(), nested_block.name) != current_stack.end()) {
+                continue;
+            }
+            current_stack.push_back(nested_block.name);
+            const int nested_group = cadgf_document_alloc_group_id(ctx.doc);
+            const DxfStyle nested_style = resolve_insert_byblock_style(nested_insert.style, current_insert_style);
+            const DxfInsert* nested_origin_insert = current_origin_insert ? current_origin_insert : &nested_insert;
+            if (!self(self, nested_block, combined, nested_layer, &nested_style, nested_group, current_source_bundle_id,
+                      current_space, current_layout_name, nested_origin_insert, current_stack, current_depth + 1)) {
+                return false;
+            }
+            current_stack.pop_back();
+        }
+
+        return true;
+    };
+
+    return emit_block(emit_block, block, tr, insert_layer, insert_style, group_id, source_bundle_id, space,
+                      layout_name, origin_insert, stack, depth);
+}

--- a/plugins/dxf_block_entity_committers.h
+++ b/plugins/dxf_block_entity_committers.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "dxf_importer_internal_types.h"
+#include "dxf_table_records.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct Transform2D {
+    double m00{1.0};
+    double m01{0.0};
+    double m10{0.0};
+    double m11{1.0};
+    cadgf_vec2 t{};
+};
+
+Transform2D make_transform(double sx, double sy, double rotation_rad,
+                           const cadgf_vec2& pos, const cadgf_vec2& base);
+Transform2D combine_transform(const Transform2D& a, const Transform2D& b);
+cadgf_vec2 apply_transform(const Transform2D& tr, const cadgf_vec2& p);
+cadgf_vec2 apply_linear(const Transform2D& tr, const cadgf_vec2& p);
+void transform_scales(const Transform2D& tr, double* out_sx, double* out_sy);
+
+struct DxfBlockEntityCommitterContext {
+    cadgf_document* doc = nullptr;
+    const std::unordered_map<std::string, DxfBlock>* blocks = nullptr;
+    const std::unordered_map<std::string, DxfLayer>* layers = nullptr;
+    const std::unordered_map<std::string, DxfTextStyle>* text_styles = nullptr;
+    std::unordered_map<std::string, int>* layer_ids = nullptr;
+    std::string default_paper_layout_name;
+    double default_line_scale = 1.0;
+    double default_text_height = 0.0;
+};
+
+bool emit_dxf_block_entities(const DxfBlockEntityCommitterContext& ctx,
+                             const DxfBlock& block,
+                             const Transform2D& tr,
+                             const std::string& insert_layer,
+                             const DxfStyle* insert_style,
+                             int group_id,
+                             int source_bundle_id,
+                             int space,
+                             const std::string& layout_name,
+                             const DxfInsert* origin_insert,
+                             std::vector<std::string>& stack,
+                             int depth,
+                             cadgf_error_v1* out_error);

--- a/plugins/dxf_importer_plugin.cpp
+++ b/plugins/dxf_importer_plugin.cpp
@@ -13,6 +13,7 @@
 #include "dxf_table_records.h"
 #include "dxf_view_finalizers.h"
 #include "dxf_document_commit_context.h"
+#include "dxf_block_entity_committers.h"
 #include "dxf_top_level_entity_committers.h"
 #include "dxf_table_block_finalizers.h"
 #include "dxf_simple_geometry_entities.h"
@@ -411,58 +412,6 @@ static void annotate_mleader_texts(std::vector<DxfText>& texts) {
             }
         }
     }
-}
-
-struct Transform2D {
-    double m00{1.0};
-    double m01{0.0};
-    double m10{0.0};
-    double m11{1.0};
-    cadgf_vec2 t{};
-};
-
-static Transform2D make_transform(double sx, double sy, double rotation_rad,
-                                  const cadgf_vec2& pos, const cadgf_vec2& base) {
-    const double cos_r = std::cos(rotation_rad);
-    const double sin_r = std::sin(rotation_rad);
-    Transform2D tr;
-    tr.m00 = cos_r * sx;
-    tr.m01 = -sin_r * sy;
-    tr.m10 = sin_r * sx;
-    tr.m11 = cos_r * sy;
-    tr.t.x = pos.x - (tr.m00 * base.x + tr.m01 * base.y);
-    tr.t.y = pos.y - (tr.m10 * base.x + tr.m11 * base.y);
-    return tr;
-}
-
-static Transform2D combine_transform(const Transform2D& a, const Transform2D& b) {
-    Transform2D out;
-    out.m00 = a.m00 * b.m00 + a.m01 * b.m10;
-    out.m01 = a.m00 * b.m01 + a.m01 * b.m11;
-    out.m10 = a.m10 * b.m00 + a.m11 * b.m10;
-    out.m11 = a.m10 * b.m01 + a.m11 * b.m11;
-    out.t.x = a.m00 * b.t.x + a.m01 * b.t.y + a.t.x;
-    out.t.y = a.m10 * b.t.x + a.m11 * b.t.y + a.t.y;
-    return out;
-}
-
-static cadgf_vec2 apply_transform(const Transform2D& tr, const cadgf_vec2& p) {
-    cadgf_vec2 out{};
-    out.x = tr.m00 * p.x + tr.m01 * p.y + tr.t.x;
-    out.y = tr.m10 * p.x + tr.m11 * p.y + tr.t.y;
-    return out;
-}
-
-static cadgf_vec2 apply_linear(const Transform2D& tr, const cadgf_vec2& p) {
-    cadgf_vec2 out{};
-    out.x = tr.m00 * p.x + tr.m01 * p.y;
-    out.y = tr.m10 * p.x + tr.m11 * p.y;
-    return out;
-}
-
-static void transform_scales(const Transform2D& tr, double* out_sx, double* out_sy) {
-    if (out_sx) *out_sx = std::hypot(tr.m00, tr.m10);
-    if (out_sy) *out_sy = std::hypot(tr.m01, tr.m11);
 }
 
 static void finalize_polyline(DxfPolyline& pl, std::vector<DxfPolyline>& out) {
@@ -2371,48 +2320,8 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             return true;
         };
 
-        auto layer_style_for = [&](const std::string& layer) -> const DxfStyle* {
-            const std::string layer_name = layer.empty() ? "0" : layer;
-            auto it = layers.find(layer_name);
-            if (it == layers.end()) return nullptr;
-            return &it->second.style;
-        };
-        auto maybe_write_layout_metadata = [&](cadgf_entity_id id, int space,
-                                              const std::string& layout_name = std::string()) {
-            if (space != 1) return;
-            const std::string effective_layout =
-                !layout_name.empty() ? layout_name : default_paper_layout_name;
-            if (!effective_layout.empty()) {
-                write_layout_metadata(doc, id, effective_layout);
-            }
-        };
-
-        auto resolve_text_height = [&](const DxfText& text_in) -> double {
-            double text_height = text_in.height;
-            if (!(text_height > 0.0)) {
-                std::string style_name = text_in.style_name;
-                if (style_name.empty()) {
-                    style_name = "STANDARD";
-                }
-                auto it = text_styles.find(style_name);
-                if (it != text_styles.end() && it->second.has_height) {
-                    text_height = it->second.height;
-                }
-            }
-            if (!(text_height > 0.0)) {
-                text_height = default_text_height > 0.0 ? default_text_height : 1.0;
-            }
-            return text_height;
-        };
-
-        constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
-        constexpr double kTwoPi = 6.28318530717958647692;
         auto include_space = [&](int space) -> bool {
             return include_all_spaces || space == target_space;
-        };
-        auto apply_group = [&](cadgf_entity_id id, int group_id) {
-            if (id == 0 || group_id < 0) return;
-            (void)cadgf_document_set_entity_group_id(doc, id, group_id);
         };
         std::unordered_map<int, int> top_level_local_groups;
 
@@ -2425,345 +2334,15 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             return 0;
         }
 
-        auto resolve_entity_layer_name = [&](const std::string& entity_layer,
-                                             const std::string& insert_layer) -> std::string {
-            if (entity_layer.empty() || entity_layer == "0") {
-                return insert_layer.empty() ? std::string("0") : insert_layer;
-            }
-            return entity_layer;
-        };
-        constexpr int kMaxBlockDepth = 8;
-
-        auto emit_block = [&](auto&& self, const DxfBlock& block, const Transform2D& tr,
-                              const std::string& insert_layer, const DxfStyle* insert_style, int group_id,
-                              int source_bundle_id, int space, const std::string& layout_name,
-                              const DxfInsert* origin_insert, std::vector<std::string>& stack,
-                              int depth) -> bool {
-            if (depth > kMaxBlockDepth) return true;
-            std::unordered_map<int, int> block_local_groups;
-            std::unordered_map<std::string, int> dimension_block_source_bundles;
-            auto resolve_entity_group = [&](int local_group_tag) {
-                return resolve_local_group_id(doc, block_local_groups, local_group_tag, group_id);
-            };
-            auto resolve_source_bundle_group = [&](int entity_group_id, const DxfEntityOriginMeta& meta) {
-                if (source_bundle_id >= 0) {
-                    return source_bundle_id;
-                }
-                if (entity_group_id < 0 || meta.source_type != "DIMENSION" || meta.block_name.empty()) {
-                    return -1;
-                }
-                auto it = dimension_block_source_bundles.find(meta.block_name);
-                if (it != dimension_block_source_bundles.end()) {
-                    return it->second;
-                }
-                dimension_block_source_bundles.emplace(meta.block_name, entity_group_id);
-                return entity_group_id;
-            };
-
-            double scale_x = 1.0;
-            double scale_y = 1.0;
-            transform_scales(tr, &scale_x, &scale_y);
-            const bool uniform_scale = std::fabs(scale_x - scale_y) <= 1e-6;
-            const double rot = std::atan2(tr.m10, tr.m00);
-            const DxfEntityOriginMeta insert_origin_meta =
-                origin_insert ? build_insert_origin_metadata(*origin_insert) : DxfEntityOriginMeta{};
-
-            for (const auto& pl : block.polylines) {
-                if (pl.points.size() < 2) continue;
-                const std::string layer_name = resolve_entity_layer_name(pl.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                std::vector<cadgf_vec2> points;
-                points.reserve(pl.points.size());
-                for (const auto& p : pl.points) {
-                    points.push_back(apply_transform(tr, p));
-                }
-                cadgf_entity_id id = cadgf_document_add_polyline_ex(doc, points.data(),
-                                                                    static_cast<int>(points.size()),
-                                                                    pl.name.empty() ? "" : pl.name.c_str(), layer_id);
-                const int entity_group_id = resolve_entity_group(pl.local_group_tag);
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_entity_origin_metadata(doc, id, pl.origin_meta);
-                if (origin_insert && pl.origin_meta.source_type.empty()) {
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                }
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, pl.origin_meta));
-                apply_line_style(doc, id, pl.style, layer_style_for(layer_name), insert_style, default_line_scale);
-            }
-
-            for (const auto& ln : block.lines) {
-                const std::string layer_name = resolve_entity_layer_name(ln.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                cadgf_line line{};
-                line.a = apply_transform(tr, ln.a);
-                line.b = apply_transform(tr, ln.b);
-                cadgf_entity_id id = cadgf_document_add_line(doc, &line, "", layer_id);
-                const int entity_group_id = group_id;
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_entity_origin_metadata(doc, id, ln.origin_meta);
-                if (origin_insert && ln.origin_meta.source_type.empty()) {
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                }
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, ln.origin_meta));
-                apply_line_style(doc, id, ln.style, layer_style_for(layer_name), insert_style, default_line_scale);
-            }
-
-            for (const auto& pt_in : block.points) {
-                const std::string layer_name = resolve_entity_layer_name(pt_in.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                cadgf_point pt{};
-                pt.p = apply_transform(tr, pt_in.p);
-                cadgf_entity_id id = cadgf_document_add_point(doc, &pt, "", layer_id);
-                const int entity_group_id = group_id;
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_entity_origin_metadata(doc, id, pt_in.origin_meta);
-                if (origin_insert && pt_in.origin_meta.source_type.empty()) {
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                }
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, pt_in.origin_meta));
-                apply_line_style(doc, id, pt_in.style, layer_style_for(layer_name), insert_style, default_line_scale);
-            }
-
-            for (const auto& circle_in : block.circles) {
-                const std::string layer_name = resolve_entity_layer_name(circle_in.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                if (uniform_scale) {
-                    cadgf_circle circle{};
-                    circle.center = apply_transform(tr, circle_in.center);
-                    circle.radius = circle_in.radius * scale_x;
-                    cadgf_entity_id id = cadgf_document_add_circle(doc, &circle, "", layer_id);
-                    const int entity_group_id = group_id;
-                    apply_group(id, entity_group_id);
-                    write_space_metadata(doc, id, space);
-                    maybe_write_layout_metadata(id, space, layout_name);
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                    write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                    apply_line_style(doc, id, circle_in.style, layer_style_for(layer_name), insert_style,
-                                     default_line_scale);
-                } else {
-                    cadgf_ellipse ellipse{};
-                    ellipse.center = apply_transform(tr, circle_in.center);
-                    ellipse.rx = circle_in.radius * scale_x;
-                    ellipse.ry = circle_in.radius * scale_y;
-                    ellipse.rotation = rot;
-                    ellipse.start_angle = 0.0;
-                    ellipse.end_angle = kTwoPi;
-                    cadgf_entity_id id = cadgf_document_add_ellipse(doc, &ellipse, "", layer_id);
-                    const int entity_group_id = group_id;
-                    apply_group(id, entity_group_id);
-                    write_space_metadata(doc, id, space);
-                    maybe_write_layout_metadata(id, space, layout_name);
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                    write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                    apply_line_style(doc, id, circle_in.style, layer_style_for(layer_name), insert_style,
-                                     default_line_scale);
-                }
-            }
-
-            for (const auto& arc_in : block.arcs) {
-                const std::string layer_name = resolve_entity_layer_name(arc_in.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                if (uniform_scale) {
-                    cadgf_arc arc{};
-                    arc.center = apply_transform(tr, arc_in.center);
-                    arc.radius = arc_in.radius * scale_x;
-                    arc.start_angle = arc_in.start_deg * kDegToRad + rot;
-                    arc.end_angle = arc_in.end_deg * kDegToRad + rot;
-                    arc.clockwise = 0;
-                    cadgf_entity_id id = cadgf_document_add_arc(doc, &arc, "", layer_id);
-                    const int entity_group_id = group_id;
-                    apply_group(id, entity_group_id);
-                    write_space_metadata(doc, id, space);
-                    maybe_write_layout_metadata(id, space, layout_name);
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                    write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                    apply_line_style(doc, id, arc_in.style, layer_style_for(layer_name), insert_style,
-                                     default_line_scale);
-                } else {
-                    cadgf_ellipse ellipse{};
-                    ellipse.center = apply_transform(tr, arc_in.center);
-                    ellipse.rx = arc_in.radius * scale_x;
-                    ellipse.ry = arc_in.radius * scale_y;
-                    ellipse.rotation = rot;
-                    ellipse.start_angle = arc_in.start_deg * kDegToRad;
-                    ellipse.end_angle = arc_in.end_deg * kDegToRad;
-                    cadgf_entity_id id = cadgf_document_add_ellipse(doc, &ellipse, "", layer_id);
-                    const int entity_group_id = group_id;
-                    apply_group(id, entity_group_id);
-                    write_space_metadata(doc, id, space);
-                    maybe_write_layout_metadata(id, space, layout_name);
-                    write_insert_derived_metadata(doc, id, origin_insert);
-                    write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                    apply_line_style(doc, id, arc_in.style, layer_style_for(layer_name), insert_style,
-                                     default_line_scale);
-                }
-            }
-
-            for (const auto& ellipse_in : block.ellipses) {
-                const std::string layer_name = resolve_entity_layer_name(ellipse_in.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                const double ax = ellipse_in.major_axis.x;
-                const double ay = ellipse_in.major_axis.y;
-                const double major_len = std::sqrt(ax * ax + ay * ay);
-                if (major_len <= 0.0 || ellipse_in.ratio <= 0.0) continue;
-                const cadgf_vec2 major_unit{ax / major_len, ay / major_len};
-                const cadgf_vec2 minor_unit{-major_unit.y, major_unit.x};
-                const cadgf_vec2 major_vec{major_unit.x * major_len, major_unit.y * major_len};
-                const cadgf_vec2 minor_vec{minor_unit.x * major_len * ellipse_in.ratio,
-                                           minor_unit.y * major_len * ellipse_in.ratio};
-                const cadgf_vec2 major_tx = apply_linear(tr, major_vec);
-                const cadgf_vec2 minor_tx = apply_linear(tr, minor_vec);
-                cadgf_ellipse ellipse{};
-                ellipse.center = apply_transform(tr, ellipse_in.center);
-                ellipse.rx = std::hypot(major_tx.x, major_tx.y);
-                ellipse.ry = std::hypot(minor_tx.x, minor_tx.y);
-                ellipse.rotation = std::atan2(major_tx.y, major_tx.x);
-                ellipse.start_angle = ellipse_in.has_start ? ellipse_in.start_param : 0.0;
-                ellipse.end_angle = ellipse_in.has_end ? ellipse_in.end_param : kTwoPi;
-                cadgf_entity_id id = cadgf_document_add_ellipse(doc, &ellipse, "", layer_id);
-                const int entity_group_id = group_id;
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_insert_derived_metadata(doc, id, origin_insert);
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                apply_line_style(doc, id, ellipse_in.style, layer_style_for(layer_name), insert_style,
-                                 default_line_scale);
-            }
-
-            for (const auto& spline_in : block.splines) {
-                if (spline_in.control_points.size() < 2) continue;
-                const std::string layer_name = resolve_entity_layer_name(spline_in.layer, insert_layer);
-                int layer_id = 0;
-                if (!resolve_layer_id(layer_name, &layer_id)) {
-                    set_error(out_err, 3, "failed to add layer");
-                    return false;
-                }
-                std::vector<cadgf_vec2> control_points;
-                control_points.reserve(spline_in.control_points.size());
-                for (const auto& p : spline_in.control_points) {
-                    control_points.push_back(apply_transform(tr, p));
-                }
-                const int degree = spline_in.degree > 0 ? spline_in.degree : 3;
-                cadgf_entity_id id = cadgf_document_add_spline(doc,
-                                                              control_points.data(),
-                                                              static_cast<int>(control_points.size()),
-                                                              spline_in.knots.empty() ? nullptr : spline_in.knots.data(),
-                                                              static_cast<int>(spline_in.knots.size()),
-                                                              degree, "", layer_id);
-                const int entity_group_id = group_id;
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_insert_derived_metadata(doc, id, origin_insert);
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, insert_origin_meta));
-                apply_line_style(doc, id, spline_in.style, layer_style_for(layer_name), insert_style,
-                                 default_line_scale);
-            }
-
-	            for (const auto& text_in : block.texts) {
-	                const std::string layer_name = resolve_entity_layer_name(text_in.layer, insert_layer);
-	                int layer_id = 0;
-	                if (!resolve_layer_id(layer_name, &layer_id)) {
-	                    set_error(out_err, 3, "failed to add layer");
-	                    return false;
-	                }
-	                // NOTE: finalize_text() applies strict alignment (only when both 11/21 exist).
-	                cadgf_vec2 base_pos = text_in.pos;
-	                cadgf_vec2 pos_out = apply_transform(tr, base_pos);
-	                const double rotation = text_in.rotation_deg * kDegToRad + rot;
-	                double text_height = resolve_text_height(text_in);
-	                cadgf_entity_id id = cadgf_document_add_text(doc, &pos_out, text_height * scale_y,
-	                                                             rotation, text_in.text.c_str(), "", layer_id);
-                if (text_in.has_width) {
-                    DxfText layout = text_in;
-                    layout.width = std::fabs(text_in.width * scale_x);
-                    write_text_metadata(doc, id, layout);
-                } else {
-                    write_text_metadata(doc, id, text_in);
-                }
-                const int entity_group_id = resolve_entity_group(text_in.local_group_tag);
-                apply_group(id, entity_group_id);
-                write_space_metadata(doc, id, space);
-                maybe_write_layout_metadata(id, space, layout_name);
-                write_entity_origin_metadata(doc, id, text_in.origin_meta);
-                if (origin_insert && text_in.origin_meta.source_type.empty()) {
-                    write_insert_derived_metadata(doc, id, origin_insert, origin_insert && origin_insert->is_dimension);
-                }
-                write_source_bundle_metadata(doc, id, resolve_source_bundle_group(entity_group_id, text_in.origin_meta));
-                apply_line_style(doc, id, text_in.style, layer_style_for(layer_name), insert_style,
-                                 default_line_scale);
-            }
-
-            for (const auto& nested_insert : block.inserts) {
-                if (nested_insert.block_name.empty()) continue;
-                auto nested_it = blocks.find(nested_insert.block_name);
-                if (nested_it == blocks.end()) continue;
-                const DxfBlock& nested_block = nested_it->second;
-                const std::string nested_layer = (nested_insert.layer.empty() || nested_insert.layer == "0")
-                                                    ? insert_layer
-                                                    : nested_insert.layer;
-                // For *D blocks (DIMENSION geometry), use identity transform
-                // because their content is already in world coordinates
-                const bool is_dim_block = nested_insert.is_dimension || nested_block.name.rfind("*D", 0) == 0;
-                Transform2D combined;
-                if (is_dim_block) {
-                    // *D blocks: use identity transform - content is already in world coordinates
-                    combined = Transform2D{};  // identity transform
-                } else {
-                    const cadgf_vec2 nested_base = nested_block.has_base ? nested_block.base : cadgf_vec2{0.0, 0.0};
-                    const double nested_rot = nested_insert.rotation_deg * kDegToRad;
-                    const Transform2D local = make_transform(nested_insert.scale_x, nested_insert.scale_y,
-                                                             nested_rot, nested_insert.pos, nested_base);
-                    combined = combine_transform(tr, local);
-                }
-                if (std::find(stack.begin(), stack.end(), nested_block.name) != stack.end()) {
-                    continue;
-                }
-                stack.push_back(nested_block.name);
-                const int nested_group = cadgf_document_alloc_group_id(doc);
-                const DxfStyle nested_style = resolve_insert_byblock_style(nested_insert.style, insert_style);
-                const DxfInsert* nested_origin_insert = origin_insert ? origin_insert : &nested_insert;
-                if (!self(self, nested_block, combined, nested_layer, &nested_style,
-                          nested_group, source_bundle_id, space, layout_name, nested_origin_insert,
-                          stack, depth + 1)) {
-                    return false;
-                }
-                stack.pop_back();
-            }
-
-            return true;
-        };
-
+        DxfBlockEntityCommitterContext block_commit_ctx{};
+        block_commit_ctx.doc = doc;
+        block_commit_ctx.blocks = &blocks;
+        block_commit_ctx.layers = &layers;
+        block_commit_ctx.text_styles = &text_styles;
+        block_commit_ctx.layer_ids = &layer_ids;
+        block_commit_ctx.default_paper_layout_name = default_paper_layout_name;
+        block_commit_ctx.default_line_scale = default_line_scale;
+        block_commit_ctx.default_text_height = default_text_height;
         const Transform2D identity{};
         std::vector<std::string> stack;
         auto block_has_entities = [](const DxfBlock& block) -> bool {
@@ -2823,9 +2402,13 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             stack.push_back(block->name);
             const int root_group = cadgf_document_alloc_group_id(doc);
             const std::string layout_name = space == 1 ? block->layout_name : std::string();
-            const bool ok = emit_block(emit_block, *block, identity, "0", nullptr, root_group,
-                                       -1, space, layout_name, nullptr, stack, 0);
+            const bool ok = emit_dxf_block_entities(block_commit_ctx, *block, identity, "0", nullptr,
+                                                    root_group, -1, space, layout_name, nullptr,
+                                                    stack, 0, out_err);
             stack.clear();
+            if (!ok) {
+                set_error(out_err, 3, "failed to emit block entities");
+            }
             return ok;
         };
         const bool has_top_level_entities =
@@ -2848,7 +2431,6 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
 
             if (fallback_block) {
                 if (!emit_root_block(fallback_block, fallback_space)) {
-                    set_error(out_err, 3, "failed to emit fallback block");
                     return 0;
                 }
             }
@@ -2867,7 +2449,6 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
                 }
                 if (!should_emit) continue;
                 if (!emit_root_block(block, 1)) {
-                    set_error(out_err, 3, "failed to emit paperspace block");
                     return 0;
                 }
             }
@@ -2909,9 +2490,9 @@ static int32_t importer_import_document(cadgf_document* doc, const char* path_ut
             } else {
                 group_id = cadgf_document_alloc_group_id(doc);
             }
-            if (!emit_block(emit_block, block, combined, insert_layer, &insert.style,
-                            group_id, insert.is_dimension ? group_id : -1,
-                            insert.space, insert.layout_name, &insert, stack, 0)) {
+            if (!emit_dxf_block_entities(block_commit_ctx, block, combined, insert_layer, &insert.style,
+                                         group_id, insert.is_dimension ? group_id : -1,
+                                         insert.space, insert.layout_name, &insert, stack, 0, out_err)) {
                 return 0;
             }
             // P2.4: annotate block reference link so downstream consumers can identify


### PR DESCRIPTION
## Summary
- extract recursive DXF block emission into dxf_block_entity_committers
- keep importer_import_document focused on top-level orchestration
- wire the new helper into the DXF importer target and preserve behavior

## Verification
- cmake --build build-codex --target cadgf_dxf_importer_plugin plus runnable DXF/DWG test targets
- ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
- git diff --check