### PR TITLE
refactor: extract DXF top-level insert committers

### DIFF
--- a/docs/DXF_B5G_TOP_LEVEL_INSERT_COMMITTERS_DESIGN.md
+++ b/docs/DXF_B5G_TOP_LEVEL_INSERT_COMMITTERS_DESIGN.md
@@ -1,0 +1,81 @@
+# DXF B5g: Top-Level Insert Committers
+
+## Goal
+
+Extract the remaining top-level `INSERT` orchestration from
+`plugins/dxf_block_entry_committers.cpp` into a dedicated helper module.
+
+This step follows B5f. After B5f, `dxf_block_entry_committers.cpp` is already
+reduced to:
+
+- root-block commit delegation
+- top-level `INSERT` orchestration
+- local-group remapping for top-level inserts
+
+B5g moves only the second half.
+
+## Scope
+
+Add:
+
+- `plugins/dxf_top_level_insert_committers.h`
+- `plugins/dxf_top_level_insert_committers.cpp`
+
+Update:
+
+- `plugins/dxf_block_entry_committers.cpp`
+- `plugins/CMakeLists.txt`
+
+## Extraction Boundary
+
+Move only the top-level `for (const auto& insert : inserts)` path, including:
+
+- `include_space(insert.space)` gating
+- block lookup by `insert.block_name`
+- dimension-block detection
+- insert-layer fallback to `"0"`
+- transform construction for top-level inserts
+- stack initialization with the referenced block name
+- local-group resolution and fallback group allocation
+- `emit_dxf_block_entities(...)` invocation for top-level inserts
+- `dxf.block_ref.<group_id>` metadata writing for non-dimension inserts
+
+Leave in `dxf_block_entry_committers.cpp`:
+
+- `resolve_local_group_id(...)`
+- delegation to `commit_dxf_root_blocks(...)`
+- the thin public `commit_dxf_block_entries(...)` wrapper
+
+## Invariants
+
+Preserve exactly:
+
+- dimension-block rule:
+  - `insert.is_dimension || block.name.rfind("*D", 0) == 0`
+- identity transform behavior for dimension blocks
+- base-point transform logic for non-dimension inserts
+- local-group reuse semantics for `insert.local_group_tag`
+- `source_bundle_id` passthrough:
+  - `insert.is_dimension ? group_id : -1`
+- `layout_name` passthrough from the top-level insert
+- `dxf.block_ref.<group_id>` metadata write only for non-dimension inserts
+
+## Non-Goals
+
+Do not:
+
+- change root-block fallback logic from B5f
+- change `emit_dxf_block_entities(...)`
+- change block recursion
+- change leaf entity emission
+- change plugin ABI
+
+## Expected End State
+
+After B5g, `dxf_block_entry_committers.cpp` should be a thin facade that:
+
+- calls `commit_dxf_root_blocks(...)`
+- calls `commit_dxf_top_level_inserts(...)`
+
+That will leave this file effectively closed out for the current B5 committer
+track.

--- a/docs/DXF_B5G_TOP_LEVEL_INSERT_COMMITTERS_VERIFICATION.md
+++ b/docs/DXF_B5G_TOP_LEVEL_INSERT_COMMITTERS_VERIFICATION.md
@@ -1,0 +1,63 @@
+# DXF B5g: Top-Level Insert Committers Verification
+
+Run from:
+
+- `/Users/huazhou/Downloads/Github/VemCAD/.worktrees/dxf-b5g-top-level-insert-committers-cadgf`
+
+## Build
+
+```bash
+cmake -S . -B build-codex -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-codex --target \
+  cadgf_dxf_importer_plugin \
+  test_dxf_importer_entities \
+  test_dxf_text_metadata \
+  test_dxf_mleader_metadata \
+  test_dxf_table_metadata \
+  test_dxf_dimension_geometry_metadata \
+  test_dxf_paperspace_insert_leader \
+  test_dxf_paperspace_insert_dimension_hatch \
+  test_dxf_paperspace_annotation_bundle \
+  test_dxf_text_alignment_partial \
+  test_dxf_text_alignment_extended \
+  test_dxf_importer_blocks \
+  test_dxf_insert_attributes \
+  test_dxf_viewport_layout_metadata \
+  test_dxf_hatch_dash \
+  test_dxf_hatch_dense_cap \
+  test_dxf_hatch_large_boundary_budget \
+  test_dxf_nonfinite_numbers \
+  test_dxf_roundtrip \
+  test_dxf_roundtrip_styles \
+  test_dxf_exporter_plugin_smoke \
+  test_dwg_importer_plugin \
+  test_dwg_matrix \
+  -j8
+```
+
+## Targeted Runtime Verification
+
+```bash
+ctest --test-dir build-codex --output-on-failure -R "dxf|dwg" -E \
+  "(convert_cli_dxf_style_smoke|test_dxf_leader_metadata_run|test_dxf_multi_layout_metadata_run|test_dxf_paperspace_insert_styles_run|test_dxf_paperspace_insert_dimension_run|test_dxf_paperspace_combo_run)"
+```
+
+Expected:
+
+- runnable `dxf|dwg` subset passes
+- no new failures versus the post-B5f baseline
+
+## Diff Hygiene
+
+```bash
+git diff --check
+```
+
+## Reviewer Focus
+
+Verify that:
+
+- `dxf_block_entry_committers.cpp` is reduced to root-block + top-level-insert delegation
+- top-level insert transform rules are unchanged
+- dimension-insert metadata and group wiring are unchanged
+- no root-block logic regresses relative to B5f

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(cadgf_dxf_importer_plugin SHARED
     dxf_importer_plugin.cpp
     dxf_block_entry_committers.cpp
     dxf_root_block_committers.cpp
+    dxf_top_level_insert_committers.cpp
     dxf_block_leaf_entity_emitters.cpp
     dxf_block_header.cpp
     dxf_parser_helpers.cpp

--- a/plugins/dxf_block_entry_committers.cpp
+++ b/plugins/dxf_block_entry_committers.cpp
@@ -1,9 +1,7 @@
 #include "dxf_block_entry_committers.h"
 
-#include "dxf_math_utils.h"
 #include "dxf_root_block_committers.h"
-
-#include <string>
+#include "dxf_top_level_insert_committers.h"
 
 namespace {
 
@@ -54,54 +52,8 @@ bool commit_dxf_block_entries(
         return false;
     }
 
-    const Transform2D identity{};
-    std::vector<std::string> stack;
-
-    for (const auto& insert : inserts) {
-        if (!include_space(insert.space)) continue;
-        if (insert.block_name.empty()) continue;
-        auto block_it = blocks.find(insert.block_name);
-        if (block_it == blocks.end()) continue;
-        const DxfBlock& block = block_it->second;
-        const bool is_dim_block = insert.is_dimension || block.name.rfind("*D", 0) == 0;
-        const std::string insert_layer =
-            (insert.layer.empty() || insert.layer == "0") ? std::string("0") : insert.layer;
-
-        Transform2D combined;
-        if (is_dim_block) {
-            combined = identity;
-        } else {
-            const cadgf_vec2 base = block.has_base ? block.base : cadgf_vec2{0.0, 0.0};
-            const Transform2D local = make_transform(insert.scale_x, insert.scale_y,
-                                                     insert.rotation_deg * kDegToRad,
-                                                     insert.pos, base);
-            combined = combine_transform(identity, local);
-        }
-
-        stack.clear();
-        stack.push_back(block.name);
-
-        int group_id = -1;
-        if (insert.local_group_tag >= 0) {
-            const int fallback_group_id = cadgf_document_alloc_group_id(doc);
-            group_id = resolve_local_group_id(doc, top_level_local_groups,
-                                              insert.local_group_tag, fallback_group_id);
-        } else {
-            group_id = cadgf_document_alloc_group_id(doc);
-        }
-
-        if (!emit_dxf_block_entities(block_commit_ctx, block, combined, insert_layer, &insert.style,
-                                     group_id, insert.is_dimension ? group_id : -1,
-                                     insert.space, insert.layout_name, &insert, stack, 0, out_err)) {
-            return false;
-        }
-
-        if (!insert.is_dimension && group_id >= 0 && !insert.block_name.empty()) {
-            const std::string ref_key =
-                "dxf.block_ref." + std::to_string(static_cast<unsigned long long>(group_id));
-            (void)cadgf_document_set_meta_value(doc, ref_key.c_str(), insert.block_name.c_str());
-        }
-    }
-
-    return true;
+    return commit_dxf_top_level_inserts(doc, blocks, inserts, block_commit_ctx,
+                                        include_all_spaces, target_space,
+                                        top_level_local_groups, &resolve_local_group_id,
+                                        out_err);
 }

--- a/plugins/dxf_top_level_insert_committers.cpp
+++ b/plugins/dxf_top_level_insert_committers.cpp
@@ -1,0 +1,74 @@
+#include "dxf_top_level_insert_committers.h"
+
+#include "dxf_math_utils.h"
+
+#include <string>
+#include <vector>
+
+bool commit_dxf_top_level_inserts(
+    cadgf_document* doc,
+    const std::unordered_map<std::string, DxfBlock>& blocks,
+    const std::vector<DxfInsert>& inserts,
+    const DxfBlockEntityCommitterContext& block_commit_ctx,
+    bool include_all_spaces,
+    int target_space,
+    std::unordered_map<int, int>& top_level_local_groups,
+    DxfResolveLocalGroupIdFn resolve_local_group_id,
+    cadgf_error_v1* out_err) {
+    if (!doc || !resolve_local_group_id) return false;
+
+    auto include_space = [&](int space) -> bool {
+        return include_all_spaces || space == target_space;
+    };
+
+    const Transform2D identity{};
+    std::vector<std::string> stack;
+
+    for (const auto& insert : inserts) {
+        if (!include_space(insert.space)) continue;
+        if (insert.block_name.empty()) continue;
+        auto block_it = blocks.find(insert.block_name);
+        if (block_it == blocks.end()) continue;
+        const DxfBlock& block = block_it->second;
+        const bool is_dim_block = insert.is_dimension || block.name.rfind("*D", 0) == 0;
+        const std::string insert_layer =
+            (insert.layer.empty() || insert.layer == "0") ? std::string("0") : insert.layer;
+
+        Transform2D combined;
+        if (is_dim_block) {
+            combined = identity;
+        } else {
+            const cadgf_vec2 base = block.has_base ? block.base : cadgf_vec2{0.0, 0.0};
+            const Transform2D local = make_transform(insert.scale_x, insert.scale_y,
+                                                     insert.rotation_deg * kDegToRad,
+                                                     insert.pos, base);
+            combined = combine_transform(identity, local);
+        }
+
+        stack.clear();
+        stack.push_back(block.name);
+
+        int group_id = -1;
+        if (insert.local_group_tag >= 0) {
+            const int fallback_group_id = cadgf_document_alloc_group_id(doc);
+            group_id = resolve_local_group_id(doc, top_level_local_groups,
+                                              insert.local_group_tag, fallback_group_id);
+        } else {
+            group_id = cadgf_document_alloc_group_id(doc);
+        }
+
+        if (!emit_dxf_block_entities(block_commit_ctx, block, combined, insert_layer, &insert.style,
+                                     group_id, insert.is_dimension ? group_id : -1,
+                                     insert.space, insert.layout_name, &insert, stack, 0, out_err)) {
+            return false;
+        }
+
+        if (!insert.is_dimension && group_id >= 0 && !insert.block_name.empty()) {
+            const std::string ref_key =
+                "dxf.block_ref." + std::to_string(static_cast<unsigned long long>(group_id));
+            (void)cadgf_document_set_meta_value(doc, ref_key.c_str(), insert.block_name.c_str());
+        }
+    }
+
+    return true;
+}

--- a/plugins/dxf_top_level_insert_committers.h
+++ b/plugins/dxf_top_level_insert_committers.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "dxf_block_entity_committers.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using DxfResolveLocalGroupIdFn = int (*)(cadgf_document*,
+                                         std::unordered_map<int, int>&,
+                                         int,
+                                         int);
+
+bool commit_dxf_top_level_inserts(
+    cadgf_document* doc,
+    const std::unordered_map<std::string, DxfBlock>& blocks,
+    const std::vector<DxfInsert>& inserts,
+    const DxfBlockEntityCommitterContext& block_commit_ctx,
+    bool include_all_spaces,
+    int target_space,
+    std::unordered_map<int, int>& top_level_local_groups,
+    DxfResolveLocalGroupIdFn resolve_local_group_id,
+    cadgf_error_v1* out_err);


### PR DESCRIPTION
# DXF B5g: Top-Level Insert Committers

## Goal

Extract the remaining top-level `INSERT` orchestration from
`plugins/dxf_block_entry_committers.cpp` into a dedicated helper module.

This step follows B5f. After B5f, `dxf_block_entry_committers.cpp` is already
reduced to:

- root-block commit delegation
- top-level `INSERT` orchestration
- local-group remapping for top-level inserts

B5g moves only the second half.

## Scope

Add:

- `plugins/dxf_top_level_insert_committers.h`
- `plugins/dxf_top_level_insert_committers.cpp`

Update:

- `plugins/dxf_block_entry_committers.cpp`
- `plugins/CMakeLists.txt`

## Extraction Boundary

Move only the top-level `for (const auto& insert : inserts)` path, including:

- `include_space(insert.space)` gating
- block lookup by `insert.block_name`
- dimension-block detection
- insert-layer fallback to `"0"`
- transform construction for top-level inserts
- stack initialization with the referenced block name
- local-group resolution and fallback group allocation
- `emit_dxf_block_entities(...)` invocation for top-level inserts
- `dxf.block_ref.<group_id>` metadata writing for non-dimension inserts

Leave in `dxf_block_entry_committers.cpp`:

- `resolve_local_group_id(...)`
- delegation to `commit_dxf_root_blocks(...)`
- the thin public `commit_dxf_block_entries(...)` wrapper

## Invariants

Preserve exactly:

- dimension-block rule:
  - `insert.is_dimension || block.name.rfind("*D", 0) == 0`
- identity transform behavior for dimension blocks
- base-point transform logic for non-dimension inserts
- local-group reuse semantics for `insert.local_group_tag`
- `source_bundle_id` passthrough:
  - `insert.is_dimension ? group_id : -1`
- `layout_name` passthrough from the top-level insert
- `dxf.block_ref.<group_id>` metadata write only for non-dimension inserts

## Non-Goals

Do not:

- change root-block fallback logic from B5f
- change `emit_dxf_block_entities(...)`
- change block recursion
- change leaf entity emission
- change plugin ABI

## Expected End State

After B5g, `dxf_block_entry_committers.cpp` should be a thin facade that:

- calls `commit_dxf_root_blocks(...)`
- calls `commit_dxf_top_level_inserts(...)`

That will leave this file effectively closed out for the current B5 committer
track.
