### PR TITLE
refactor: extract DXF root block committers

### DIFF
--- a/docs/DXF_B5F_ROOT_BLOCK_COMMITTERS_DESIGN.md
+++ b/docs/DXF_B5F_ROOT_BLOCK_COMMITTERS_DESIGN.md
@@ -1,0 +1,101 @@
+# DXF B5f: Root Block Committers
+
+## Goal
+
+Extract the root-block emission path from `plugins/dxf_block_entry_committers.cpp`
+into a dedicated helper module without changing DXF import behavior.
+
+This step is intentionally narrow. It only moves the logic that:
+
+- discovers emit-worthy root blocks
+- decides which paperspace root blocks should be emitted
+- performs fallback root-block emission when there are no top-level entities
+
+It does **not** change top-level `INSERT` handling.
+
+## Scope
+
+Add:
+
+- `plugins/dxf_root_block_committers.h`
+- `plugins/dxf_root_block_committers.cpp`
+
+Update:
+
+- `plugins/dxf_block_entry_committers.cpp`
+- `plugins/CMakeLists.txt`
+
+## Extraction Boundary
+
+Move only the root-block path from `commit_dxf_block_entries(...)`, including the
+minimal local helpers it needs:
+
+- `block_has_entities(...)`
+- `find_named_block(...)`
+- paperspace block collection
+- top-level paperspace layout collection
+- `emit_root_block(...)`
+- fallback `*MODEL_SPACE` / `*PAPER_SPACE` handling when there are no top-level entities
+- paperspace root-block emission when `has_paperspace && include_space(1)`
+
+Leave in `dxf_block_entry_committers.cpp`:
+
+- `uppercase_ascii(...)`
+- `is_paper_block_name(...)`
+- `is_model_layout_name(...)`
+- `resolve_local_group_id(...)`
+- the top-level `INSERT` loop
+- group-id assignment for top-level inserts
+- top-level insert recursion entry via `emit_dxf_block_entities(...)`
+
+## Public Contract
+
+The new helper should expose one narrow entry point:
+
+- `commit_dxf_root_blocks(...)`
+
+It should receive the existing commit context pieces it needs and return `false`
+on the same failures as the current inline logic.
+
+## Invariants
+
+Preserve exactly:
+
+- fallback order:
+  - `*Model_Space`
+  - `*MODEL_SPACE`
+  - `*Paper_Space`
+  - `*PAPER_SPACE`
+- root block deduplication by block name
+- paperspace layout omission rules based on:
+  - `commit_ctx.count_space1`
+  - explicit layout-name attribution
+  - `has_unattributed_top_level_paperspace`
+- layout-name propagation into `emit_dxf_block_entities(...)`
+- `set_error(out_err, 3, "failed to emit block entities")`
+- recursion stack reset behavior around each root emission
+
+## Non-Goals
+
+Do not:
+
+- change `emit_dxf_block_entities(...)`
+- change `commit_dxf_block_entries(...)` top-level insert semantics
+- change root block selection rules
+- change metadata writing
+- change plugin ABI
+- mix this step with committer leaf emission or insert orchestration work
+
+## Notes
+
+This is the natural follow-up to:
+
+- B5c: block entity committers
+- B5d: block entry committers
+- B5e: block leaf entity emitters
+
+After this step, `dxf_block_entry_committers.cpp` should mainly own:
+
+- helper predicates
+- top-level insert orchestration
+- local-group wiring for top-level inserts

--- a/docs/DXF_B5F_ROOT_BLOCK_COMMITTERS_VERIFICATION.md
+++ b/docs/DXF_B5F_ROOT_BLOCK_COMMITTERS_VERIFICATION.md
@@ -1,0 +1,64 @@
+# DXF B5f: Root Block Committers Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/dxf-b5f-root-block-committers-cadgf`
+
+## Build
+
+```bash
+cmake -S . -B build-codex -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-codex --target \
+  cadgf_dxf_importer_plugin \
+  test_dxf_importer_entities \
+  test_dxf_text_metadata \
+  test_dxf_mleader_metadata \
+  test_dxf_table_metadata \
+  test_dxf_dimension_geometry_metadata \
+  test_dxf_paperspace_insert_leader \
+  test_dxf_paperspace_insert_dimension_hatch \
+  test_dxf_paperspace_annotation_bundle \
+  test_dxf_text_alignment_partial \
+  test_dxf_text_alignment_extended \
+  test_dxf_importer_blocks \
+  test_dxf_insert_attributes \
+  test_dxf_viewport_layout_metadata \
+  test_dxf_hatch_dash \
+  test_dxf_hatch_dense_cap \
+  test_dxf_hatch_large_boundary_budget \
+  test_dxf_nonfinite_numbers \
+  test_dxf_roundtrip \
+  test_dxf_roundtrip_styles \
+  test_dxf_exporter_plugin_smoke \
+  test_dwg_importer_plugin \
+  test_dwg_matrix \
+  -j8
+```
+
+## Targeted Runtime Verification
+
+```bash
+ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E \
+  "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+Expected:
+
+- runnable `dxf|dwg` subset passes
+- no new failures versus current `main`
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Reviewer Focus
+
+Verify that:
+
+- `dxf_block_entry_committers.cpp` no longer owns root-block emission selection
+- the helper receives enough context without introducing dependency cycles
+- fallback `*MODEL_SPACE` / `*PAPER_SPACE` order is unchanged
+- paperspace root-block omission rules are unchanged
+- top-level `INSERT` orchestration remains in `dxf_block_entry_committers.cpp`

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(cadgf_sample_plugin PROPERTIES
 add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
     dxf_block_entry_committers.cpp
+    dxf_root_block_committers.cpp
     dxf_block_leaf_entity_emitters.cpp
     dxf_block_header.cpp
     dxf_parser_helpers.cpp

--- a/plugins/dxf_block_entry_committers.cpp
+++ b/plugins/dxf_block_entry_committers.cpp
@@ -1,34 +1,11 @@
 #include "dxf_block_entry_committers.h"
 
 #include "dxf_math_utils.h"
+#include "dxf_root_block_committers.h"
 
-#include <algorithm>
-#include <cctype>
 #include <string>
-#include <unordered_set>
 
 namespace {
-
-static std::string uppercase_ascii(const std::string& value) {
-    std::string out;
-    out.reserve(value.size());
-    for (char c : value) {
-        out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
-    }
-    return out;
-}
-
-static bool is_paper_block_name(const std::string& name) {
-    if (name.empty()) return false;
-    const std::string upper = uppercase_ascii(name);
-    return upper.rfind("*PAPER_SPACE", 0) == 0;
-}
-
-static bool is_model_layout_name(const std::string& name) {
-    if (name.empty()) return false;
-    const std::string upper = uppercase_ascii(name);
-    return upper == "MODEL" || upper == "MODEL_SPACE" || upper == "*MODEL_SPACE";
-}
 
 static int resolve_local_group_id(cadgf_document* doc,
                                   std::unordered_map<int, int>& local_to_doc_group,
@@ -71,120 +48,14 @@ bool commit_dxf_block_entries(
         return include_all_spaces || space == target_space;
     };
 
+    if (!commit_dxf_root_blocks(doc, blocks, polylines, lines, circles, arcs, ellipses,
+                                splines, texts, inserts, commit_ctx, block_commit_ctx,
+                                has_paperspace, include_all_spaces, target_space, out_err)) {
+        return false;
+    }
+
     const Transform2D identity{};
     std::vector<std::string> stack;
-
-    auto block_has_entities = [](const DxfBlock& block) -> bool {
-        return !(block.polylines.empty() && block.lines.empty() && block.points.empty() &&
-                 block.circles.empty() && block.arcs.empty() && block.ellipses.empty() &&
-                 block.splines.empty() && block.texts.empty() && block.inserts.empty());
-    };
-
-    auto find_named_block = [&](const char* name) -> const DxfBlock* {
-        auto it = blocks.find(name);
-        if (it == blocks.end()) return nullptr;
-        if (!block_has_entities(it->second)) return nullptr;
-        return &it->second;
-    };
-
-    std::vector<const DxfBlock*> paper_blocks;
-    if (has_paperspace) {
-        std::vector<std::string> paper_block_names;
-        paper_block_names.reserve(blocks.size());
-        for (const auto& entry : blocks) {
-            if (!is_paper_block_name(entry.first) || !block_has_entities(entry.second)) continue;
-            paper_block_names.push_back(entry.first);
-        }
-        std::sort(paper_block_names.begin(), paper_block_names.end());
-        for (const auto& name : paper_block_names) {
-            auto it = blocks.find(name);
-            if (it == blocks.end()) continue;
-            paper_blocks.push_back(&it->second);
-        }
-    }
-
-    std::unordered_set<std::string> top_level_paper_layouts;
-    bool has_unattributed_top_level_paperspace = false;
-    auto collect_top_level_paper_layout = [&](const auto& entity) {
-        if (entity.space != 1) return;
-        if (entity.layout_name.empty() || is_model_layout_name(entity.layout_name)) {
-            has_unattributed_top_level_paperspace = true;
-            return;
-        }
-        top_level_paper_layouts.insert(entity.layout_name);
-    };
-    auto collect_top_level_paper_layouts = [&](const auto& entities) {
-        for (const auto& entity : entities) {
-            collect_top_level_paper_layout(entity);
-        }
-    };
-    collect_top_level_paper_layouts(polylines);
-    collect_top_level_paper_layouts(lines);
-    collect_top_level_paper_layouts(circles);
-    collect_top_level_paper_layouts(arcs);
-    collect_top_level_paper_layouts(ellipses);
-    collect_top_level_paper_layouts(splines);
-    collect_top_level_paper_layouts(texts);
-    collect_top_level_paper_layouts(inserts);
-
-    std::unordered_set<std::string> emitted_root_blocks;
-    auto emit_root_block = [&](const DxfBlock* block, int space) -> bool {
-        if (!block) return true;
-        if (!emitted_root_blocks.insert(block->name).second) return true;
-        stack.clear();
-        stack.push_back(block->name);
-        const int root_group = cadgf_document_alloc_group_id(doc);
-        const std::string layout_name = space == 1 ? block->layout_name : std::string();
-        const bool ok = emit_dxf_block_entities(block_commit_ctx, *block, identity, "0", nullptr,
-                                                root_group, -1, space, layout_name, nullptr,
-                                                stack, 0, out_err);
-        stack.clear();
-        if (!ok) {
-            set_error(out_err, 3, "failed to emit block entities");
-        }
-        return ok;
-    };
-
-    const bool has_top_level_entities =
-        !(polylines.empty() && lines.empty() && circles.empty() && arcs.empty() &&
-          ellipses.empty() && splines.empty() && texts.empty() && inserts.empty());
-
-    if (!has_top_level_entities) {
-        const DxfBlock* fallback_block = nullptr;
-        int fallback_space = 0;
-        fallback_block = find_named_block("*Model_Space");
-        if (!fallback_block) fallback_block = find_named_block("*MODEL_SPACE");
-        if (!fallback_block) {
-            fallback_block = find_named_block("*Paper_Space");
-            if (fallback_block) fallback_space = 1;
-        }
-        if (!fallback_block) {
-            fallback_block = find_named_block("*PAPER_SPACE");
-            if (fallback_block) fallback_space = 1;
-        }
-
-        if (fallback_block && !emit_root_block(fallback_block, fallback_space)) {
-            return false;
-        }
-    }
-
-    if (has_paperspace && include_space(1)) {
-        for (const DxfBlock* block : paper_blocks) {
-            bool should_emit = commit_ctx.count_space1 == 0;
-            if (!should_emit) {
-                if (!block->layout_name.empty() && !is_model_layout_name(block->layout_name)) {
-                    should_emit = top_level_paper_layouts.find(block->layout_name) ==
-                                  top_level_paper_layouts.end();
-                } else {
-                    should_emit = has_unattributed_top_level_paperspace;
-                }
-            }
-            if (!should_emit) continue;
-            if (!emit_root_block(block, 1)) {
-                return false;
-            }
-        }
-    }
 
     for (const auto& insert : inserts) {
         if (!include_space(insert.space)) continue;

--- a/plugins/dxf_root_block_committers.cpp
+++ b/plugins/dxf_root_block_committers.cpp
@@ -1,0 +1,175 @@
+#include "dxf_root_block_committers.h"
+
+#include "dxf_math_utils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+static std::string uppercase_ascii(const std::string& value) {
+    std::string out;
+    out.reserve(value.size());
+    for (char c : value) {
+        out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    }
+    return out;
+}
+
+static bool is_paper_block_name(const std::string& name) {
+    if (name.empty()) return false;
+    const std::string upper = uppercase_ascii(name);
+    return upper.rfind("*PAPER_SPACE", 0) == 0;
+}
+
+static bool is_model_layout_name(const std::string& name) {
+    if (name.empty()) return false;
+    const std::string upper = uppercase_ascii(name);
+    return upper == "MODEL" || upper == "MODEL_SPACE" || upper == "*MODEL_SPACE";
+}
+
+static bool block_has_entities(const DxfBlock& block) {
+    return !(block.polylines.empty() && block.lines.empty() && block.points.empty() &&
+             block.circles.empty() && block.arcs.empty() && block.ellipses.empty() &&
+             block.splines.empty() && block.texts.empty() && block.inserts.empty());
+}
+
+}  // namespace
+
+bool commit_dxf_root_blocks(
+    cadgf_document* doc,
+    const std::unordered_map<std::string, DxfBlock>& blocks,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const DxfDocumentCommitContext& commit_ctx,
+    const DxfBlockEntityCommitterContext& block_commit_ctx,
+    bool has_paperspace,
+    bool include_all_spaces,
+    int target_space,
+    cadgf_error_v1* out_err) {
+    if (!doc) return false;
+
+    auto include_space = [&](int space) -> bool {
+        return include_all_spaces || space == target_space;
+    };
+
+    const Transform2D identity{};
+    std::vector<std::string> stack;
+
+    auto find_named_block = [&](const char* name) -> const DxfBlock* {
+        auto it = blocks.find(name);
+        if (it == blocks.end()) return nullptr;
+        if (!block_has_entities(it->second)) return nullptr;
+        return &it->second;
+    };
+
+    std::vector<const DxfBlock*> paper_blocks;
+    if (has_paperspace) {
+        std::vector<std::string> paper_block_names;
+        paper_block_names.reserve(blocks.size());
+        for (const auto& entry : blocks) {
+            if (!is_paper_block_name(entry.first) || !block_has_entities(entry.second)) continue;
+            paper_block_names.push_back(entry.first);
+        }
+        std::sort(paper_block_names.begin(), paper_block_names.end());
+        for (const auto& name : paper_block_names) {
+            auto it = blocks.find(name);
+            if (it == blocks.end()) continue;
+            paper_blocks.push_back(&it->second);
+        }
+    }
+
+    std::unordered_set<std::string> top_level_paper_layouts;
+    bool has_unattributed_top_level_paperspace = false;
+    auto collect_top_level_paper_layout = [&](const auto& entity) {
+        if (entity.space != 1) return;
+        if (entity.layout_name.empty() || is_model_layout_name(entity.layout_name)) {
+            has_unattributed_top_level_paperspace = true;
+            return;
+        }
+        top_level_paper_layouts.insert(entity.layout_name);
+    };
+    auto collect_top_level_paper_layouts = [&](const auto& entities) {
+        for (const auto& entity : entities) {
+            collect_top_level_paper_layout(entity);
+        }
+    };
+    collect_top_level_paper_layouts(polylines);
+    collect_top_level_paper_layouts(lines);
+    collect_top_level_paper_layouts(circles);
+    collect_top_level_paper_layouts(arcs);
+    collect_top_level_paper_layouts(ellipses);
+    collect_top_level_paper_layouts(splines);
+    collect_top_level_paper_layouts(texts);
+    collect_top_level_paper_layouts(inserts);
+
+    std::unordered_set<std::string> emitted_root_blocks;
+    auto emit_root_block = [&](const DxfBlock* block, int space) -> bool {
+        if (!block) return true;
+        if (!emitted_root_blocks.insert(block->name).second) return true;
+        stack.clear();
+        stack.push_back(block->name);
+        const int root_group = cadgf_document_alloc_group_id(doc);
+        const std::string layout_name = space == 1 ? block->layout_name : std::string();
+        const bool ok = emit_dxf_block_entities(block_commit_ctx, *block, identity, "0", nullptr,
+                                                root_group, -1, space, layout_name, nullptr,
+                                                stack, 0, out_err);
+        stack.clear();
+        if (!ok) {
+            set_error(out_err, 3, "failed to emit block entities");
+        }
+        return ok;
+    };
+
+    const bool has_top_level_entities =
+        !(polylines.empty() && lines.empty() && circles.empty() && arcs.empty() &&
+          ellipses.empty() && splines.empty() && texts.empty() && inserts.empty());
+
+    if (!has_top_level_entities) {
+        const DxfBlock* fallback_block = nullptr;
+        int fallback_space = 0;
+        fallback_block = find_named_block("*Model_Space");
+        if (!fallback_block) fallback_block = find_named_block("*MODEL_SPACE");
+        if (!fallback_block) {
+            fallback_block = find_named_block("*Paper_Space");
+            if (fallback_block) fallback_space = 1;
+        }
+        if (!fallback_block) {
+            fallback_block = find_named_block("*PAPER_SPACE");
+            if (fallback_block) fallback_space = 1;
+        }
+
+        if (fallback_block && !emit_root_block(fallback_block, fallback_space)) {
+            return false;
+        }
+    }
+
+    if (has_paperspace && include_space(1)) {
+        for (const DxfBlock* block : paper_blocks) {
+            bool should_emit = commit_ctx.count_space1 == 0;
+            if (!should_emit) {
+                if (!block->layout_name.empty() && !is_model_layout_name(block->layout_name)) {
+                    should_emit = top_level_paper_layouts.find(block->layout_name) ==
+                                  top_level_paper_layouts.end();
+                } else {
+                    should_emit = has_unattributed_top_level_paperspace;
+                }
+            }
+            if (!should_emit) continue;
+            if (!emit_root_block(block, 1)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/plugins/dxf_root_block_committers.h
+++ b/plugins/dxf_root_block_committers.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "dxf_block_entity_committers.h"
+#include "dxf_document_commit_context.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+bool commit_dxf_root_blocks(
+    cadgf_document* doc,
+    const std::unordered_map<std::string, DxfBlock>& blocks,
+    const std::vector<DxfPolyline>& polylines,
+    const std::vector<DxfLine>& lines,
+    const std::vector<DxfCircle>& circles,
+    const std::vector<DxfArc>& arcs,
+    const std::vector<DxfEllipse>& ellipses,
+    const std::vector<DxfSpline>& splines,
+    const std::vector<DxfText>& texts,
+    const std::vector<DxfInsert>& inserts,
+    const DxfDocumentCommitContext& commit_ctx,
+    const DxfBlockEntityCommitterContext& block_commit_ctx,
+    bool has_paperspace,
+    bool include_all_spaces,
+    int target_space,
+    cadgf_error_v1* out_err);


### PR DESCRIPTION
# DXF B5f: Root Block Committers

## Goal

Extract the root-block emission path from `plugins/dxf_block_entry_committers.cpp`
into a dedicated helper module without changing DXF import behavior.

This step is intentionally narrow. It only moves the logic that:

- discovers emit-worthy root blocks
- decides which paperspace root blocks should be emitted
- performs fallback root-block emission when there are no top-level entities

It does **not** change top-level `INSERT` handling.

## Scope

Add:

- `plugins/dxf_root_block_committers.h`
- `plugins/dxf_root_block_committers.cpp`

Update:

- `plugins/dxf_block_entry_committers.cpp`
- `plugins/CMakeLists.txt`

## Extraction Boundary

Move only the root-block path from `commit_dxf_block_entries(...)`, including the
minimal local helpers it needs:

- `block_has_entities(...)`
- `find_named_block(...)`
- paperspace block collection
- top-level paperspace layout collection
- `emit_root_block(...)`
- fallback `*MODEL_SPACE` / `*PAPER_SPACE` handling when there are no top-level entities
- paperspace root-block emission when `has_paperspace && include_space(1)`

Leave in `dxf_block_entry_committers.cpp`:

- `uppercase_ascii(...)`
- `is_paper_block_name(...)`
- `is_model_layout_name(...)`
- `resolve_local_group_id(...)`
- the top-level `INSERT` loop
- group-id assignment for top-level inserts
- top-level insert recursion entry via `emit_dxf_block_entities(...)`

## Public Contract

The new helper should expose one narrow entry point:

- `commit_dxf_root_blocks(...)`

It should receive the existing commit context pieces it needs and return `false`
on the same failures as the current inline logic.

## Invariants

Preserve exactly:

- fallback order:
  - `*Model_Space`
  - `*MODEL_SPACE`
  - `*Paper_Space`
  - `*PAPER_SPACE`
- root block deduplication by block name
- paperspace layout omission rules based on:
  - `commit_ctx.count_space1`
  - explicit layout-name attribution
  - `has_unattributed_top_level_paperspace`
- layout-name propagation into `emit_dxf_block_entities(...)`
- `set_error(out_err, 3, "failed to emit block entities")`
- recursion stack reset behavior around each root emission

## Non-Goals

Do not:

- change `emit_dxf_block_entities(...)`
- change `commit_dxf_block_entries(...)` top-level insert semantics
- change root block selection rules
- change metadata writing
- change plugin ABI
- mix this step with committer leaf emission or insert orchestration work

## Notes

This is the natural follow-up to:

- B5c: block entity committers
- B5d: block entry committers
- B5e: block leaf entity emitters

After this step, `dxf_block_entry_committers.cpp` should mainly own:

- helper predicates
- top-level insert orchestration
- local-group wiring for top-level inserts
